### PR TITLE
Follow-up: fix secret handling guidance in CLAUDE.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ crops/
 *.engine
 .venv/
 venv/
+config.local.ini

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,8 @@ Follow the **discover → review → fix** workflow:
 - Keep the detector interface (`detectors/base.py`) stable — new detectors
   implement `BaseDetector`
 - Web endpoints in `web/server.py` require bearer token auth for control actions
-- Never commit secrets or API tokens — use `config.ini` (gitignored values)
+- Never commit secrets or API tokens — keep `config.ini` token fields empty and
+  store local secrets in an ignored override file like `config.local.ini`
 
 ## Common Commands
 


### PR DESCRIPTION
### Motivation
- Remove unsafe guidance that suggested placing API tokens in the tracked `config.ini` and instead direct contributors to use a locally ignored override to prevent accidental credential commits.

### Description
- Update `CLAUDE.md` to instruct maintainers to keep token fields empty in `config.ini` and store local secrets in an ignored override such as `config.local.ini`, and add `config.local.ini` to `.gitignore` to ensure local secrets are not committed.

### Testing
- No automated tests were required for this documentation-only change; validation was performed by verifying the updated file contents with `git diff -- .gitignore CLAUDE.md` and inspecting the relevant lines with `nl -ba CLAUDE.md | sed -n '88,95p'`, which showed the intended updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4f453ec8c8328a8ae00a33a9c5f0c)