### PR TITLE
Follow-up to #7: correct CLAUDE.md secret config instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,8 +88,10 @@ Follow the **discover → review → fix** workflow:
 - Keep the detector interface (`detectors/base.py`) stable — new detectors
   implement `BaseDetector`
 - Web endpoints in `web/server.py` require bearer token auth for control actions
-- Never commit secrets or API tokens — keep `config.ini` token fields empty and
-  store local secrets in an ignored override file like `config.local.ini`
+- Never commit secrets or API tokens — do not place secrets in tracked
+  `config.ini`; instead create an ignored local config file (for example,
+  `config.local.ini` copied from `config.ini`) and run with
+  `python -m hydra_detect --config config.local.ini`
 
 ## Common Commands
 


### PR DESCRIPTION
### Motivation
- Remove unsafe/misleading documentation that implied the runtime would automatically read a `config.local.ini` override, which could leave `api_token` unset and disable bearer-token protection.

### Description
- Update `CLAUDE.md` to remove the automatic-override wording and instead instruct maintainers to keep secrets out of tracked `config.ini`, create an ignored local config file (for example, `config.local.ini` copied from `config.ini`), and explicitly run with `python -m hydra_detect --config config.local.ini`.

### Testing
- Verified the edited lines with `nl -ba CLAUDE.md | sed -n '86,100p'`; attempted `python -m pytest tests/ -q` but collection failed due to missing system dependency `libGL.so.1` and missing Python package `httpx`, so automated tests could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4f53ea3c48328a31164e644defce8)