### PR TITLE
Show lat/lon coordinates with optional MGRS grid reference

### DIFF
--- a/hydra_detect/msp_displayport.py
+++ b/hydra_detect/msp_displayport.py
@@ -260,16 +260,21 @@ class MspDisplayPort:
     def _format_gps_line(self, data: MspOsdData) -> str:
         """Format the GPS position string for row 17, left side.
 
-        Uses MGRS if the mgrs module is available, otherwise lat/lon.
+        Shows decimal lat/lon by default.  If the ``mgrs`` module is
+        available the MGRS grid reference is appended after the coordinates,
+        space permitting.
         """
         if data.gps_lat is None or data.gps_lon is None:
             return "NO GPS"
+        latlon = f"{data.gps_lat:.5f},{data.gps_lon:.5f}"
         try:
             import mgrs
             m = mgrs.MGRS()
-            return m.toMGRS(data.gps_lat, data.gps_lon)
+            grid = m.toMGRS(data.gps_lat, data.gps_lon)
+            combined = f"{latlon} {grid}"
+            return combined[:self._cols]
         except Exception:
-            return f"{data.gps_lat:.5f},{data.gps_lon:.5f}"
+            return latlon
 
     def _format_det_line(self, data: MspOsdData) -> str:
         """Format the most recent detection for row 17, right-aligned."""


### PR DESCRIPTION
## Summary
Updated the GPS display format to prioritize decimal latitude/longitude coordinates while optionally appending MGRS grid reference when the `mgrs` module is available.

## Key Changes
- Changed default GPS display from MGRS-only to decimal lat/lon format (`lat.5f,lon.5f`)
- When `mgrs` module is available, appends the MGRS grid reference after coordinates (space permitting)
- Combined output is truncated to fit within the display column width
- Simplified fallback behavior to return lat/lon when MGRS conversion fails or module unavailable
- Updated docstring to reflect the new behavior

## Implementation Details
- Decimal coordinates are now always calculated and displayed as the primary format
- MGRS grid reference is treated as supplementary information appended to the coordinates
- The combined string is truncated using `[:self._cols]` to ensure it fits within the display constraints
- Exception handling remains in place to gracefully fall back to lat/lon if MGRS conversion fails

https://claude.ai/code/session_0177tpfWtHpML22rJk64E2Dr