### PR TITLE
Fix flaky cooldown test with deterministic time mocking

### DIFF
--- a/tests/test_autonomous.py
+++ b/tests/test_autonomous.py
@@ -251,16 +251,22 @@ class TestEvaluate:
         strike_cb = MagicMock(return_value=True)
         tracks = _make_tracks((1, "mine", 0.92))
 
-        # First strike succeeds
-        ctrl.evaluate(tracks, mav, MagicMock(return_value=True), strike_cb)
-        assert strike_cb.call_count == 1
+        # Use deterministic time to avoid flaky results
+        fake_time = [1000.0]
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(time, "monotonic", lambda: fake_time[0])
 
-        # Second strike blocked by cooldown
-        tracks2 = _make_tracks((2, "buoy", 0.95))
-        for _ in range(5):
-            ctrl.evaluate(tracks2, mav, MagicMock(return_value=True), strike_cb)
+            # First strike succeeds at t=1000
+            ctrl.evaluate(tracks, mav, MagicMock(return_value=True), strike_cb)
+            assert strike_cb.call_count == 1
 
-        assert strike_cb.call_count == 1  # Still just the first
+            # Second strike blocked by cooldown (only 10s later, need 100s)
+            fake_time[0] = 1010.0
+            tracks2 = _make_tracks((2, "buoy", 0.95))
+            for _ in range(5):
+                ctrl.evaluate(tracks2, mav, MagicMock(return_value=True), strike_cb)
+
+            assert strike_cb.call_count == 1  # Still just the first
 
     def test_no_gps_fix(self):
         ctrl = _make_controller()


### PR DESCRIPTION
## Summary
Fixed a flaky test in `test_cooldown_enforced` by introducing deterministic time control instead of relying on wall-clock time, which could cause intermittent failures.

## Key Changes
- Wrapped the test logic with `pytest.MonkeyPatch.context()` to mock `time.monotonic()`
- Introduced a `fake_time` list to control time progression deterministically
- Set explicit timestamps: first strike at t=1000.0s, second evaluation attempt at t=1010.0s
- Updated comments to clarify the timing constraints (10s elapsed vs 100s cooldown requirement)
- Indented test assertions to be within the mocked time context

## Implementation Details
The test now uses a controlled time progression rather than depending on actual elapsed time between `evaluate()` calls. This eliminates the race condition where the test could fail if the system was under heavy load or slow. The 10-second gap between strikes is well below the 100-second cooldown period, ensuring the second strike is reliably blocked regardless of execution speed.

https://claude.ai/code/session_01LE8vNmADHQNjGmxFQm3hzN