### PR TITLE
Harden RF API validation and connection error handling

### DIFF
--- a/hydra_detect/rf/kismet_client.py
+++ b/hydra_detect/rf/kismet_client.py
@@ -65,8 +65,8 @@ class KismetClient:
                 return True
             logger.error("Kismet API returned %d", r.status_code)
             return False
-        except requests.ConnectionError:
-            logger.error("Cannot reach Kismet API at %s", self._host)
+        except requests.RequestException as exc:
+            logger.error("Cannot reach Kismet API at %s: %s", self._host, exc)
             return False
 
     # -- WiFi RSSI by BSSID ------------------------------------------------

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -6,6 +6,7 @@ import asyncio
 import datetime
 import hmac
 import logging
+import re
 import threading
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
@@ -65,6 +66,7 @@ audit_log = logging.getLogger("hydra.audit")
 # Prompt constraints
 MAX_PROMPTS = 20
 MAX_PROMPT_LENGTH = 200
+BSSID_RE = re.compile(r"^[0-9A-Fa-f]{2}(?::[0-9A-Fa-f]{2}){5}$")
 
 
 def _audit(request: Request, action: str, target: str = "", outcome: str = "ok") -> None:
@@ -208,6 +210,7 @@ async def api_set_prompts(request: Request, authorization: Optional[str] = Heade
             return JSONResponse({"error": "prompts must not be empty or blank"}, status_code=400)
         cleaned.append(p[:MAX_PROMPT_LENGTH])
 
+    stream_state.set_runtime_config("prompts", cleaned)
     cb = stream_state.get_callback("on_prompts_change")
     if cb:
         cb(cleaned)
@@ -500,7 +503,7 @@ async def api_rf_start(request: Request, authorization: Optional[str] = Header(N
     bssid = body.get("target_bssid", "").strip()
     if mode == "wifi" and not bssid:
         return JSONResponse({"error": "target_bssid required for wifi mode"}, status_code=400)
-    if bssid and len(bssid) != 17:
+    if bssid and not BSSID_RE.fullmatch(bssid):
         return JSONResponse({"error": "target_bssid must be MAC format AA:BB:CC:DD:EE:FF"}, status_code=400)
 
     # Validate freq if SDR

--- a/tests/test_rf_kismet.py
+++ b/tests/test_rf_kismet.py
@@ -31,6 +31,18 @@ class TestKismetConnection:
         client._session = session
         assert client.check_connection() is False
 
+
+    @patch("hydra_detect.rf.kismet_client.requests.Session")
+    def test_connection_timeout_failure(self, mock_session_cls):
+        import requests
+        session = MagicMock()
+        mock_session_cls.return_value = session
+        session.get.side_effect = requests.Timeout("timed out")
+
+        client = KismetClient()
+        client._session = session
+        assert client.check_connection() is False
+
     @patch("hydra_detect.rf.kismet_client.requests.Session")
     def test_connection_bad_status(self, mock_session_cls):
         session = MagicMock()


### PR DESCRIPTION
### Motivation
- Improve robustness of RF/Kismet integration by handling more transport-layer failures and logging more detail for debugging. 
- Prevent malformed input to the RF start API by tightening BSSID validation. 
- Ensure runtime prompt configuration persists correctly for the web UI. 

### Description
- Broadened `KismetClient.check_connection()` exception handling from `ConnectionError` to `requests.RequestException` and include the exception in the log message to cover timeouts and other request failures (`hydra_detect/rf/kismet_client.py`).
- Tightened RF start endpoint BSSID validation by replacing the length check with a strict MAC regex (`BSSID_RE`) to enforce `AA:BB:CC:DD:EE:FF` format (`hydra_detect/web/server.py`).
- Persist cleaned prompts into runtime config before dispatching the `on_prompts_change` callback by calling `stream_state.set_runtime_config("prompts", cleaned)` (`hydra_detect/web/server.py`).
- Added a regression test to cover Kismet timeout behavior (`tests/test_rf_kismet.py`).

### Testing
- Ran `pytest -q tests/test_rf_kismet.py tests/test_rf_hunt.py tests/test_rf_navigator.py` and all tests passed: `51 passed`.
- Performed static sanity checks with `python -m py_compile hydra_detect/web/server.py hydra_detect/rf/kismet_client.py` which completed successfully.
- Attempted broader API test collection (`tests/test_rf_web_api.py` and `tests/test_pipeline_callbacks.py`) but collection failed in this environment due to missing external test dependencies (`httpx`) and system OpenCV library (`libGL.so.1`), so those endpoints were not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b81ad263548328a966a525959e03c1)