### PR TITLE
DetectionLogger: seed log index and robust rotation; SPA init fixes; roadmap reorganized

### DIFF
--- a/hydra_detect/detection_logger.py
+++ b/hydra_detect/detection_logger.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import json
 import logging
+import re
 import queue
 import threading
 from collections import deque
@@ -108,6 +109,7 @@ class DetectionLogger:
             self._disabled = True
             return
 
+        self._seed_log_index()
         if not self._open_log_file():
             self._disabled = True
             return
@@ -256,6 +258,7 @@ class DetectionLogger:
             logger.info("Logging detections to %s", path)
             return True
         except OSError as exc:
+            self._current_log_path = None
             logger.error("Failed to open detection log file: %s", exc)
             return False
 
@@ -272,6 +275,7 @@ class DetectionLogger:
                 finally:
                     setattr(self, fh_name, None)
         self._csv_writer = None
+        self._current_log_path = None
 
     def _log_file_size(self) -> int:
         """Return byte size of the current log file, or 0 on error."""
@@ -295,12 +299,50 @@ class DetectionLogger:
             self._current_log_path,
             self._max_log_size_bytes / (1024 * 1024),
         )
-        self._close_log_file()
-        self._open_log_file()
+        if not self._open_rotated_log_file():
+            self._disabled = True
+            logger.error("Disabling detection logger after log rotation failure")
+            return
         self._prune_old_logs()
 
         if self._save_images:
             self._prune_old_images()
+
+    def _seed_log_index(self) -> None:
+        """Initialize the log index from existing files to avoid reuse on restart."""
+        ext = "csv" if self._log_format == "csv" else "jsonl"
+        pattern = re.compile(rf"^detections_(\d{{3}})\.{ext}$")
+        max_index = 0
+        for path in self._log_dir.glob(f"detections_*.{ext}"):
+            match = pattern.match(path.name)
+            if match:
+                max_index = max(max_index, int(match.group(1)))
+        self._log_index = max_index
+
+    def _open_rotated_log_file(self) -> bool:
+        """Rotate to a new file without losing the current log if reopen fails."""
+        old_csv_file = self._csv_file
+        old_json_file = self._json_file
+        old_csv_writer = self._csv_writer
+        old_path = self._current_log_path
+        old_index = self._log_index
+
+        if not self._open_log_file():
+            self._csv_file = old_csv_file
+            self._json_file = old_json_file
+            self._csv_writer = old_csv_writer
+            self._current_log_path = old_path
+            self._log_index = old_index
+            return False
+
+        try:
+            for fh in (old_csv_file, old_json_file):
+                if fh is not None:
+                    fh.flush()
+                    fh.close()
+        except OSError as exc:
+            logger.warning("Error closing rotated log file: %s", exc)
+        return True
 
     def _prune_old_logs(self) -> None:
         """Delete the oldest log files beyond the configured retention limit."""

