### PR TITLE
Add MSP DisplayPort OSD driver for direct HDZero VTX rendering

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -57,10 +57,18 @@ api_token =
 ; Works with any ArduPilot FC (including Pixhawk 6C) — no MAX7456 chip needed.
 ; Set OSD_TYPE=3 and SERIALn_PROTOCOL=33 on the FC. See docs/hdzero-osd-setup.md.
 enabled = false
-; Mode: 'statustext' (simple, no Lua needed) or 'named_value' (richer, needs Lua script on FC)
+; Mode: 'statustext' (simple, no Lua needed), 'named_value' (richer, needs Lua on FC),
+;        or 'msp_displayport' (direct serial to HDZero VTX — bypasses FC entirely).
 mode = statustext
 ; How often to send OSD updates (seconds). Lower = more responsive but more MAVLink traffic.
 update_interval = 0.2
+; --- MSP DisplayPort settings (only used when mode = msp_displayport) ---
+; Serial device connected to HDZero VTX UART (USB-UART adapter on Jetson)
+serial_port = /dev/ttyUSB0
+serial_baud = 115200
+; HD OSD canvas dimensions (HDZero default: 50 cols × 18 rows)
+canvas_cols = 50
+canvas_rows = 18
 
 [autonomous]
 ; Autonomous strike — auto-engage targets meeting ALL qualification criteria.

