### PR TITLE
Add thread-safe callback access and improve target lock handling

### DIFF
--- a/hydra_detect/detection_logger.py
+++ b/hydra_detect/detection_logger.py
@@ -52,6 +52,7 @@ class DetectionLogger:
         self._csv_file = None
         self._json_file = None
         self._frame_count = 0
+        self._disabled = False
 
         # Recent detections ring buffer for web UI
         self._recent: list[Dict[str, Any]] = []
@@ -66,6 +67,7 @@ class DetectionLogger:
                 self._crop_dir.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
             logger.error("Failed to create logging directories: %s", exc)
+            self._disabled = True
             return
 
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
@@ -87,6 +89,7 @@ class DetectionLogger:
                 logger.info("Logging detections to %s", path)
         except OSError as exc:
             logger.error("Failed to open detection log file: %s", exc)
+            self._disabled = True
 
     def stop(self) -> None:
         """Flush and close log files."""
@@ -115,7 +118,7 @@ class DetectionLogger:
             frame: The BGR frame (for image saving).
             gps: GPS dict with keys lat, lon, alt, fix (raw MAVLink ints).
         """
-        if len(tracking_result) == 0:
+        if self._disabled or len(tracking_result) == 0:
             self._frame_count += 1
             return
 

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -133,8 +133,10 @@ class Pipeline:
 
         self._running = False
         self._total_detections = 0
+        self._init_target_state()
 
-        # Target lock state (protected by _state_lock)
+    def _init_target_state(self) -> None:
+        """Initialise target-lock state. Safe to call from tests."""
         self._state_lock = threading.Lock()
         self._locked_track_id: Optional[int] = None
         self._lock_mode: Optional[str] = None  # "track" or "strike"
@@ -242,6 +244,8 @@ class Pipeline:
             with self._state_lock:
                 self._last_track_result = track_result
                 self._total_detections += len(track_result)
+                current_lock_id = self._locked_track_id
+                current_lock_mode = self._lock_mode
 
             # Get GPS state for logging and alerts
             gps = None
@@ -256,11 +260,6 @@ class Pipeline:
                 # Auto-loiter on detection
                 if self._mavlink.auto_loiter:
                     self._mavlink.command_loiter()
-
-            # Keep-in-frame: adjust yaw to center locked target
-            with self._state_lock:
-                current_lock_id = self._locked_track_id
-                current_lock_mode = self._lock_mode
 
             if current_lock_id is not None and self._mavlink is not None:
                 locked_track = None
@@ -281,7 +280,11 @@ class Pipeline:
                     elif current_lock_mode == "strike":
                         self._mavlink.adjust_yaw(error_x, yaw_rate_max=15.0)
                 else:
-                    # Target lost — auto-unlock and notify operator
+                    # Target lost — auto-unlock and notify operator.
+                    # NOTE: The lock is released automatically so the vehicle
+                    # stops yaw corrections toward a stale position. The
+                    # operator is notified via MAVLink STATUSTEXT and can
+                    # re-acquire manually if the target reappears.
                     logger.warning(
                         "Locked target #%d lost from tracker — auto-unlocking.",
                         current_lock_id,
@@ -302,6 +305,7 @@ class Pipeline:
             with self._state_lock:
                 render_lock_id = self._locked_track_id
                 render_lock_mode = self._lock_mode
+                total_det = self._total_detections
             annotated = draw_tracks(
                 frame, track_result,
                 inference_ms=det_result.inference_ms,
@@ -313,8 +317,6 @@ class Pipeline:
             # Push to web stream
             if self._web_enabled:
                 stream_state.update_frame(annotated)
-                with self._state_lock:
-                    total_det = self._total_detections
                 stats_update = {
                     "fps": fps,
                     "inference_ms": det_result.inference_ms,
@@ -329,19 +331,17 @@ class Pipeline:
                 stream_state.update_stats(**stats_update)
 
                 # Update target lock state for web UI
-                with self._state_lock:
-                    lock_id = self._locked_track_id
-                    lock_mode = self._lock_mode
-                if lock_id is not None:
+                # (reuse render_lock_id/render_lock_mode from above)
+                if render_lock_id is not None:
                     locked_label = None
                     for t in track_result:
-                        if t.track_id == lock_id:
+                        if t.track_id == render_lock_id:
                             locked_label = t.label
                             break
                     stream_state.set_target_lock({
                         "locked": True,
-                        "track_id": lock_id,
-                        "mode": lock_mode,
+                        "track_id": render_lock_id,
+                        "mode": render_lock_mode,
                         "label": locked_label,
                     })
                 else:
@@ -451,17 +451,21 @@ class Pipeline:
 
         target_lat, target_lon = target_pos
 
-        # Lock target and set mode
-        with self._state_lock:
-            self._locked_track_id = track_id
-            self._lock_mode = "strike"
-
         # Command GUIDED to estimated position
         success = self._mavlink.command_guided_to(target_lat, target_lon)
         if success:
+            # Only lock target after GUIDED is confirmed
+            with self._state_lock:
+                self._locked_track_id = track_id
+                self._lock_mode = "strike"
             logger.info(
                 "STRIKE initiated: #%d (%s) -> %.6f, %.6f",
                 track_id, target_track.label, target_lat, target_lon,
+            )
+        else:
+            logger.error(
+                "STRIKE failed: GUIDED command rejected for #%d (%s)",
+                track_id, target_track.label,
             )
         return success
 

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -163,14 +163,20 @@ class StreamState:
         get_recent_detections: Optional[Callable] = None,
         get_active_tracks: Optional[Callable] = None,
     ) -> None:
-        self._on_prompts_change = on_prompts_change
-        self._on_threshold_change = on_threshold_change
-        self._on_loiter_command = on_loiter_command
-        self._on_target_lock = on_target_lock
-        self._on_target_unlock = on_target_unlock
-        self._on_strike_command = on_strike_command
-        self._get_recent_detections = get_recent_detections
-        self._get_active_tracks = get_active_tracks
+        with self._lock:
+            self._on_prompts_change = on_prompts_change
+            self._on_threshold_change = on_threshold_change
+            self._on_loiter_command = on_loiter_command
+            self._on_target_lock = on_target_lock
+            self._on_target_unlock = on_target_unlock
+            self._on_strike_command = on_strike_command
+            self._get_recent_detections = get_recent_detections
+            self._get_active_tracks = get_active_tracks
+
+    def get_callback(self, name: str) -> Optional[Callable]:
+        """Safely retrieve a callback by name."""
+        with self._lock:
+            return getattr(self, name, None)
 
 
 # Global state instance — set by the pipeline before starting the server
@@ -221,8 +227,9 @@ async def api_set_prompts(request: Request, authorization: Optional[str] = Heade
         s = p.strip()[:MAX_PROMPT_LENGTH]
         sanitized.append(s)
 
-    if stream_state._on_prompts_change:
-        stream_state._on_prompts_change(sanitized)
+    cb = stream_state.get_callback("_on_prompts_change")
+    if cb:
+        cb(sanitized)
         stream_state.set_runtime_config("prompts", sanitized)
         _audit(request, "set_prompts", target=",".join(sanitized))
         return {"status": "ok", "prompts": sanitized}
@@ -245,8 +252,9 @@ async def api_set_threshold(request: Request, authorization: Optional[str] = Hea
     if not (0.0 <= threshold_val <= 1.0):
         return JSONResponse({"error": "threshold must be 0.0-1.0"}, status_code=400)
 
-    if stream_state._on_threshold_change:
-        stream_state._on_threshold_change(threshold_val)
+    cb = stream_state.get_callback("_on_threshold_change")
+    if cb:
+        cb(threshold_val)
         stream_state.set_runtime_config("threshold", threshold_val)
         _audit(request, "set_threshold", target=f"{threshold_val:.2f}")
         return {"status": "ok", "threshold": threshold_val}
@@ -260,8 +268,9 @@ async def api_command_loiter(request: Request, authorization: Optional[str] = He
     auth_err = _check_auth(authorization)
     if auth_err:
         return auth_err
-    if stream_state._on_loiter_command:
-        stream_state._on_loiter_command()
+    cb = stream_state.get_callback("_on_loiter_command")
+    if cb:
+        cb()
         _audit(request, "loiter")
         return {"status": "ok", "command": "loiter"}
     _audit(request, "loiter", outcome="mavlink_disconnected")
@@ -271,8 +280,9 @@ async def api_command_loiter(request: Request, authorization: Optional[str] = He
 @app.get("/api/tracks")
 async def api_active_tracks():
     """Return currently active tracked objects (for target selection)."""
-    if stream_state._get_active_tracks:
-        return stream_state._get_active_tracks()
+    cb = stream_state.get_callback("_get_active_tracks")
+    if cb:
+        return cb()
     return []
 
 
@@ -300,8 +310,9 @@ async def api_target_lock(request: Request, authorization: Optional[str] = Heade
     except (TypeError, ValueError):
         return JSONResponse({"error": "track_id must be an integer"}, status_code=400)
 
-    if stream_state._on_target_lock:
-        result = stream_state._on_target_lock(track_id_int, mode="track")
+    cb = stream_state.get_callback("_on_target_lock")
+    if cb:
+        result = cb(track_id_int, mode="track")
         if result:
             _audit(request, "target_lock", target=str(track_id))
             return {"status": "ok", "track_id": track_id, "mode": "track"}
@@ -317,8 +328,9 @@ async def api_target_unlock(request: Request, authorization: Optional[str] = Hea
     auth_err = _check_auth(authorization)
     if auth_err:
         return auth_err
-    if stream_state._on_target_unlock:
-        stream_state._on_target_unlock()
+    cb = stream_state.get_callback("_on_target_unlock")
+    if cb:
+        cb()
         _audit(request, "target_unlock")
         return {"status": "ok"}
     _audit(request, "target_unlock", outcome="unavailable")
@@ -351,8 +363,9 @@ async def api_strike_command(request: Request, authorization: Optional[str] = He
     except (TypeError, ValueError):
         return JSONResponse({"error": "track_id must be an integer"}, status_code=400)
 
-    if stream_state._on_strike_command:
-        result = stream_state._on_strike_command(track_id_int)
+    cb = stream_state.get_callback("_on_strike_command")
+    if cb:
+        result = cb(track_id_int)
         if result:
             _audit(request, "strike", target=str(track_id))
             return {"status": "ok", "track_id": track_id, "mode": "strike"}
@@ -368,8 +381,9 @@ async def api_strike_command(request: Request, authorization: Optional[str] = He
 @app.get("/api/detections")
 async def api_recent_detections():
     """Return recent detection log entries."""
-    if stream_state._get_recent_detections:
-        return stream_state._get_recent_detections()
+    cb = stream_state.get_callback("_get_recent_detections")
+    if cb:
+        return cb()
     return []
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ supervision>=0.18,<1.0
 pymavlink>=2.4,<3.0
 pyserial>=3.5,<4.0
 mgrs>=1.4,<2.0
-fastapi>=0.104,<1.0
+fastapi>=0.104,<2.0
 uvicorn[standard]>=0.24,<1.0
 jinja2>=3.1,<4.0

--- a/tests/test_pipeline_callbacks.py
+++ b/tests/test_pipeline_callbacks.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import configparser
-import threading
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -43,10 +42,7 @@ def _make_pipeline(**overrides) -> Pipeline:
     p._camera.has_frame = True
     p._camera.width = 640
     p._mavlink = None
-    p._state_lock = threading.Lock()
-    p._locked_track_id = None
-    p._lock_mode = None
-    p._last_track_result = None
+    p._init_target_state()
     p._running = False
     return p
 


### PR DESCRIPTION
## Summary
This PR improves thread safety in the web server's callback management and refactors target lock state handling in the pipeline to prevent race conditions and ensure proper state synchronization.

## Key Changes

### Web Server (server.py)
- **Thread-safe callback retrieval**: Wrapped all callback assignments in `set_callbacks()` with `self._lock` to prevent concurrent modification
- **New `get_callback()` method**: Introduced a safe getter that retrieves callbacks by name under lock protection, replacing direct attribute access throughout the codebase
- **Consistent callback invocation**: Updated all API endpoints to use `get_callback()` instead of directly accessing private callback attributes

### Pipeline (pipeline.py)
- **Extracted target state initialization**: Created `_init_target_state()` method to centralize initialization of lock-related state variables, improving testability
- **Optimized lock scope**: Moved lock acquisition earlier in `_run_loop()` to capture `current_lock_id` and `current_lock_mode` once, reducing redundant lock/unlock cycles
- **Improved strike command safety**: Modified `_handle_strike_command()` to only set the lock state *after* the GUIDED command is confirmed successful, preventing stale lock state if the command fails
- **Enhanced error handling**: Added explicit error logging when STRIKE command fails
- **Reduced lock contention**: Consolidated multiple lock acquisitions in the web stream update section by reusing previously captured lock state

### Detection Logger (detection_logger.py)
- **Graceful degradation**: Added `_disabled` flag to skip logging operations when initialization fails, preventing repeated error logging
- **Early exit on disabled state**: Check `_disabled` flag in `log()` method to avoid unnecessary processing

### Dependencies (requirements.txt)
- Updated FastAPI version constraint from `<1.0` to `<2.0` to allow newer versions

## Notable Implementation Details
- The `get_callback()` method uses `getattr()` with a default to safely handle missing attributes
- Lock state capture is now done once per loop iteration and reused for both yaw correction and web UI updates
- The strike command now validates MAVLink success before committing to the locked state, improving reliability

https://claude.ai/code/session_0149FSUGmhXTN6MpvWHr4VyA