### PR TITLE
Add Pixhawk 6C setup documentation for Hydra USV

### DIFF
--- a/docs/pixhawk-setup.md
+++ b/docs/pixhawk-setup.md
@@ -1,0 +1,166 @@
+# Pixhawk 6C Setup — Hydra USV Integration
+
+## Overview
+
+This documents the Pixhawk 6C configuration for use as the flight controller in
+the Hydra detection system. The Pixhawk runs ArduRover (Boat frame) and
+communicates with the Jetson Orin Nano companion computer via MAVLink.
+
+## Hardware
+
+- **Flight Controller:** Holybro Pixhawk 6C
+- **GPS:** Holybro M9N on GPS1 port
+- **Telemetry:** SiK 915 MHz radio pair on TELEM1
+- **Companion Computer:** NVIDIA Jetson Orin Nano (connected via USB-C or TELEM2 UART)
+
+## Firmware
+
+- **Firmware:** ArduRover (latest stable) — flashed via Mission Planner
+- **Version at time of writing:** V4.6.3
+
+### Flash Procedure
+
+1. Connect Pixhawk to PC via USB
+2. Open Mission Planner → Setup → Install Firmware → Rover
+3. Wait for flash and reboot to complete
+4. Connect at 115200 baud
+5. Config → Full Parameter List → Reset to Default → Reboot
+
+## Frame Configuration
+
+Boat mode is not available through the Frame Type GUI page. Set directly in
+parameters:
+
+```
+FRAME_CLASS = 2    (Boat)
+```
+
+## Sensor Calibration
+
+### Accelerometer
+
+- Setup → Mandatory Hardware → Accel Calibration
+- 6-position hold calibration (level, nose up, nose down, left, right, upside down)
+
+### Compass
+
+- Setup → Mandatory Hardware → Compass
+- M9N external compass (IST8310, Bus 1) set as Compass 1 / Primary
+- Internal compass (IST8310, Bus 0) disabled (noisy)
+- Perform onboard mag calibration — rotate through all orientations
+
+> **NOTE:** Indoor calibration will produce poor offsets. Recalibrate outdoors
+> before water testing.
+
+## Serial Port Configuration
+
+| Port   | Param Prefix | Use              | Protocol       | Baud          |
+|--------|-------------|------------------|----------------|---------------|
+| USB    | SERIAL0     | GCS (MP) or Jetson | 2 (MAVLink2) | 115 (115200)  |
+| TELEM1 | SERIAL1     | SiK 915 MHz radio | 2 (MAVLink2) | 57 (57600)    |
+| TELEM2 | SERIAL2     | Jetson (UART)    | 2 (MAVLink2)   | 921 (921600)  |
+| GPS1   | SERIAL3     | M9N GPS          | 5 (GPS)        | 38 (38400)    |
+
+### Parameters
+
+```
+SERIAL0_PROTOCOL = 2
+SERIAL0_BAUD = 115
+SERIAL1_PROTOCOL = 2
+SERIAL1_BAUD = 57
+SERIAL2_PROTOCOL = 2
+SERIAL2_BAUD = 921
+SERIAL3_PROTOCOL = 5
+SERIAL3_BAUD = 38
+GPS1_TYPE = 1    (Auto)
+```
+
+## SiK Radio Configuration
+
+Both radios configured identically via Mission Planner (Setup → Optional
+Hardware → SiK Radio). Configure one at a time over USB — MP cannot enter AT
+command mode while actively connected via MAVLink on the same port.
+
+| Setting   | Value   |
+|-----------|---------|
+| Baud      | 57600   |
+| Air Speed | 64      |
+| Net ID    | 8       |
+| ECC       | On      |
+| Mavlink   | Mavlink |
+| Min Freq  | 915000  |
+| Tx Power  | 20      |
+
+### Procedure (USB, one radio at a time)
+
+1. Plug radio into USB
+2. In MP: select COM port, set baud to 57600, do **NOT** click Connect
+3. Go to Setup → Optional Hardware → SiK Radio → Load Settings
+4. Set Net ID and verify other settings match
+5. Save Settings
+6. Unplug, repeat for second radio
+
+## Flight Modes
+
+```
+MODE1 = 0     (Manual)
+MODE2 = 4     (Hold)
+MODE3 = 15    (Guided)
+MODE4 = 10    (Auto)
+MODE5 = 11    (Loiter)
+MODE6 = 0     (Manual)
+```
+
+Hydra uses **Guided** mode for Strike/navigation commands and **Hold** for the
+LOITER/HOLD function.
+
+## Arming
+
+```
+ARMING_CHECK = 0    (disabled — bench testing ONLY)
+```
+
+Re-enable before any water testing:
+
+```
+ARMING_CHECK = 1
+```
+
+## Companion Computer Connection
+
+### Bench Testing: USB-C
+
+Connect Pixhawk to Jetson via USB-C cable. Device appears as `/dev/ttyACM0`.
+
+```ini
+# config.ini
+[mavlink]
+connection = /dev/ttyACM0
+baud = 115200
+```
+
+- Baud is ignored on USB virtual serial but pymavlink requires a value
+- Do **NOT** power the Pixhawk from both USB and battery simultaneously to avoid
+  backfeed
+- For bench testing: power Pixhawk solely through the Jetson USB-C connection
+  (no battery). Servo/motor outputs will not function on USB power alone.
+
+### Field Deployment: TELEM2 UART
+
+Wire Jetson UART TX/RX to Pixhawk TELEM2 port (TX→RX, RX→TX, common GND).
+
+```ini
+# config.ini
+[mavlink]
+connection = /dev/ttyTHS1
+baud = 921600
+```
+
+> If USB and battery must be used simultaneously (e.g., during hull
+> integration), use a USB isolator dongle to block VBUS while passing data.
+
+## Mission Planner (GCS)
+
+With the SiK radios configured, Mission Planner connects wirelessly via the
+ground-side SiK module at 57600 baud. This allows simultaneous GCS monitoring
+while the Jetson communicates over USB or TELEM2.


### PR DESCRIPTION
## Summary
Add comprehensive setup and configuration documentation for the Pixhawk 6C flight controller used in the Hydra USV detection system.

## Changes
- **New documentation file:** `docs/pixhawk-setup.md` with complete Pixhawk 6C configuration guide including:
  - Hardware specifications (Pixhawk 6C, M9N GPS, SiK 915 MHz radio, Jetson Orin Nano)
  - Firmware flashing procedure for ArduRover (Boat frame)
  - Sensor calibration steps (accelerometer and compass)
  - Serial port configuration table and parameters for all ports (USB, TELEM1, TELEM2, GPS1)
  - SiK radio configuration settings and programming procedure
  - Flight mode assignments optimized for Hydra's Guided/Hold operations
  - Arming configuration notes for bench vs. field testing
  - Companion computer connection setup for both USB-C (bench) and TELEM2 UART (field deployment)
  - Mission Planner GCS wireless connectivity via SiK radio

## Notable Details
- Includes critical safety notes (e.g., avoiding simultaneous USB/battery power, USB isolator recommendation)
- Provides specific parameter values and baud rates for all serial connections
- Documents the workaround for boat frame configuration (direct parameter setting vs. GUI)
- Emphasizes outdoor compass calibration requirement before water testing
- Covers both development (USB) and production (UART) deployment scenarios

https://claude.ai/code/session_01RqNM7sVPbxrFsEdLA3Xkoq