--- a/hydra_detect/msp_displayport.py
+++ b/hydra_detect/msp_displayport.py
@@ -1,0 +1,336 @@
+"""MSP v1 DisplayPort OSD driver for HDZero VTX.
+
+Speaks the MSP DisplayPort protocol over a dedicated serial UART to draw
+detection telemetry directly on the HDZero VTX's OSD canvas, bypassing the
+flight controller entirely.
+
+Protocol reference:
+- MSP v1 frame: ``$M<`` + payload_size (1 B) + command_id (1 B) + payload + XOR checksum
+- MSP command 182 (``MSP_DISPLAYPORT``) sub-commands:
+    0 = Heartbeat  — keeps VTX OSD alive
+    2 = Clear      — clears the canvas
+    3 = Write      — writes a string at (row, col) with attribute byte
+    4 = Draw       — commits buffered writes to the display
+"""
+
+from __future__ import annotations
+
+import logging
+import struct
+import threading
+import time
+from dataclasses import dataclass
+
+import serial
+
+logger = logging.getLogger(__name__)
+
+# MSP v1 constants
+_MSP_HEADER = b"$M<"
+_MSP_CMD_DISPLAYPORT = 182
+
+# DisplayPort sub-commands
+_DP_SUB_HEARTBEAT = 0
+_DP_SUB_CLEAR = 2
+_DP_SUB_WRITE = 3
+_DP_SUB_DRAW = 4
+
+# Default HD canvas size (HDZero / Walksnail HD)
+DEFAULT_CANVAS_COLS = 50
+DEFAULT_CANVAS_ROWS = 18
+
+
+def _msp_frame(command: int, payload: bytes | bytearray) -> bytes:
+    """Build an MSP v1 frame: ``$M<`` + size + cmd + payload + XOR checksum.
+
+    Args:
+        command: MSP command ID (e.g. 182 for DisplayPort).
+        payload: Raw payload bytes.
+
+    Returns:
+        Complete MSP v1 frame ready for serial transmission.
+    """
+    size = len(payload)
+    # Checksum is XOR of size, command, and every payload byte
+    checksum = size ^ command
+    for b in payload:
+        checksum ^= b
+    checksum &= 0xFF
+    header = _MSP_HEADER + struct.pack("BB", size, command)
+    return header + bytes(payload) + struct.pack("B", checksum)
+
+
+def heartbeat_frame(rows: int = DEFAULT_CANVAS_ROWS, cols: int = DEFAULT_CANVAS_COLS) -> bytes:
+    """Build an MSP DisplayPort heartbeat frame.
+
+    The heartbeat must be sent every OSD cycle to keep the VTX OSD alive.
+
+    Args:
+        rows: Canvas row count.
+        cols: Canvas column count.
+
+    Returns:
+        Complete MSP v1 frame with heartbeat sub-command.
+    """
+    payload = bytearray([_DP_SUB_HEARTBEAT, rows, cols, 0, 0])
+    return _msp_frame(_MSP_CMD_DISPLAYPORT, payload)
+
+
+def clear_frame() -> bytes:
+    """Build an MSP DisplayPort clear-screen frame.
+
+    Returns:
+        Complete MSP v1 frame with clear sub-command.
+    """
+    return _msp_frame(_MSP_CMD_DISPLAYPORT, bytearray([_DP_SUB_CLEAR]))
+
+
+def write_string_frame(row: int, col: int, text: str, attr: int = 0) -> bytes:
+    """Build an MSP DisplayPort write-string frame.
+
+    Args:
+        row: Row position (0-based).
+        col: Column position (0-based).
+        text: ASCII string to write.
+        attr: Display attribute byte (0 = normal).
+
+    Returns:
+        Complete MSP v1 frame with write sub-command.
+    """
+    ascii_bytes = text.encode("ascii", errors="replace")
+    payload = bytearray([_DP_SUB_WRITE, row, col, attr]) + ascii_bytes
+    return _msp_frame(_MSP_CMD_DISPLAYPORT, payload)
+
+
+def draw_frame() -> bytes:
+    """Build an MSP DisplayPort draw (commit) frame.
+
+    Returns:
+        Complete MSP v1 frame with draw sub-command.
+    """
+    return _msp_frame(_MSP_CMD_DISPLAYPORT, bytearray([_DP_SUB_DRAW]))
+
+
+@dataclass
+class MspOsdData:
+    """Thread-safe snapshot of data to render on the MSP OSD.
+
+    This is populated by the OSD update path and consumed by the MSP
+    serial thread.
+    """
+
+    fps: float = 0.0
+    inference_ms: float = 0.0
+    active_tracks: int = 0
+    locked_track_id: int | None = None
+    lock_mode: str | None = None
+    locked_label: str = ""
+    gps_lat: float | None = None
+    gps_lon: float | None = None
+    latest_det_label: str = ""
+    latest_det_conf: float = 0.0
+
+
+class MspDisplayPort:
+    """MSP DisplayPort OSD driver running in a dedicated daemon thread.
+
+    Opens a serial connection to the HDZero VTX and continuously renders
+    detection telemetry on the HD OSD canvas. Handles serial disconnects
+    gracefully with automatic reconnection.
+
+    Args:
+        serial_port: Path to the serial device (e.g. ``/dev/ttyUSB0``).
+        serial_baud: Baud rate for the serial connection.
+        canvas_rows: Number of OSD canvas rows.
+        canvas_cols: Number of OSD canvas columns.
+        update_interval: Minimum seconds between OSD frame cycles.
+    """
+
+    def __init__(
+        self,
+        serial_port: str = "/dev/ttyUSB0",
+        serial_baud: int = 115200,
+        canvas_rows: int = DEFAULT_CANVAS_ROWS,
+        canvas_cols: int = DEFAULT_CANVAS_COLS,
+        update_interval: float = 0.1,
+    ):
+        self._port = serial_port
+        self._baud = serial_baud
+        self._rows = canvas_rows
+        self._cols = canvas_cols
+        self._interval = max(0.05, update_interval)
+
+        self._lock = threading.Lock()
+        self._data = MspOsdData()
+        self._running = False
+        self._thread: threading.Thread | None = None
+        self._ser: serial.Serial | None = None
+
+    def start(self) -> None:
+        """Start the background serial thread."""
+        if self._running:
+            return
+        self._running = True
+        self._thread = threading.Thread(
+            target=self._run,
+            name="msp-displayport",
+            daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "MSP DisplayPort thread started: port=%s baud=%d canvas=%dx%d interval=%.2fs",
+            self._port, self._baud, self._cols, self._rows, self._interval,
+        )
+
+    def stop(self) -> None:
+        """Stop the background serial thread and close the port."""
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+        self._close_serial()
+
+    def update(self, data: MspOsdData) -> None:
+        """Update the OSD data snapshot (called from the pipeline thread).
+
+        Args:
+            data: New telemetry snapshot to render on next OSD cycle.
+        """
+        with self._lock:
+            self._data = data
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _open_serial(self) -> bool:
+        """Attempt to open the serial port. Returns True on success."""
+        try:
+            self._ser = serial.Serial(
+                port=self._port,
+                baudrate=self._baud,
+                timeout=1.0,
+                write_timeout=1.0,
+            )
+            logger.info("MSP serial port opened: %s @ %d", self._port, self._baud)
+            return True
+        except (serial.SerialException, OSError) as exc:
+            logger.warning("MSP serial open failed (%s): %s", self._port, exc)
+            self._ser = None
+            return False
+
+    def _close_serial(self) -> None:
+        """Close the serial port if open."""
+        if self._ser is not None:
+            try:
+                self._ser.close()
+            except Exception:
+                pass
+            self._ser = None
+
+    def _write_bytes(self, data: bytes) -> bool:
+        """Write bytes to serial, returning False on failure."""
+        if self._ser is None:
+            return False
+        try:
+            self._ser.write(data)
+            return True
+        except (serial.SerialException, OSError) as exc:
+            logger.warning("MSP serial write failed: %s", exc)
+            self._close_serial()
+            return False
+
+    def _format_status_line(self, data: MspOsdData) -> str:
+        """Format the top status line (row 0).
+
+        Format: ``T:<tracks> <fps>fps <ms>ms LK#<id><mode>``
+        """
+        parts: list[str] = []
+        parts.append(f"T:{data.active_tracks}")
+        parts.append(f"{data.fps:.0f}fps")
+        parts.append(f"{data.inference_ms:.0f}ms")
+
+        if data.locked_track_id is not None:
+            mode_tag = "STK" if data.lock_mode == "strike" else "TRK"
+            parts.append(f"LK#{data.locked_track_id}{mode_tag}")
+
+        line = " ".join(parts)
+        return line[:self._cols]
+
+    def _format_gps_line(self, data: MspOsdData) -> str:
+        """Format the GPS position string for row 17, left side.
+
+        Uses MGRS if the mgrs module is available, otherwise lat/lon.
+        """
+        if data.gps_lat is None or data.gps_lon is None:
+            return "NO GPS"
+        try:
+            import mgrs
+            m = mgrs.MGRS()
+            return m.toMGRS(data.gps_lat, data.gps_lon)
+        except Exception:
+            return f"{data.gps_lat:.5f},{data.gps_lon:.5f}"
+
+    def _format_det_line(self, data: MspOsdData) -> str:
+        """Format the most recent detection for row 17, right-aligned."""
+        if not data.latest_det_label:
+            return ""
+        return f"{data.latest_det_label} {data.latest_det_conf:.2f}"
+
+    def _render_frame(self, data: MspOsdData) -> None:
+        """Send one complete OSD frame cycle: heartbeat → clear → writes → draw."""
+        # Heartbeat — MUST be sent every frame
+        if not self._write_bytes(heartbeat_frame(self._rows, self._cols)):
+            return
+
+        # Clear screen
+        if not self._write_bytes(clear_frame()):
+            return
+
+        # Row 0: status line (left-aligned)
+        status = self._format_status_line(data)
+        if status:
+            if not self._write_bytes(write_string_frame(0, 0, status)):
+                return
+
+        # Row 17: GPS position (left-aligned)
+        gps_text = self._format_gps_line(data)
+        if gps_text:
+            if not self._write_bytes(write_string_frame(self._rows - 1, 0, gps_text)):
+                return
+
+        # Row 17: latest detection (right-aligned)
+        det_text = self._format_det_line(data)
+        if det_text:
+            col = max(0, self._cols - len(det_text))
+            if not self._write_bytes(write_string_frame(self._rows - 1, col, det_text)):
+                return
+
+        # Draw — commit buffered writes
+        self._write_bytes(draw_frame())
+
+    def _run(self) -> None:
+        """Background thread main loop with reconnection logic."""
+        while self._running:
+            # Ensure serial is open
+            if self._ser is None:
+                if not self._open_serial():
+                    # Retry after 2 seconds on connection failure
+                    for _ in range(20):  # 20 × 0.1s = 2s, checking _running
+                        if not self._running:
+                            return
+                        time.sleep(0.1)
+                    continue
+
+            # Snapshot current data
+            with self._lock:
+                data = self._data
+
+            # Render one OSD frame
+            self._render_frame(data)
+
+            # Sleep for the configured interval
+            time.sleep(self._interval)
+
+        # Clean up on exit
+        self._close_serial()

