### PR TITLE
Add Jetson MAXN preflight checklist and README guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,23 @@ docker run --rm --runtime nvidia \
   hydra-detect
 ```
 
+### Jetson Orin Nano Super (MAXN SUPER) Preflight
+
+Before field deployment, run a quick host sanity check on the Jetson:
+
+```bash
+./scripts/jetson_preflight.sh
+```
+
+Recommended one-time performance setup:
+
+```bash
+sudo nvpmodel -m 0
+sudo jetson_clocks
+```
+
+If preflight reports no failures, Hydra is generally ready to run on-device (camera/MAVLink wiring still needs to match your `config.ini`).
+
 ### systemd Service
 
 ```bash

--- a/scripts/jetson_preflight.sh
+++ b/scripts/jetson_preflight.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PASS=0
+WARN=0
+FAIL=0
+
+ok() { echo "[PASS] $1"; PASS=$((PASS+1)); }
+warn() { echo "[WARN] $1"; WARN=$((WARN+1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL+1)); }
+
+check_cmd() {
+  local cmd="$1"
+  local label="$2"
+  if command -v "$cmd" >/dev/null 2>&1; then
+    ok "$label"
+    return 0
+  fi
+  fail "$label (missing command: $cmd)"
+  return 0
+}
+
+echo "Hydra Detect Jetson preflight"
+echo "============================="
+
+check_cmd python3 "python3 is installed"
+check_cmd nvpmodel "nvpmodel utility is available"
+check_cmd tegrastats "tegrastats utility is available"
+check_cmd systemctl "systemctl is available"
+
+if command -v nvpmodel >/dev/null 2>&1; then
+  mode_raw="$(nvpmodel -q 2>/dev/null || true)"
+  if echo "$mode_raw" | rg -qi "MAXN"; then
+    ok "Power model reports MAXN"
+  else
+    warn "Power model is not MAXN. Run: sudo nvpmodel -m 0"
+  fi
+fi
+
+if command -v jetson_clocks >/dev/null 2>&1; then
+  if jetson_clocks --show 2>/dev/null | rg -qi "ON|running"; then
+    ok "jetson_clocks appears enabled"
+  else
+    warn "jetson_clocks may be disabled. Consider: sudo jetson_clocks"
+  fi
+else
+  warn "jetson_clocks utility not found"
+fi
+
+if python3 -c "import cv2" >/dev/null 2>&1; then
+  ok "OpenCV import works"
+else
+  fail "OpenCV import failed (check opencv-python-headless/opencv libs)"
+fi
+
+if python3 -c "import fastapi,uvicorn" >/dev/null 2>&1; then
+  ok "Web stack imports (fastapi, uvicorn)"
+else
+  fail "Web stack imports failed"
+fi
+
+if [ -e /dev/video0 ]; then
+  ok "Camera device /dev/video0 exists"
+else
+  warn "No /dev/video0 found (skip if using RTSP/file source)"
+fi
+
+if [ -e /dev/ttyACM0 ] || [ -e /dev/ttyUSB0 ]; then
+  ok "Telemetry serial device present"
+else
+  warn "No telemetry serial device found (/dev/ttyACM0 or /dev/ttyUSB0)"
+fi
+
+if [ -r config.ini ]; then
+  if rg -q "^engine\s*=\s*(nanoowl|yolo)" config.ini; then
+    ok "config.ini detector engine is set"
+  else
+    fail "config.ini detector engine is invalid"
+  fi
+else
+  fail "config.ini not found"
+fi
+
+echo
+echo "Summary: PASS=$PASS WARN=$WARN FAIL=$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
### Motivation
- Provide a simple, repeatable host-side readiness check for Jetson Orin Nano Super (MAXN SUPER) before deploying Hydra on-device. 
- Surface common Jetson setup steps (`nvpmodel`, `jetson_clocks`) and call out the preflight command in the README. 

### Description
- Add `scripts/jetson_preflight.sh`, a POSIX-style script that verifies presence of host utilities (`python3`, `nvpmodel`, `tegrastats`, `systemctl`), checks for MAXN power mode and `jetson_clocks`, verifies Python imports for `cv2`, `fastapi`, and `uvicorn`, and checks for camera/telemetry device nodes and `config.ini` detector settings. 
- Insert a `Jetson Orin Nano Super (MAXN SUPER) Preflight` section into `README.md` documenting how to run the preflight and the recommended one-time performance setup commands (`sudo nvpmodel -m 0` / `sudo jetson_clocks`). 
- Script exits non-zero when required checks fail to make automated gating easy for CI or pre-deployment hooks. 

### Testing
- Ran shell syntax check `bash -n scripts/jetson_preflight.sh`, which passed. 
- Executed `./scripts/jetson_preflight.sh` in the current (non-Jetson) container, which produced a non-zero exit and reported missing Jetson-specific utilities and an OpenCV import failure (expected in this environment). 
- Ran `pytest -q` earlier for repository tests and observed unrelated test collection errors in this container: `ImportError: libGL.so.1` from OpenCV and `ModuleNotFoundError: httpx` required by the testclient, so full test suite did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b3dd285483288940f6c634aca1c6)