### PR TITLE
Add configurable YOLO inference size (imgsz) to improve Jetson FPS

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -10,7 +10,8 @@ video_standard = ntsc
 [detector]
 yolo_model = yolov8n.pt
 yolo_confidence = 0.45
-yolo_classes = 
+yolo_imgsz = 416
+yolo_classes =
 
 [tracker]
 track_thresh = 0.5

--- a/hydra_detect/detectors/yolo_detector.py
+++ b/hydra_detect/detectors/yolo_detector.py
@@ -21,10 +21,12 @@ class YOLODetector(BaseDetector):
         model_path: str = "yolov8n.pt",
         confidence: float = 0.45,
         classes: Optional[List[int]] = None,
+        imgsz: int | None = None,
     ):
         self._model_path = model_path
         self._confidence = confidence
         self._classes = classes
+        self._imgsz = imgsz
         self._model = None
 
     def load(self) -> None:
@@ -39,12 +41,14 @@ class YOLODetector(BaseDetector):
             raise RuntimeError("Model not loaded — call load() first.")
 
         t0 = time.perf_counter()
-        results = self._model.predict(
-            frame,
+        predict_kwargs: dict = dict(
             conf=self._confidence,
             classes=self._classes,
             verbose=False,
         )
+        if self._imgsz is not None:
+            predict_kwargs["imgsz"] = self._imgsz
+        results = self._model.predict(frame, **predict_kwargs)
         elapsed_ms = (time.perf_counter() - t0) * 1000
 
         detections: list[Detection] = []

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -64,10 +64,13 @@ def _build_detector(cfg: configparser.ConfigParser, models_dir: Path | None = No
             if candidate.exists():
                 model_path = str(candidate)
                 break
+    imgsz_raw = cfg.get("detector", "yolo_imgsz", fallback="")
+    imgsz = int(imgsz_raw) if imgsz_raw.strip() else None
     return YOLODetector(
         model_path=model_path,
         confidence=cfg.getfloat("detector", "yolo_confidence", fallback=0.45),
         classes=classes,
+        imgsz=imgsz,
     )
 
 


### PR DESCRIPTION
The YOLO predict() call was using the default 640x640 inference size,
which is a bottleneck on Jetson Orin Nano (~1 FPS). This adds a
yolo_imgsz config option (defaulting to 416) that directly controls
the model input resolution, reducing computation and improving
throughput without requiring camera resolution changes.

https://claude.ai/code/session_01BfXVk4JRFBYYZNvgXBvVZT