### PR TITLE
Add Jetson Orin Nano initial setup documentation

### DIFF
--- a/docs/jetson-initial-setup.md
+++ b/docs/jetson-initial-setup.md
@@ -102,34 +102,11 @@ A **Software Updater** popup will appear shortly after setup completes.
 The Jetson will show the NVIDIA boot screen with an update progress bar during
 restart. This is normal — do not power off during this step.
 
-## 5. Install Claude Code
-
-Once the desktop comes back up, open a terminal (`Ctrl+Alt+T` or find Terminal
-in the app menu).
-
-Install Claude Code:
-
-```bash
-# Install Node.js (Claude Code requires it)
-curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
-sudo apt-get install -y nodejs
-
-# Install Claude Code globally
-sudo npm install -g @anthropic-ai/claude-code
-
-# Launch it
-claude
-```
-
-Follow the authentication prompts to connect Claude Code to your Anthropic
-account.
-
 ## What's Next
 
-Claude Code is now running in the terminal. From here, it can handle the rest
-of the Hydra Detect setup — cloning the repo, building Docker images, and
-configuring the system. See [jetson-setup-guide.md](jetson-setup-guide.md) for
-the full software setup process.
+The Jetson is ready. Open a terminal (`Ctrl+Alt+T`) and proceed to the
+[Hydra software setup guide](jetson-setup-guide.md) to clone the repo, build
+the Docker image, and get Hydra Detect running.
 
 ---
 


### PR DESCRIPTION
## Summary
Add comprehensive documentation for flashing JetPack and completing initial Ubuntu setup on a Jetson Orin Nano device.

## Changes
- **New file:** `docs/jetson-initial-setup.md`
  - Step-by-step guide for flashing JetPack 6.2.1 to microSD card using Balena Etcher
  - Detailed walkthrough of Ubuntu OOBE wizard configuration (license, language, keyboard, Wi-Fi, timezone, user account)
  - Standard credentials (`sorcc`/`sorcc`) for classroom/lab deployments
  - Post-reboot desktop setup instructions (skipping online accounts, Ubuntu Pro, location services)
  - System update procedure with timing expectations (20-30 minutes)
  - Hardware requirements and prerequisites
  - Cross-reference to the Hydra software setup guide for next steps

## Details
This guide is written for students reproducing the Hydra Detect build from scratch and provides clear, actionable instructions from initial hardware setup through a ready-to-use desktop environment. The documentation includes specific JetPack version (6.2.1), timing expectations, and notes on design decisions (e.g., disabling location services since GPS comes from the flight controller).

https://claude.ai/code/session_0191iX8zLKKCQr7i7UeihJgj