--- a/hydra_detect/osd.py
+++ b/hydra_detect/osd.py
@@ -1,19 +1,22 @@
-"""FPV OSD overlay via MAVLink — sends detection data to FC onboard OSD chip.
+"""FPV OSD overlay — sends detection data to an OSD renderer.
 
-Supports two modes:
+Supports three modes:
 - 'statustext': Sends formatted STATUSTEXT messages shown in the OSD message
   panel. Works on any ArduPilot FC with OSD. No Lua script required.
 - 'named_value': Sends structured NAMED_VALUE_FLOAT/INT messages for a Lua
   script on the FC to decode and render at specific OSD positions. Richer
   display but requires the companion Lua script on the FC SD card.
+- 'msp_displayport': Speaks MSP v1 DisplayPort protocol over a dedicated
+  serial UART directly to an HDZero VTX, bypassing the flight controller.
+  Draws detection telemetry on the HD OSD canvas (50×18 by default).
 
-Compatible FC boards (with onboard OSD chip):
+Compatible FC boards (with onboard OSD chip — statustext/named_value modes):
 - Matek H743 (AT7456E)
 - SpeedyBee F405-Wing (AT7456E)
 - Any ArduPilot FC with MAX7456/AT7456E OSD
 
-NOTE: Pixhawk 6C does not have an onboard OSD chip. Use the web dashboard
-overlay for Pixhawk platforms instead.
+NOTE: Pixhawk 6C does not have an onboard OSD chip. Use msp_displayport mode
+for direct VTX OSD, or the web dashboard overlay for Pixhawk platforms.
 """
 
 from __future__ import annotations
@@ -23,6 +26,7 @@ import time
 import threading
 from dataclasses import dataclass
 
+from .msp_displayport import MspDisplayPort, MspOsdData
 from .tracker import TrackingResult
 
 logger = logging.getLogger(__name__)
@@ -39,6 +43,10 @@ class OSDState:
     lock_mode: str | None = None
     locked_label: str = ""
     gps_fix: int = 0
+    gps_lat: float | None = None
+    gps_lon: float | None = None
+    latest_det_label: str = ""
+    latest_det_conf: float = 0.0
 
 
 # Max length for NAMED_VALUE_FLOAT name field in MAVLink
@@ -46,13 +54,23 @@ _NV_NAME_MAX = 10
 
 
 class FpvOsd:
-    """Formats and sends OSD data to the FC over an existing MAVLink link.
+    """Formats and sends OSD data to an OSD renderer.
 
-    This class does NOT own the MAVLink connection — it borrows a reference
-    to send OSD-specific messages alongside normal telemetry.
+    For ``statustext`` and ``named_value`` modes this class borrows an
+    existing MAVLink connection.  For ``msp_displayport`` mode it owns a
+    dedicated serial link to the VTX and runs a background thread.
+
+    Args:
+        mavlink_io: MAVLinkIO instance (used by statustext/named_value modes).
+        mode: OSD mode — ``statustext``, ``named_value``, or ``msp_displayport``.
+        update_interval: Minimum seconds between OSD updates.
+        serial_port: Serial device for MSP DisplayPort (only used in that mode).
+        serial_baud: Baud rate for MSP serial (only used in msp_displayport mode).
+        canvas_rows: OSD canvas rows (only used in msp_displayport mode).
+        canvas_cols: OSD canvas columns (only used in msp_displayport mode).
     """
 
