### PR TITLE
fix: add requests runtime dependency for RF/Kismet

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ sudo usermod -aG dialout $USER  # log out/in after this
 git clone https://github.com/rmeadomavic/Hydra.git
 cd Hydra
 sudo pip3 install -r requirements.txt
+# `requests` is included here because RF/Kismet support uses it at runtime.
 
 mkdir -p models
 wget -P models https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8s.pt

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -124,7 +124,7 @@ Docker is the easiest path on a Jetson. The base image is large (~6 GB) but incl
 
 <Step title="Install dependencies">
   ```bash
-  sudo pip3 install -r requirements.txt
+  sudo pip3 install -r requirements.txt  # includes the RF/Kismet `requests` runtime dependency
   ```
 
   <Note>

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ mgrs>=1.4,<2.0
 fastapi>=0.104,<2.0
 uvicorn[standard]>=0.24,<1.0
 jinja2>=3.1,<4.0
+requests>=2.31,<3.0

--- a/tests/test_rf_kismet.py
+++ b/tests/test_rf_kismet.py
@@ -7,6 +7,15 @@ from unittest.mock import MagicMock, patch
 from hydra_detect.rf.kismet_client import KismetClient
 
 
+class TestKismetDependencyPolicy:
+    @patch("hydra_detect.rf.kismet_client.requests.Session")
+    def test_client_uses_requests_session_dependency(self, mock_session_cls):
+        client = KismetClient()
+
+        mock_session_cls.assert_called_once_with()
+        assert client._session is mock_session_cls.return_value
+
+
 class TestKismetConnection:
     @patch("hydra_detect.rf.kismet_client.requests.Session")
     def test_connection_success(self, mock_session_cls):

--- a/tests/test_rf_kismet_manager.py
+++ b/tests/test_rf_kismet_manager.py
@@ -13,6 +13,18 @@ import pytest
 from hydra_detect.rf.kismet_manager import KismetManager
 
 
+class TestKismetManagerDependencyPolicy:
+    @patch("hydra_detect.rf.kismet_manager.requests.get")
+    def test_health_check_uses_requests_dependency(self, mock_get):
+        mgr = KismetManager()
+        response = MagicMock()
+        response.status_code = 200
+        mock_get.return_value = response
+
+        assert mgr._check_api() is True
+        mock_get.assert_called_once()
+
+
 class TestKismetManagerInit:
     def test_stores_config(self):
         mgr = KismetManager(


### PR DESCRIPTION
### Motivation
- Ensure RF/Kismet features work on clean installs by declaring the HTTP client dependency used at runtime. 
- Make the dependency policy explicit in tests and installation docs so users and CI see that `requests` is required for RF/Kismet functionality.

### Description
- Add `requests>=2.31,<3.0` to `requirements.txt` to match the repo's bounded-version style. 
- Confirmed `requests` is directly imported in `hydra_detect/rf/kismet_client.py` and `hydra_detect/rf/kismet_manager.py`, so the dependency is kept mandatory rather than made optional. 
- Extend tests by adding assertions that `KismetClient` constructs a `requests.Session` in `tests/test_rf_kismet.py` and that `KismetManager` health checks call `requests.get` in `tests/test_rf_kismet_manager.py`. 
- Update install docs in `README.md` and `docs/quickstart.mdx` to note that `requirements.txt` now includes the RF/Kismet `requests` runtime dependency.

### Testing
- Ran `python -m pytest tests/test_rf_kismet.py tests/test_rf_kismet_manager.py -q` and the tests passed with `35 passed in 0.53s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb9048585c8328ac41e86fcbb3d4f8)