--- a/hydra_detect/web/static/js/app.js
+++ b/hydra_detect/web/static/js/app.js
@@ -9,7 +9,7 @@
 
 const HydraApp = (() => {
     // ── State ──
-    let currentView = 'operations';
+    let currentView = null;
     const pollers = {};
     let pollFailCount = 0;
     const MAX_BACKOFF = 10000;

--- a/hydra_detect/web/static/js/panels.js
+++ b/hydra_detect/web/static/js/panels.js
@@ -10,6 +10,7 @@ const HydraPanels = (() => {
     const KNOWN_IDS = ['vehicle', 'target', 'pipeline', 'detection', 'rf', 'log'];
     const STORAGE_PREFIX = 'hydra-panels-';
     let sortableInstance = null;
+    let initialized = false;
 
     // ── Breakpoint helper ──
     function getBreakpoint() {
@@ -24,6 +25,8 @@ const HydraPanels = (() => {
     function init() {
         const container = document.getElementById('operations-panels');
         if (!container) return;
+        if (initialized) return;
+        initialized = true;
 
         // Init SortableJS
         if (typeof Sortable !== 'undefined') {

--- a/plan.md
+++ b/plan.md
@@ -1,19 +1,51 @@
-# Implementation Plan: MAVLink Commands, Autonomous Strike, Mission Review
+# Hydra Roadmap: Commands, Autonomy, Review, and Reliability
 
-## Overview
+## Why this rewrite exists
 
-Three features to enable full beyond-visual-range USV operations:
+This roadmap keeps the original ideas intact, but organizes them into:
 
-1. **MAVLink Command Path** — Strike/lock/unlock over telemetry radio (no WiFi needed)
-2. **Autonomous Strike Controller** — Geofenced auto-engage with qualification criteria
-3. **Post-Mission Review Tool** — Web page + CLI script for reviewing detection logs on a map
+1. **Must have next** — highest value / lowest regret work
+2. **Should have soon** — important enabling work and risk reduction
+3. **Nice to have later** — worthwhile extensions that should stay visible
+4. **Idea backlog (do not lose)** — notable future ideas pulled forward so they do not disappear in later edits
+
+The goal is to preserve the existing feature concepts while making sequencing and tradeoffs clearer.
 
 ---
 
-## Feature 1: MAVLink Command Path
+## Priority Overview
+
+### Must have next
+
+1. **MAVLink Command Path** — radio-only lock / strike / unlock commands
+2. **Post-Mission Review Tool** — web + export tooling for validating missions and detections
+3. **Reliability / Regression hardening** — lifecycle, auth, degraded-mode, and restart-path coverage
+4. **RF restart cleanup** — remove private auth mutation by giving `KismetClient` an explicit reset path
+
+### Should have soon
+
+5. **Autonomous Strike Controller** — only with explicit safety / explainability controls
+6. **Offline review workflow** — bundle/export strategy for field and air-gapped use
+7. **Fleet trust / time semantics** — identity, freshness, and conflict groundwork before heavier C2 features
+
+### Nice to have later
+
+8. **Fleet coordination extensions** — TAK/CoT, commander node, deconfliction, shared geofence
+9. **Advanced RF / Kismet expansion** — WiFi monitor mode, multi-SDR, richer RF indexing
+10. **UI polish** — presentation mode refinement and more operator-focused display options
+
+---
+
+## Workstream 1: MAVLink Command Path
 
 ### Goal
 Allow operators to send target lock, strike, and unlock commands from Mission Planner over RFD 900x radio using MAV_CMD_USER commands and NAMED_VALUE_INT messages.
+
+### Why it is first
+- Enables control without WiFi
+- Useful immediately in the field
+- Lower safety risk than autonomous strike
+- Creates a clean command channel that later autonomy and fleet work can build on
 
 ### Files Modified
 - `hydra_detect/mavlink_io.py` — Add command listener thread
@@ -56,10 +88,126 @@ Allow operators to send target lock, strike, and unlock commands from Mission Pl
 
 ---
 
-## Feature 2: Autonomous Strike Controller
+## Workstream 2: Post-Mission Review Tool
+
+### Goal
+Two ways to review detection logs after a mission:
+1. Web page on the Jetson (`/review`) with interactive Leaflet map
+2. CLI script that generates a standalone HTML file for offline viewing
+
+### Why it is early
+- Increases confidence in detections and mission behavior
+- Helps debug autonomy, RF, and target-control behavior later
+- Valuable even before autonomous strike ships
+- Produces artifacts operators and stakeholders can inspect
+
+### Files Created
+- `hydra_detect/web/templates/review.html` — Leaflet map review page
+- `hydra_detect/review_export.py` — CLI script for standalone HTML export
+- `tests/test_review.py` — Tests for log parsing and export
+
+### Files Modified
+- `hydra_detect/web/server.py` — Add review endpoints
+
+### Web Review Page
+
+**New endpoints in server.py:**
+- `GET /review` — Serve the review HTML page
+- `GET /api/review/logs` — List available JSONL/CSV log files in log_dir
+- `GET /api/review/log/{filename}` — Parse and return detection data from a log file
+- `GET /api/review/images/{filename}` — Serve saved detection images from image_dir
+
+**Review page features (Leaflet.js via CDN):**
+- OpenStreetMap tile layer (works offline with cached tiles)
+- Detection markers placed at GPS coordinates
+- Marker popup: label, confidence, timestamp, thumbnail image
+- Color-coded markers by class
+- Filter panel: filter by class label, minimum confidence slider
+- Track trails: toggle to connect markers with same track_id as polylines
+- Timeline slider: scrub through detections by timestamp
+- Log file selector dropdown
+
+### CLI Export Script
+
+`python -m hydra_detect.review_export /data/logs/detections_20260315_120000.jsonl -o mission_report.html`
+
+**Features:**
+- Reads JSONL or CSV log file
+- Embeds detection data as inline JSON in a self-contained HTML file
+- Uses Leaflet.js CDN (requires internet to open) or optionally inlines the JS
+- Generates summary statistics: total detections, unique classes, time range
+- Outputs a single .html file you can SCP off and open anywhere
+- Optional: `--images-dir` flag to embed thumbnail images as base64
+
+### Offline / field-use additions that should be tracked with this work
+- Fully offline export mode (no CDN dependency)
+- Optional tile caching or alternate map source strategy
+- Large-log handling (pagination / decimation / filtering before render)
+- Log/image consistency checks for missing media
+
+### Tests
+- `tests/test_review.py`:
+  - Test JSONL log parsing
+  - Test CSV log parsing
+  - Test log file listing endpoint
+  - Test image serving with path traversal protection
+  - Test CLI export generates valid HTML
+  - Test filtering by class and confidence
+
+---
+
+## Workstream 3: Reliability / Regression Hardening
+
+### Goal
+Capture the cross-cutting work that prevents repeated lifecycle, restart, auth, and degraded-mode failures as the project grows.
+
+### Why it is explicit now
+Recent fixes were mostly not “missing features”; they were correctness and resilience issues. This should be visible as a real workstream, not treated as incidental cleanup.
+
+### Scope
+- UI lifecycle regression coverage
+- Auth-enabled web control flow coverage
+- Degraded startup behavior when optional dependencies are missing
+- Disk-full / unwritable storage behavior
+- Restart-path visibility for RF/Kismet
+- Clear operator-facing health state where useful
+
+### Concrete near-term tasks
+- Add explicit tests for first-load Operations init, repeated view entry, and panel re-init regressions
+- Add smoke coverage for auth-enabled control endpoints from the SPA perspective
+- Add tests / behavior checks for missing `cv2`, missing `httpx`, missing Kismet binary, and unwritable log directories where practical
+- Surface RF subsystem restart count / last restart reason / adopted-vs-owned status in status APIs or UI as needed
+- Keep degraded modes safe and obvious rather than silently partial
+
+---
+
+## Workstream 4: RF Restart / Auth Cleanup
+
+### Goal
+Remove the current private-attribute auth reset in the RF restart path and replace it with a real client API.
+
+### Why it matters
+There is already a TODO in the hunt controller to stop mutating Kismet client internals directly after a restart. This is small, concrete, and worth fixing soon.
+
+### Files Modified
+- `hydra_detect/rf/kismet_client.py` — Add `reset_auth()` or equivalent
+- `hydra_detect/rf/hunt.py` — Use the public reset path
+- `tests/test_rf_hunt.py` / `tests/test_rf_kismet.py` — Cover restart + re-auth behavior
+
+### Success criteria
+- No direct mutation of private auth state from `RFHuntController`
+- Restart path remains test-covered
+- Failure behavior is unchanged or clearer
+
+---
+
+## Workstream 5: Autonomous Strike Controller
 
 ### Goal
 When the vehicle is in AUTO mode, inside a geofence, and a target meets qualification criteria, automatically initiate a strike without operator confirmation.
+
+### Why it is not first
+This is the highest-consequence feature in the current roadmap. It is important, but should ship with more explicit safety and explainability controls than the current draft implies.
 
 ### Files Created
 - `hydra_detect/autonomous.py` — AutonomousController class
@@ -136,7 +284,7 @@ class AutonomousController:
 - Extract `custom_mode` field and map to mode name
 - Store in GPS-like state dict, read by autonomous controller
 
-**Safety features:**
+**Safety features already in scope:**
 - Disabled by default (`enabled = false`)
 - Geofence must be explicitly configured (0,0 center = invalid)
 - Cooldown prevents rapid successive strikes
@@ -145,6 +293,12 @@ class AutonomousController:
 - Track persistence debounces false positives
 - All autonomous decisions logged to `hydra.audit` logger with full context
 - STATUSTEXT alert: `"AUTO-STRIKE: mine #4 @ 18SUJ1234567890"` sent to GCS
+
+### Additional controls that should be preserved in the roadmap
+- Dry-run mode (evaluate and report, but never strike)
+- Explicit runtime enable / inhibit control beyond config alone
+- Explainability logging for why a candidate did or did not qualify
+- Pre-strike audit trail that operators can review after the fact
 
 ### Pipeline Integration Point
 In `_run_loop()`, after tracking and MAVLink alerts, before overlay:
@@ -173,68 +327,86 @@ if self._autonomous is not None:
 
 ---
 
-## Feature 3: Post-Mission Review Tool
+## Workstream 6: Fleet groundwork before heavier coordination
 
 ### Goal
-Two ways to review detection logs after a mission:
-1. Web page on the Jetson (`/review`) with interactive Leaflet map
-2. CLI script that generates a standalone HTML file for offline viewing
+Keep fleet work visible, but sequence the foundations before the bigger C2 ideas.
 
-### Files Created
-- `hydra_detect/web/templates/review.html` — Leaflet map review page
-- `hydra_detect/review_export.py` — CLI script for standalone HTML export
-- `tests/test_review.py` — Tests for log parsing and export
+### Nearer-term groundwork
+- Node identity / authenticity assumptions
+- Duplicate node_id handling
+- Timestamp / freshness semantics
+- Stale / replay handling expectations
 
-### Files Modified
-- `hydra_detect/web/server.py` — Add review endpoints
+### Later feature ideas already worth preserving
+- TAK/CoT integration
+- Automated target deconfliction
+- Commander node / C2 commands
+- Fleet map overlay on video feed
+- Shared geofence enforcement
 
-### Web Review Page
+---
 
-**New endpoints in server.py:**
-- `GET /review` — Serve the review HTML page
-- `GET /api/review/logs` — List available JSONL/CSV log files in log_dir
-- `GET /api/review/log/{filename}` — Parse and return detection data from a log file
-- `GET /api/review/images/{filename}` — Serve saved detection images from image_dir
+## Workstream 7: Advanced RF / UI polish (later)
 
-**Review page features (Leaflet.js via CDN):**
-- OpenStreetMap tile layer (works offline with cached tiles)
-- Detection markers placed at GPS coordinates
-- Marker popup: label, confidence, timestamp, thumbnail image
-- Color-coded markers by class
-- Filter panel: filter by class label, minimum confidence slider
-- Track trails: toggle to connect markers with same track_id as polylines
-- Timeline slider: scrub through detections by timestamp
-- Log file selector dropdown
+### Advanced RF / Kismet ideas to keep visible
+- Elasticsearch indexing of RF samples
+- WiFi monitor-mode source support
+- Multi-SDR dongle support
 
-### CLI Export Script
-
-`python -m hydra_detect.review_export /data/logs/detections_20260315_120000.jsonl -o mission_report.html`
-
-**Features:**
-- Reads JSONL or CSV log file
-- Embeds detection data as inline JSON in a self-contained HTML file
-- Uses Leaflet.js CDN (requires internet to open) or optionally inlines the JS
-- Generates summary statistics: total detections, unique classes, time range
-- Outputs a single .html file you can SCP off and open anywhere
-- Optional: `--images-dir` flag to embed thumbnail images as base64
-
-### Tests
-- `tests/test_review.py`:
-  - Test JSONL log parsing
-  - Test CSV log parsing
-  - Test log file listing endpoint
-  - Test image serving with path traversal protection
-  - Test CLI export generates valid HTML
-  - Test filtering by class and confidence
+### UI polish ideas to keep visible
+- Presentation Mode updates, including optionally hiding panel columns
+- More operator-oriented full-screen / display presets
 
 ---
 
 ## Implementation Order
 
-1. **Feature 2 first** (autonomous.py) — standalone module, no dependencies on other features
-2. **Feature 1 second** (MAVLink commands) — modifies mavlink_io.py which is also needed by Feature 2
-3. **Feature 3 last** (review tool) — completely independent, touches web/server.py
+### Recommended order
+1. **MAVLink Command Path**
+2. **Post-Mission Review Tool**
+3. **Reliability / Regression Hardening** (ongoing alongside feature work)
+4. **RF Restart / Auth Cleanup**
+5. **Autonomous Strike Controller**
+6. **Fleet groundwork (trust / time semantics)**
+7. **Fleet coordination extensions**
+8. **Advanced RF / UI polish**
+
+### Alternative if autonomy urgency is very high
+If autonomous strike is the mission-critical driver, keep it early — but only if the dry-run, inhibit, and explainability items above stay attached to it and do not get split off into “later cleanup.”
+
+---
 
 ## Testing Strategy
 
 Run `python -m pytest tests/ -v` after each feature. All existing tests must continue to pass. New tests added per feature as described above.
+
+In addition to unit tests, prefer to keep a lightweight checklist for:
+- auth-enabled web flows
+- first-load SPA lifecycle
+- degraded startup behavior
+- restart behavior for external managed processes
+- field validation of RF and mission-review artifacts
+
+---
+
+## Idea Backlog (do not lose)
+
+These ideas should remain visible even if they are not the next thing implemented:
+
+- Radio-only operator control via MAVLink user commands
+- Autonomous strike with geofence + qualification gates
+- Review/export workflow for after-action mission analysis
+- Dry-run / explainability / inhibit controls for autonomy
+- Offline review/export support for field use
+- RF restart-path cleanup and observability
+- Fleet identity / freshness groundwork
+- TAK/CoT integration
+- Automated target deconfliction
+- Commander-node / C2 semantics
+- Fleet map overlay
+- Shared geofence enforcement
+- WiFi monitor-mode support
+- Multi-SDR support
+- RF sample indexing / richer analysis
+- Presentation Mode improvements

--- a/tests/test_detection_logger.py
+++ b/tests/test_detection_logger.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import time
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
@@ -91,6 +91,29 @@ class TestOpenCloseLogFile:
         assert dl._json_file is None
         assert dl._csv_file is None
         assert dl._csv_writer is None
+
+    def test_seed_index_from_existing_logs(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "detections_001.jsonl").write_text("{}\n")
+        (log_dir / "detections_007.jsonl").write_text("{}\n")
+
+        dl = _make_logger(tmp_path, log_dir=str(log_dir))
+        dl._seed_log_index()
+
+        assert dl._log_index == 7
+
+    def test_open_after_seed_uses_next_index(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        (log_dir / "detections_004.jsonl").write_text("{}\n")
+
+        dl = _make_logger(tmp_path, log_dir=str(log_dir))
+        dl._seed_log_index()
+        assert dl._open_log_file()
+
+        assert dl._current_log_path.name == "detections_005.jsonl"
+        dl._close_log_file()
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +269,22 @@ class TestRotationIntegration:
                     records.append(json.loads(line))
         assert len(records) > 0
         assert all("label" in r for r in records)
+
+    @patch("hydra_detect.detection_logger.open", new_callable=mock_open)
+    def test_rotation_failure_disables_logger_without_closing_current_file(self, mock_file, tmp_path):
+        dl = _make_logger(tmp_path)
+        dl._log_dir.mkdir(parents=True, exist_ok=True)
+        assert dl._open_log_file()
+        dl._max_log_size_bytes = 0
+
+        original_handle = dl._json_file
+        assert original_handle is not None
+
+        mock_file.side_effect = OSError("disk full")
+        dl._rotate_if_needed()
+
+        assert dl._disabled is True
+        assert dl._json_file is original_handle
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Ensure log files are never reused across restarts and make rotation failure-safe to avoid data loss or silent stop/start bugs.
- Prevent SPA and panel double-initialization and establish a clearer default view state for the web UI.
- Rework the project roadmap into a clearer, prioritized plan to make next steps and reliability work explicit.

### Description
- Added `_seed_log_index()` to initialize `DetectionLogger._log_index` from existing `detections_###.{csv,jsonl}` files and call it during `start()` to avoid reusing indices on restart.
- Implemented `_open_rotated_log_file()` and updated `_rotate_if_needed()` to attempt opening the new file before closing the old one, restoring previous handles on failure and disabling the logger if rotation cannot be completed safely; also added precautionary `_current_log_path` handling on open/close errors.
- Added `re` import and small refactors to file open/close logic and file-size handling used during rotation and pruning.
- UI fixes: set `currentView` to `null` in `web/static/js/app.js` instead of defaulting to `'operations'`, and added an `initialized` guard in `web/static/js/panels.js` to prevent repeated panel initialization.
- Large editorial rewrite of `plan.md` to reorganize the roadmap with prioritized workstreams and clearer testing/implementation notes.
- Tests: extended `tests/test_detection_logger.py` to add `test_seed_index_from_existing_logs` and `test_rotation_failure_disables_logger_without_closing_current_file`, and switched a mock import to use `mock_open` for rotation failure simulation.

### Testing
- Ran `pytest tests/test_detection_logger.py -q`; all tests passed, including the new `test_seed_index_from_existing_logs` and `test_rotation_failure_disables_logger_without_closing_current_file`.
- Existing rotation and pruning tests were exercised (JSONL/CSV naming, prune behavior, rotation integration) and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb7a992a588328a92d51d694dc3dee)