-    _VALID_MODES = ("statustext", "named_value")
+    _VALID_MODES = ("statustext", "named_value", "msp_displayport")
 
     def __init__(
         self,
@@ -60,6 +78,10 @@ class FpvOsd:
         *,
         mode: str = "statustext",
         update_interval: float = 0.2,
+        serial_port: str = "/dev/ttyUSB0",
+        serial_baud: int = 115200,
+        canvas_rows: int = 18,
+        canvas_cols: int = 50,
     ):
         if mode not in self._VALID_MODES:
             logger.warning(
@@ -73,6 +95,18 @@ class FpvOsd:
         self._last_send: float = 0.0
         self._lock = threading.Lock()
 
+        # MSP DisplayPort driver (lazy-started on first update)
+        self._msp: MspDisplayPort | None = None
+        if mode == "msp_displayport":
+            self._msp = MspDisplayPort(
+                serial_port=serial_port,
+                serial_baud=serial_baud,
+                canvas_rows=canvas_rows,
+                canvas_cols=canvas_cols,
+                update_interval=update_interval,
+            )
+            self._msp.start()
+
     @property
     def mode(self) -> str:
         return self._mode
@@ -85,7 +119,9 @@ class FpvOsd:
                 return
             self._last_send = now
 
-        if self._mode == "named_value":
+        if self._mode == "msp_displayport":
+            self._send_msp_displayport(state)
+        elif self._mode == "named_value":
             self._send_named_values(state)
         else:
             self._send_statustext(state)
@@ -160,6 +196,26 @@ class FpvOsd:
         except Exception as exc:
             logger.debug("OSD named_value_int send failed: %s", exc)
 
+    # ------------------------------------------------------------------
+    # MSP DisplayPort mode — direct serial to HDZero VTX
+    # ------------------------------------------------------------------
+    def _send_msp_displayport(self, state: OSDState) -> None:
+        """Forward OSD state to the MSP DisplayPort driver thread."""
+        if self._msp is None:
+            return
+        self._msp.update(MspOsdData(
+            fps=state.fps,
+            inference_ms=state.inference_ms,
+            active_tracks=state.active_tracks,
+            locked_track_id=state.locked_track_id,
+            lock_mode=state.lock_mode,
+            locked_label=state.locked_label,
+            gps_lat=state.gps_lat,
+            gps_lon=state.gps_lon,
+            latest_det_label=state.latest_det_label,
+            latest_det_conf=state.latest_det_conf,
+        ))
+
 
 def build_osd_state(
     track_result: TrackingResult,
@@ -170,6 +226,21 @@ def build_osd_state(
     gps: dict | None,
 ) -> OSDState:
     """Build an OSDState snapshot from current pipeline data."""
+    # Extract GPS lat/lon (MAVLink stores as int × 1e7)
+    gps_lat: float | None = None
+    gps_lon: float | None = None
+    if gps and gps.get("lat") is not None and gps.get("lon") is not None:
+        gps_lat = gps["lat"] / 1e7
+        gps_lon = gps["lon"] / 1e7
+
+    # Pick the highest-confidence detection for OSD display
+    latest_label = ""
+    latest_conf = 0.0
+    for t in track_result:
+        if t.confidence > latest_conf:
+            latest_conf = t.confidence
+            latest_label = t.label
+
     state = OSDState(
         fps=fps,
         inference_ms=inference_ms,
@@ -177,6 +248,10 @@ def build_osd_state(
         locked_track_id=locked_track_id,
         lock_mode=lock_mode,
         gps_fix=gps.get("fix", 0) if gps else 0,
+        gps_lat=gps_lat,
+        gps_lon=gps_lon,
+        latest_det_label=latest_label,
+        latest_det_conf=latest_conf,
     )
 
     # Resolve locked target label

--- a/tests/test_osd.py
+++ b/tests/test_osd.py
@@ -2,8 +2,17 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from hydra_detect.msp_displayport import (
+    MspDisplayPort,
+    MspOsdData,
+    _msp_frame,
+    heartbeat_frame,
+    clear_frame,
+    draw_frame,
+    write_string_frame,
+)
 from hydra_detect.osd import FpvOsd, OSDState, build_osd_state
 from hydra_detect.tracker import TrackedObject, TrackingResult
 
@@ -196,9 +205,10 @@ class TestFpvOsdValidation:
         osd = FpvOsd(mav, mode="bogus", update_interval=0.0)
         assert osd.mode == "statustext"
 
-    def test_valid_modes_accepted(self):
+    @patch("hydra_detect.osd.MspDisplayPort")
+    def test_valid_modes_accepted(self, mock_msp_cls):
         mav = _make_mavlink_mock()
-        for mode in ("statustext", "named_value"):
+        for mode in ("statustext", "named_value", "msp_displayport"):
             osd = FpvOsd(mav, mode=mode, update_interval=0.0)
             assert osd.mode == mode
 
@@ -220,3 +230,270 @@ class TestOsdState:
         assert state.lock_mode is None
         assert state.locked_label == ""
         assert state.gps_fix == 0
+        assert state.gps_lat is None
+        assert state.gps_lon is None
+        assert state.latest_det_label == ""
+        assert state.latest_det_conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# build_osd_state — GPS and detection fields
+# ---------------------------------------------------------------------------
+
+class TestBuildOsdStateExtended:
+    def test_gps_lat_lon_extracted(self):
+        """GPS lat/lon should be converted from 1e7 integer to float degrees."""
+        state = build_osd_state(
+            _make_tracking_result(), fps=10.0, inference_ms=20.0,
+            locked_track_id=None, lock_mode=None,
+            gps={"fix": 3, "lat": 340500000, "lon": -1182500000},
+        )
+        assert state.gps_lat is not None
+        assert abs(state.gps_lat - 34.05) < 1e-6
+        assert abs(state.gps_lon - (-118.25)) < 1e-6
+
+    def test_gps_none_when_no_fix(self):
+        state = build_osd_state(
+            _make_tracking_result(), fps=10.0, inference_ms=20.0,
+            locked_track_id=None, lock_mode=None, gps=None,
+        )
+        assert state.gps_lat is None
+        assert state.gps_lon is None
+
+    def test_latest_detection_picks_highest_confidence(self):
+        tracks = [
+            {"track_id": 1, "label": "car", "confidence": 0.7},
+            {"track_id": 2, "label": "person", "confidence": 0.95},
+            {"track_id": 3, "label": "dog", "confidence": 0.6},
+        ]
+        state = build_osd_state(
+            _make_tracking_result(tracks), fps=10.0, inference_ms=20.0,
+            locked_track_id=None, lock_mode=None, gps=None,
+        )
+        assert state.latest_det_label == "person"
+        assert abs(state.latest_det_conf - 0.95) < 1e-6
+
+    def test_no_detections_empty_label(self):
+        state = build_osd_state(
+            _make_tracking_result(), fps=10.0, inference_ms=20.0,
+            locked_track_id=None, lock_mode=None, gps=None,
+        )
+        assert state.latest_det_label == ""
+        assert state.latest_det_conf == 0.0
+
+
+# ---------------------------------------------------------------------------
+# MSP v1 frame encoding
+# ---------------------------------------------------------------------------
+
+class TestMspFrameEncoding:
+    def test_frame_header_and_structure(self):
+        """MSP v1 frame: $M< + size + cmd + payload + checksum."""
+        frame = _msp_frame(182, bytearray([0, 18, 50, 0, 0]))
+        assert frame[:3] == b"$M<"
+        assert frame[3] == 5       # payload size
+        assert frame[4] == 182     # command
+        assert frame[5:10] == bytes([0, 18, 50, 0, 0])  # payload
+        # Verify checksum: XOR of size, cmd, and all payload bytes
+        expected_cksum = 5 ^ 182 ^ 0 ^ 18 ^ 50 ^ 0 ^ 0
+        assert frame[10] == (expected_cksum & 0xFF)
+
+    def test_heartbeat_frame(self):
+        frame = heartbeat_frame(rows=18, cols=50)
+        assert frame[:3] == b"$M<"
+        assert frame[3] == 5   # payload length
+        assert frame[4] == 182  # MSP_DISPLAYPORT
+        assert frame[5] == 0   # sub-cmd heartbeat
+        assert frame[6] == 18  # rows
+        assert frame[7] == 50  # cols
+
+    def test_clear_frame(self):
+        frame = clear_frame()
+        assert frame[:3] == b"$M<"
+        assert frame[3] == 1   # payload length
+        assert frame[5] == 2   # sub-cmd clear
+
+    def test_draw_frame(self):
+        frame = draw_frame()
+        assert frame[:3] == b"$M<"
+        assert frame[3] == 1   # payload length
+        assert frame[5] == 4   # sub-cmd draw
+
+    def test_write_string_frame(self):
+        frame = write_string_frame(0, 5, "HELLO", attr=0)
+        assert frame[:3] == b"$M<"
+        payload_size = 4 + 5  # sub_cmd + row + col + attr + 5 chars
+        assert frame[3] == payload_size
+        assert frame[5] == 3   # sub-cmd write
+        assert frame[6] == 0   # row
+        assert frame[7] == 5   # col
+        assert frame[8] == 0   # attr
+        assert frame[9:14] == b"HELLO"
+
+    def test_checksum_correctness(self):
+        """Verify checksum is XOR of size ^ cmd ^ payload bytes."""
+        payload = bytearray([3, 0, 10, 0]) + b"TEST"
+        frame = _msp_frame(182, payload)
+        size = len(payload)
+        cksum = size ^ 182
+        for b in payload:
+            cksum ^= b
+        cksum &= 0xFF
+        assert frame[-1] == cksum
+
+
+# ---------------------------------------------------------------------------
+# MspDisplayPort driver
+# ---------------------------------------------------------------------------
+
+class TestMspDisplayPort:
+    def test_format_status_line_basic(self):
+        driver = MspDisplayPort(update_interval=0.1)
+        data = MspOsdData(fps=12.0, inference_ms=35.0, active_tracks=3)
+        line = driver._format_status_line(data)
+        assert "T:3" in line
+        assert "12fps" in line
+        assert "35ms" in line
+
+    def test_format_status_line_with_lock(self):
+        driver = MspDisplayPort(update_interval=0.1)
+        data = MspOsdData(
+            fps=10.0, inference_ms=20.0, active_tracks=1,
+            locked_track_id=5, lock_mode="track",
+        )
+        line = driver._format_status_line(data)
+        assert "LK#5TRK" in line
+
+    def test_format_status_line_strike_mode(self):
+        driver = MspDisplayPort(update_interval=0.1)
+        data = MspOsdData(
+            fps=10.0, inference_ms=20.0, active_tracks=1,
+            locked_track_id=5, lock_mode="strike",
+        )
+        line = driver._format_status_line(data)
+        assert "LK#5STK" in line
+
+    def test_format_status_line_truncated_to_canvas(self):
+        driver = MspDisplayPort(canvas_cols=20, update_interval=0.1)
+        data = MspOsdData(
+            fps=10.0, inference_ms=20.0, active_tracks=99,
+            locked_track_id=12345, lock_mode="track",
+        )
+        line = driver._format_status_line(data)
+        assert len(line) <= 20
+
+    def test_format_gps_line_no_gps(self):
+        driver = MspDisplayPort(update_interval=0.1)
+        data = MspOsdData()
+        assert driver._format_gps_line(data) == "NO GPS"
+
+    def test_format_gps_line_latlon(self):
+        driver = MspDisplayPort(update_interval=0.1)
+        data = MspOsdData(gps_lat=34.05, gps_lon=-118.25)
+        line = driver._format_gps_line(data)
+        assert "34.05" in line
+        assert "-118.25" in line
+
+    def test_format_det_line_empty(self):
+        driver = MspDisplayPort(update_interval=0.1)
+        data = MspOsdData()
+        assert driver._format_det_line(data) == ""
+
+    def test_format_det_line_with_detection(self):
+        driver = MspDisplayPort(update_interval=0.1)
+        data = MspOsdData(latest_det_label="person", latest_det_conf=0.92)
+        line = driver._format_det_line(data)
+        assert line == "person 0.92"
+
+    @patch("hydra_detect.msp_displayport.serial.Serial")
+    def test_render_frame_sends_all_commands(self, mock_serial_cls):
+        """A render cycle should send heartbeat, clear, writes, and draw."""
+        mock_ser = MagicMock()
+        mock_serial_cls.return_value = mock_ser
+
+        driver = MspDisplayPort(update_interval=0.1)
+        driver._ser = mock_ser
+
+        data = MspOsdData(
+            fps=12.0, inference_ms=35.0, active_tracks=3,
+            gps_lat=34.05, gps_lon=-118.25,
+            latest_det_label="person", latest_det_conf=0.92,
+        )
+        driver._render_frame(data)
+
+        # Should have written: heartbeat, clear, status row, gps row,
+        # detection row, draw = at least 6 writes
+        assert mock_ser.write.call_count >= 5
+
+        # First call should be heartbeat (starts with $M<)
+        first_frame = mock_ser.write.call_args_list[0][0][0]
+        assert first_frame[:3] == b"$M<"
+
+    @patch("hydra_detect.msp_displayport.serial.Serial")
+    def test_serial_disconnect_does_not_crash(self, mock_serial_cls):
+        """If serial write raises, the driver should handle it gracefully."""
+        from serial import SerialException
+
+        mock_ser = MagicMock()
+        mock_ser.write.side_effect = SerialException("port gone")
+        mock_serial_cls.return_value = mock_ser
+
+        driver = MspDisplayPort(update_interval=0.1)
+        driver._ser = mock_ser
+
+        data = MspOsdData(fps=10.0, inference_ms=20.0, active_tracks=0)
+        # Should not raise
+        driver._render_frame(data)
+        # Serial should be closed after failure
+        assert driver._ser is None
+
+    def test_update_is_thread_safe(self):
+        """update() should safely replace the data snapshot."""
+        driver = MspDisplayPort(update_interval=0.1)
+        data = MspOsdData(fps=15.0, active_tracks=5)
+        driver.update(data)
+        assert driver._data.fps == 15.0
+        assert driver._data.active_tracks == 5
+
+
+# ---------------------------------------------------------------------------
+# FpvOsd — msp_displayport mode integration
+# ---------------------------------------------------------------------------
+
+class TestFpvOsdMspDisplayPort:
+    @patch("hydra_detect.osd.MspDisplayPort")
+    def test_msp_mode_creates_and_starts_driver(self, mock_msp_cls):
+        mav = _make_mavlink_mock()
+        osd = FpvOsd(
+            mav, mode="msp_displayport", update_interval=0.1,
+            serial_port="/dev/ttyUSB0", serial_baud=115200,
+        )
+        assert osd.mode == "msp_displayport"
+        mock_msp_cls.assert_called_once()
+        mock_msp_cls.return_value.start.assert_called_once()
+
+    @patch("hydra_detect.osd.MspDisplayPort")
+    def test_msp_mode_forwards_state(self, mock_msp_cls):
+        mav = _make_mavlink_mock()
+        osd = FpvOsd(
+            mav, mode="msp_displayport", update_interval=0.0,
+        )
+        state = OSDState(
+            fps=12.0, inference_ms=35.0, active_tracks=3,
+            gps_lat=34.05, gps_lon=-118.25,
+            latest_det_label="person", latest_det_conf=0.92,
+        )
+        osd.update(state)
+        mock_msp_cls.return_value.update.assert_called_once()
+
+    @patch("hydra_detect.osd.MspDisplayPort")
+    def test_msp_mode_does_not_use_mavlink(self, mock_msp_cls):
+        """MSP mode should not send anything via MAVLink."""
+        mav = _make_mavlink_mock()
+        osd = FpvOsd(
+            mav, mode="msp_displayport", update_interval=0.0,
+        )
+        state = OSDState(fps=10.0, inference_ms=20.0, active_tracks=0)
+        osd.update(state)
+        mav.send_statustext.assert_not_called()
+        mav._mav.mav.named_value_float_send.assert_not_called()


### PR DESCRIPTION
## Summary
Adds a new MSP v1 DisplayPort OSD driver that communicates directly with HDZero VTX hardware over a dedicated serial UART, bypassing the flight controller entirely. This enables rendering detection telemetry directly on the VTX's HD OSD canvas (50×18 by default).

## Key Changes

- **New `msp_displayport.py` module**: Complete MSP v1 DisplayPort protocol implementation
  - Frame encoding functions (`_msp_frame`, `heartbeat_frame`, `clear_frame`, `write_string_frame`, `draw_frame`)
  - `MspOsdData` dataclass for thread-safe telemetry snapshots
  - `MspDisplayPort` driver class running in a dedicated daemon thread with automatic reconnection logic
  - Graceful serial error handling and recovery

- **Enhanced `osd.py`**: 
  - Added `msp_displayport` as a third OSD mode alongside `statustext` and `named_value`
  - Extended `OSDState` dataclass with GPS coordinates and latest detection fields
  - `FpvOsd` now owns and manages the `MspDisplayPort` instance when in that mode
  - New `_send_msp_displayport()` method to forward state to the MSP driver

- **Updated `build_osd_state()` function**:
  - Extracts GPS lat/lon from MAVLink format (int × 1e7) to float degrees
  - Tracks highest-confidence detection for OSD display
  - Populates new GPS and detection fields in `OSDState`

- **Comprehensive test coverage** in `test_osd.py`:
  - MSP frame encoding validation (header, checksum, sub-commands)
  - `MspDisplayPort` formatting and rendering logic
  - Serial error handling and thread safety
  - Integration tests for `FpvOsd` with msp_displayport mode

- **Configuration updates** in `config.ini`:
  - New `[osd]` section parameters for MSP serial port and baud rate
  - Documentation of the three OSD modes

## Implementation Details

- The MSP driver runs in a background thread with configurable update interval (default 0.1s)
- Each OSD frame cycle sends: heartbeat → clear → text writes → draw command
- Renders status line (row 0), GPS position (row 17 left), and latest detection (row 17 right)
- Automatic serial reconnection with 2-second retry backoff
- Thread-safe data updates via lock-protected snapshot mechanism
- Graceful degradation on serial failures without crashing the pipeline

https://claude.ai/code/session_01J9a4tu9GtVLszvUDbJayNM