### PR TITLE
Add public Kismet auth reset API

### DIFF
--- a/hydra_detect/rf/hunt.py
+++ b/hydra_detect/rf/hunt.py
@@ -305,9 +305,7 @@ class RFHuntController:
         if not self._kismet.check_connection():
             logger.warning("Kismet connection lost — attempting restart")
             if self._kismet_manager.restart(stop_event=self._stop_evt):
-                # Reset auth so KismetClient re-authenticates with new Kismet instance.
-                # TODO: Add KismetClient.reset_auth() method to avoid private attr access.
-                self._kismet._authenticated = False
+                self._kismet.reset_auth()
                 return self._kismet.get_rssi(
                     mode=self._mode,
                     bssid=self._target_bssid,

--- a/hydra_detect/rf/kismet_client.py
+++ b/hydra_detect/rf/kismet_client.py
@@ -121,6 +121,12 @@ class KismetClient:
             logger.error("Cannot reach Kismet API at %s: %s", self._host, exc)
             return False
 
+    def reset_auth(self) -> None:
+        """Clear cached auth/session state so the next request re-authenticates."""
+        self._authenticated = False
+        self._session.auth = None
+        self._session.cookies.clear()
+
     # -- WiFi RSSI by BSSID ------------------------------------------------
 
     def get_wifi_rssi(self, bssid: str) -> float | None:

--- a/tests/test_rf_hunt.py
+++ b/tests/test_rf_hunt.py
@@ -294,4 +294,5 @@ class TestHuntKismetManagerIntegration:
         rssi = ctrl._poll_rssi()
         # Should have attempted restart and returned the retry value
         mgr.restart.assert_called_once()
+        ctrl._kismet.reset_auth.assert_called_once_with()
         assert rssi == -60.0

--- a/tests/test_rf_kismet.py
+++ b/tests/test_rf_kismet.py
@@ -178,6 +178,18 @@ class TestUnifiedGetter:
         client.close()
         client._session.close.assert_called_once()
 
+    def test_reset_auth_clears_cached_session_state(self):
+        client = KismetClient()
+        client._session = MagicMock()
+        client._authenticated = True
+        client._session.auth = ("user", "pass")
+
+        client.reset_auth()
+
+        assert client._authenticated is False
+        assert client._session.auth is None
+        client._session.cookies.clear.assert_called_once()
+
     def test_context_manager(self):
         with KismetClient() as client:
             assert client._session is not None


### PR DESCRIPTION
### Motivation

- The RF restart path was mutating `KismetClient` internals (`_authenticated`) after a Kismet restart, which is fragile and breaks encapsulation. 
- Provide a clear public API to clear cached auth/session state so the client re-authenticates cleanly after a restart.

### Description

- Add `KismetClient.reset_auth()` to `hydra_detect/rf/kismet_client.py` which clears `_authenticated`, `session.auth`, and session cookies. 
- Replace direct private-attribute mutation in the hunt restart path with a call to `self._kismet.reset_auth()` in `hydra_detect/rf/hunt.py`. 
- Extend `tests/test_rf_kismet.py` with `test_reset_auth_clears_cached_session_state` to verify `reset_auth()` behavior. 
- Extend `tests/test_rf_hunt.py` to assert the hunt controller invokes `reset_auth()` during Kismet restart recovery.

### Testing

- Ran `pytest tests/test_rf_kismet.py tests/test_rf_hunt.py` and the updated tests executed successfully. 
- All test cases passed (43 passed in ~1.7s).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb83b9877083289f470f420c19bb89)