### PR TITLE
DetectionLogger: seed log index and safe rotation; UI init fixes

### DIFF
--- a/hydra_detect/detection_logger.py
+++ b/hydra_detect/detection_logger.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import re
 import queue
 import threading
 from collections import deque
@@ -108,6 +109,7 @@ class DetectionLogger:
             self._disabled = True
             return
 
+        self._seed_log_index()
         if not self._open_log_file():
             self._disabled = True
             return
@@ -256,6 +258,7 @@ class DetectionLogger:
             logger.info("Logging detections to %s", path)
             return True
         except OSError as exc:
+            self._current_log_path = None
             logger.error("Failed to open detection log file: %s", exc)
             return False
 
@@ -272,6 +275,7 @@ class DetectionLogger:
                 finally:
                     setattr(self, fh_name, None)
         self._csv_writer = None
+        self._current_log_path = None
 
     def _log_file_size(self) -> int:
         """Return byte size of the current log file, or 0 on error."""
@@ -295,12 +299,50 @@ class DetectionLogger:
             self._current_log_path,
             self._max_log_size_bytes / (1024 * 1024),
         )
-        self._close_log_file()
-        self._open_log_file()
+        if not self._open_rotated_log_file():
+            self._disabled = True
+            logger.error("Disabling detection logger after log rotation failure")
+            return
         self._prune_old_logs()
 
         if self._save_images:
             self._prune_old_images()
+
+    def _seed_log_index(self) -> None:
+        """Initialize the log index from existing files to avoid reuse on restart."""
+        ext = "csv" if self._log_format == "csv" else "jsonl"
+        pattern = re.compile(rf"^detections_(\d{{3}})\.{ext}$")
+        max_index = 0
+        for path in self._log_dir.glob(f"detections_*.{ext}"):
+            match = pattern.match(path.name)
+            if match:
+                max_index = max(max_index, int(match.group(1)))
+        self._log_index = max_index
+
+    def _open_rotated_log_file(self) -> bool:
+        """Rotate to a new file without losing the current log if reopen fails."""
+        old_csv_file = self._csv_file
+        old_json_file = self._json_file
+        old_csv_writer = self._csv_writer
+        old_path = self._current_log_path
+        old_index = self._log_index
+
+        if not self._open_log_file():
+            self._csv_file = old_csv_file
+            self._json_file = old_json_file
+            self._csv_writer = old_csv_writer
+            self._current_log_path = old_path
+            self._log_index = old_index
+            return False
+
+        try:
+            for fh in (old_csv_file, old_json_file):
+                if fh is not None:
+                    fh.flush()
+                    fh.close()
+        except OSError as exc:
+            logger.warning("Error closing rotated log file: %s", exc)
+        return True
 
     def _prune_old_logs(self) -> None:
         """Delete the oldest log files beyond the configured retention limit."""

--- a/hydra_detect/web/static/js/app.js
+++ b/hydra_detect/web/static/js/app.js
@@ -9,7 +9,7 @@
 
 const HydraApp = (() => {
     // ── State ──
-    let currentView = 'operations';
+    let currentView = null;
     const pollers = {};
     let pollFailCount = 0;
     const MAX_BACKOFF = 10000;

--- a/hydra_detect/web/static/js/panels.js
+++ b/hydra_detect/web/static/js/panels.js
@@ -10,6 +10,7 @@ const HydraPanels = (() => {
     const KNOWN_IDS = ['vehicle', 'target', 'pipeline', 'detection', 'rf', 'log'];
     const STORAGE_PREFIX = 'hydra-panels-';
     let sortableInstance = null;
+    let initialized = false;
 
     // ── Breakpoint helper ──
     function getBreakpoint() {
@@ -24,6 +25,8 @@ const HydraPanels = (() => {
     function init() {
         const container = document.getElementById('operations-panels');
         if (!container) return;
+        if (initialized) return;
+        initialized = true;
 
         // Init SortableJS
         if (typeof Sortable !== 'undefined') {

--- a/tests/test_detection_logger.py
+++ b/tests/test_detection_logger.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -91,6 +91,29 @@ class TestOpenCloseLogFile:
         assert dl._json_file is None
         assert dl._csv_file is None
         assert dl._csv_writer is None
+
+    def test_seed_index_from_existing_logs(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "detections_001.jsonl").write_text("{}\n")
+        (log_dir / "detections_007.jsonl").write_text("{}\n")
+
+        dl = _make_logger(tmp_path, log_dir=str(log_dir))
+        dl._seed_log_index()
+
+        assert dl._log_index == 7
+
+    def test_open_after_seed_uses_next_index(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "detections_004.jsonl").write_text("{}\n")
+
+        dl = _make_logger(tmp_path, log_dir=str(log_dir))
+        dl._seed_log_index()
+        assert dl._open_log_file()
+
+        assert dl._current_log_path.name == "detections_005.jsonl"
+        dl._close_log_file()
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +269,22 @@ class TestRotationIntegration:
                     records.append(json.loads(line))
         assert len(records) > 0
         assert all("label" in r for r in records)
+
+    @patch("hydra_detect.detection_logger.open", new_callable=mock_open)
+    def test_rotation_failure_disables_logger_without_closing_current_file(self, mock_file, tmp_path):
+        dl = _make_logger(tmp_path)
+        dl._log_dir.mkdir(parents=True, exist_ok=True)
+        assert dl._open_log_file()
+        dl._max_log_size_bytes = 0
+
+        original_handle = dl._json_file
+        assert original_handle is not None
+
+        mock_file.side_effect = OSError("disk full")
+        dl._rotate_if_needed()
+
+        assert dl._disabled is True
+        assert dl._json_file is original_handle
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Avoid reusing log file names on restart by seeding the next log index from existing files. 
- Make log rotation robust so a failed reopen does not close the current log and the logger can be disabled safely on unrecoverable I/O errors. 
- Prevent duplicate panel initialization and make initial SPA view explicit to avoid implicit assumptions. 

### Description
- Add `_seed_log_index` (uses `re` + `Path.glob`) and call it from `start()` to initialize `self._log_index` from existing `detections_###.(csv|jsonl)` files. 
- Implement `_open_rotated_log_file` to attempt creating the new rotated file while preserving current file handles on failure and update `_rotate_if_needed` to use it and disable the logger on fatal rotation failure. 
- Ensure `_current_log_path` is cleared when open/close fail and make `_log_file_size` safely return `0` when no current path exists. 
- Change SPA initial state in `web/static/js/app.js` to set `currentView` to `null`, and add an `initialized` guard in `web/static/js/panels.js` to avoid double initialization. 
- Update tests to use `mock_open` and add unit tests `test_seed_index_from_existing_logs`, `test_open_after_seed_uses_next_index`, and `test_rotation_failure_disables_logger_without_closing_current_file`. 

### Testing
- Ran `pytest -q tests/test_detection_logger.py` which includes the new seeding and rotation failure tests and observed all tests passing. 
- Existing rotation and pruning tests were exercised by the same test module and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb7a992a588328a92d51d694dc3dee)