### PR TITLE
feat: follow mode and unified approach controller

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -74,6 +74,9 @@ strike_cooldown_sec = 30.0
 allowed_vehicle_modes = AUTO
 gps_max_stale_sec = 2.0                 ; abort if GPS data is older than this
 require_operator_lock = false            ; require explicit target lock before auto-strike
+follow_speed_max = 3.0                  ; max speed in follow mode (m/s)
+follow_min_distance = 5.0               ; minimum follow distance (metres)
+approach_method = gps_waypoint           ; gps_waypoint | rc_override | hybrid
 
 [rf_homing]
 enabled = false

--- a/hydra_detect/approach.py
+++ b/hydra_detect/approach.py
@@ -40,6 +40,8 @@ class ApproachConfig:
     speed_scale_far: float = 1.0        # speed multiplier when far
     speed_scale_near: float = 0.3       # speed multiplier when close
     near_threshold_px: float = 0.4      # bbox area ratio considered "near"
+    abort_mode: str = "LOITER"          # preferred vehicle mode on abort
+    close_stop_bbox: float = 0.5        # bbox area ratio to stop closing
 
 
 class ApproachController:
@@ -108,16 +110,28 @@ class ApproachController:
             self._mode = ApproachMode.IDLE
             self._target_track_id = None
 
-            # Restore vehicle mode or go to LOITER/HOLD
-            try:
-                self._mavlink.set_mode("LOITER")
-            except Exception:
-                pass
+            # Restore vehicle mode — try preferred abort mode with fallbacks
+            abort_mode_set = False
+            if self._mavlink.set_mode(self._cfg.abort_mode):
+                abort_mode_set = True
+            else:
+                for fallback in ["HOLD", "BRAKE", "LOITER", "RTL"]:
+                    if fallback == self._cfg.abort_mode:
+                        continue  # already tried
+                    if self._mavlink.set_mode(fallback):
+                        abort_mode_set = True
+                        break
 
-            logger.info(
-                "Approach ABORTED from %s mode — vehicle set to LOITER",
-                prev_mode.value,
-            )
+            if abort_mode_set:
+                logger.info(
+                    "Approach ABORTED from %s mode — vehicle safed",
+                    prev_mode.value,
+                )
+            else:
+                logger.error(
+                    "Approach ABORTED from %s mode — FAILED to set any safe mode",
+                    prev_mode.value,
+                )
 
     def update(
         self,
@@ -183,10 +197,12 @@ class ApproachController:
             )
             speed = self._cfg.follow_speed_max * scale
 
-        # Check minimum distance (using bbox as proxy)
-        if bbox_area > 0.5:  # Very close — more than half the frame
+        # Check minimum distance (using bbox area as proxy — no depth sensor
+        # available, so we cannot convert to metres directly)
+        if bbox_area > self._cfg.close_stop_bbox:
             logger.debug(
-                "Follow: target very close (bbox=%.2f), holding", bbox_area,
+                "Follow: target very close (bbox=%.2f > %.2f), holding",
+                bbox_area, self._cfg.close_stop_bbox,
             )
             return
 

--- a/hydra_detect/approach.py
+++ b/hydra_detect/approach.py
@@ -1,0 +1,216 @@
+"""Unified approach controller — drives vehicle toward a tracked target."""
+
+from __future__ import annotations
+
+import logging
+import time
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .mavlink_io import MAVLinkIO
+    from .tracker import TrackedObject
+
+logger = logging.getLogger(__name__)
+
+
+class ApproachMode(Enum):
+    IDLE = "idle"
+    FOLLOW = "follow"
+    DROP = "drop"
+    STRIKE = "strike"
+
+
+class ApproachMethod(Enum):
+    GPS_WAYPOINT = "gps_waypoint"
+    RC_OVERRIDE = "rc_override"
+    HYBRID = "hybrid"
+
+
+@dataclass
+class ApproachConfig:
+    """Configuration for approach behavior."""
+
+    method: ApproachMethod = ApproachMethod.GPS_WAYPOINT
+    follow_speed_max: float = 3.0       # m/s max speed in follow
+    follow_min_distance: float = 5.0    # metres — don't close further
+    update_hz: float = 2.0              # waypoint update rate
+    speed_scale_far: float = 1.0        # speed multiplier when far
+    speed_scale_near: float = 0.3       # speed multiplier when close
+    near_threshold_px: float = 0.4      # bbox area ratio considered "near"
+
+
+class ApproachController:
+    """Drives the vehicle toward a locked target using configurable methods.
+
+    The approach controller is the execution layer — it handles the HOW of
+    getting to a target.  The autonomous controller handles the WHAT and WHEN
+    (safety gates, qualification).  Pipeline wires them together.
+    """
+
+    def __init__(
+        self,
+        mavlink: MAVLinkIO,
+        config: ApproachConfig | None = None,
+    ):
+        self._mavlink = mavlink
+        self._cfg = config or ApproachConfig()
+        self._mode = ApproachMode.IDLE
+        self._target_track_id: int | None = None
+        self._lock = threading.Lock()
+
+        # State for speed control
+        self._last_bbox_area: float = 0.0    # normalised bbox area (0-1)
+        self._last_update: float = 0.0
+        self._pre_approach_mode: str | None = None  # vehicle mode before approach
+
+        # Stats
+        self._waypoints_sent: int = 0
+        self._active_since: float | None = None
+
+    @property
+    def mode(self) -> ApproachMode:
+        return self._mode
+
+    @property
+    def active(self) -> bool:
+        return self._mode != ApproachMode.IDLE
+
+    def start_follow(self, track_id: int) -> bool:
+        """Begin following a tracked target.  Returns True if started."""
+        with self._lock:
+            if self._mode != ApproachMode.IDLE:
+                logger.warning(
+                    "Approach already active in %s mode", self._mode.value,
+                )
+                return False
+
+            # Save current vehicle mode for restoration on abort
+            self._pre_approach_mode = self._mavlink.get_vehicle_mode()
+            self._target_track_id = track_id
+            self._mode = ApproachMode.FOLLOW
+            self._waypoints_sent = 0
+            self._active_since = time.monotonic()
+            self._last_update = 0.0
+
+            logger.info("Follow mode STARTED for track #%d", track_id)
+            return True
+
+    def abort(self) -> None:
+        """Stop all approach activity and safe the vehicle."""
+        with self._lock:
+            if self._mode == ApproachMode.IDLE:
+                return
+
+            prev_mode = self._mode
+            self._mode = ApproachMode.IDLE
+            self._target_track_id = None
+
+            # Restore vehicle mode or go to LOITER/HOLD
+            try:
+                self._mavlink.set_mode("LOITER")
+            except Exception:
+                pass
+
+            logger.info(
+                "Approach ABORTED from %s mode — vehicle set to LOITER",
+                prev_mode.value,
+            )
+
+    def update(
+        self,
+        track: TrackedObject | None,
+        frame_width: int,
+        frame_height: int,
+    ) -> None:
+        """Called every frame with the current track state.
+
+        If track is None, the target is lost — hold position.
+        """
+        if self._mode == ApproachMode.IDLE:
+            return
+
+        now = time.monotonic()
+        interval = 1.0 / self._cfg.update_hz
+
+        if now - self._last_update < interval:
+            return
+        self._last_update = now
+
+        if self._mode == ApproachMode.FOLLOW:
+            self._update_follow(track, frame_width, frame_height)
+
+    def _update_follow(
+        self,
+        track: TrackedObject | None,
+        fw: int,
+        fh: int,
+    ) -> None:
+        """Update follow mode — send waypoint toward target."""
+        if track is None:
+            # Target lost — hold position
+            logger.debug("Follow: target lost, holding position")
+            return
+
+        # Compute normalised centre offset for bearing estimation
+        cx, cy = track.center
+        error_x = (cx - fw / 2.0) / (fw / 2.0)  # -1..+1
+
+        # Estimate target position using existing MAVLink helper
+        target_pos = self._mavlink.estimate_target_position(error_x)
+        if target_pos is None:
+            return
+
+        target_lat, target_lon = target_pos
+
+        # Speed control based on bounding box size
+        bbox_area = (
+            (track.x2 - track.x1) * (track.y2 - track.y1)
+        ) / (fw * fh)
+        self._last_bbox_area = bbox_area
+
+        # Scale speed: large bbox = close = slow, small bbox = far = fast
+        if bbox_area > self._cfg.near_threshold_px:
+            speed = self._cfg.follow_speed_max * self._cfg.speed_scale_near
+        else:
+            # Linear interpolation between near and far speeds
+            t = min(1.0, bbox_area / self._cfg.near_threshold_px)
+            scale = (
+                self._cfg.speed_scale_far
+                + t * (self._cfg.speed_scale_near - self._cfg.speed_scale_far)
+            )
+            speed = self._cfg.follow_speed_max * scale
+
+        # Check minimum distance (using bbox as proxy)
+        if bbox_area > 0.5:  # Very close — more than half the frame
+            logger.debug(
+                "Follow: target very close (bbox=%.2f), holding", bbox_area,
+            )
+            return
+
+        # Send speed command
+        try:
+            self._mavlink.command_do_change_speed(speed)
+        except Exception as exc:
+            logger.debug("Follow: speed command failed: %s", exc)
+
+        # Send waypoint
+        try:
+            self._mavlink.command_guided_to(target_lat, target_lon)
+            self._waypoints_sent += 1
+        except Exception as exc:
+            logger.warning("Follow: guided waypoint failed: %s", exc)
+
+    def get_status(self) -> dict:
+        """Return current approach status for web API."""
+        return {
+            "mode": self._mode.value,
+            "active": self.active,
+            "target_track_id": self._target_track_id,
+            "method": self._cfg.method.value,
+            "waypoints_sent": self._waypoints_sent,
+            "bbox_area": round(self._last_bbox_area, 3),
+            "active_since": self._active_since,
+        }

--- a/hydra_detect/mavlink_io.py
+++ b/hydra_detect/mavlink_io.py
@@ -561,6 +561,32 @@ class MAVLinkIO:
             logger.warning("Failed to clear ROI: %s", exc)
 
     # ------------------------------------------------------------------
+    # Speed control
+    # ------------------------------------------------------------------
+    def command_do_change_speed(self, speed_m_s: float) -> bool:
+        """Set vehicle ground speed via MAV_CMD_DO_CHANGE_SPEED."""
+        if self._mav is None:
+            return False
+        try:
+            from pymavlink import mavutil
+
+            with self._send_lock:
+                self._mav.mav.command_long_send(
+                    self._mav.target_system,
+                    self._mav.target_component,
+                    mavutil.mavlink.MAV_CMD_DO_CHANGE_SPEED,
+                    0,          # confirmation
+                    1,          # speed type: ground speed
+                    speed_m_s,
+                    -1,         # throttle (-1 = no change)
+                    0, 0, 0, 0,
+                )
+            return True
+        except Exception as exc:
+            logger.warning("DO_CHANGE_SPEED failed: %s", exc)
+            return False
+
+    # ------------------------------------------------------------------
     # Keep-in-frame: yaw the vehicle to center the target in camera
     # ------------------------------------------------------------------
     def adjust_yaw(self, error_x: float, yaw_rate_max: float = 30.0) -> None:

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -12,7 +12,7 @@ from collections import deque
 from pathlib import Path
 from typing import Optional
 
-from .approach import ApproachConfig, ApproachController
+from .approach import ApproachConfig, ApproachController, ApproachMode
 from .autonomous import AutonomousController, parse_polygon
 from .servo_tracker import ServoTracker
 from .camera import Camera, list_video_sources
@@ -1086,10 +1086,16 @@ class Pipeline:
         """Start follow mode for a track."""
         if self._approach is None:
             return False
-        # Lock the track first
+        if self._approach.mode != ApproachMode.IDLE:
+            return False
+        # Now safe to lock and start
         if not self._handle_target_lock(track_id, mode="follow"):
             return False
-        return self._approach.start_follow(track_id)
+        if not self._approach.start_follow(track_id):
+            self._handle_target_unlock()  # rollback
+            return False
+        self._lock_mode = "follow"
+        return True
 
     def _handle_abort_command(self) -> None:
         """Abort all autonomous approach activity."""

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -12,6 +12,7 @@ from collections import deque
 from pathlib import Path
 from typing import Optional
 
+from .approach import ApproachConfig, ApproachController
 from .autonomous import AutonomousController, parse_polygon
 from .servo_tracker import ServoTracker
 from .camera import Camera, list_video_sources
@@ -310,6 +311,19 @@ class Pipeline:
                 self._cfg.getint("autonomous", "min_track_frames", fallback=5),
                 classes_raw or "NONE (fail-closed)",
             )
+
+        # Approach controller (follow / drop / strike approach behaviors)
+        self._approach: ApproachController | None = None
+        if self._mavlink is not None:
+            approach_cfg = ApproachConfig(
+                follow_speed_max=self._cfg.getfloat(
+                    "autonomous", "follow_speed_max", fallback=3.0,
+                ),
+                follow_min_distance=self._cfg.getfloat(
+                    "autonomous", "follow_min_distance", fallback=5.0,
+                ),
+            )
+            self._approach = ApproachController(self._mavlink, approach_cfg)
 
         # RF homing controller
         self._rf_hunt: RFHuntController | None = None
@@ -632,6 +646,12 @@ class Pipeline:
                 get_tak_status=self._get_tak_status,
                 get_profiles=self._get_profiles,
                 on_profile_switch=self._handle_profile_switch,
+                on_follow_command=self._handle_follow_command,
+                on_abort_command=self._handle_abort_command,
+                get_approach_status=lambda: (
+                    self._approach.get_status()
+                    if self._approach else {"mode": "idle"}
+                ),
             )
 
             stream_state.update_stats(
@@ -819,6 +839,19 @@ class Pipeline:
                 self._autonomous.evaluate(
                     track_result, self._mavlink,
                     self._handle_target_lock, self._handle_strike_command,
+                )
+
+            # Update approach controller with locked track
+            if self._approach is not None and self._approach.active:
+                locked_track_for_approach = None
+                if current_lock_id is not None:
+                    locked_track_for_approach = track_result.find(
+                        current_lock_id,
+                    )
+                self._approach.update(
+                    locked_track_for_approach,
+                    frame.shape[1],
+                    frame.shape[0],
                 )
 
             if current_lock_id is not None and self._mavlink is not None:
@@ -1048,6 +1081,35 @@ class Pipeline:
                     self._mavlink.clear_roi()
         if self._servo_tracker is not None:
             self._servo_tracker.safe()
+
+    def _handle_follow_command(self, track_id: int) -> bool:
+        """Start follow mode for a track."""
+        if self._approach is None:
+            return False
+        # Lock the track first
+        if not self._handle_target_lock(track_id, mode="follow"):
+            return False
+        return self._approach.start_follow(track_id)
+
+    def _handle_abort_command(self) -> None:
+        """Abort all autonomous approach activity."""
+        if self._approach is not None:
+            self._approach.abort()
+        if self._autonomous is not None:
+            self._autonomous.suppressed = True
+        # Release lock
+        with self._state_lock:
+            self._locked_track_id = None
+            self._lock_mode = None
+        # Safe servos
+        if self._servo_tracker is not None:
+            self._servo_tracker.safe()
+        if self._mavlink is not None:
+            callsign = self._cfg.get("tak", "callsign", fallback="HYDRA")
+            self._mavlink.send_statustext(
+                f"{callsign}: ABORT", severity=3,
+            )
+        logger.info("ABORT: all approach activity cancelled")
 
     def _handle_strike_command(self, track_id: int) -> bool:
         """Command vehicle to navigate toward a tracked target.

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -527,6 +527,51 @@ async def api_strike_command(request: Request, authorization: Optional[str] = He
     return JSONResponse({"error": "strike not available"}, status_code=503)
 
 
+# ── Approach / Follow ─────────────────────────────────────────
+
+@app.post("/api/follow/{track_id}")
+async def follow_track(
+    track_id: int,
+    request: Request,
+    authorization: Optional[str] = Header(None),
+):
+    """Start follow mode on a track."""
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    cb = stream_state.get_callback("on_follow_command")
+    if cb and cb(track_id):
+        _audit(request, "follow", target=str(track_id))
+        return {"status": "following", "track_id": track_id}
+    _audit(request, "follow", target=str(track_id), outcome="failed")
+    return JSONResponse({"error": "follow not available"}, status_code=400)
+
+
+@app.post("/api/abort")
+async def abort_approach(
+    request: Request,
+    authorization: Optional[str] = Header(None),
+):
+    """Abort all autonomous approach activity."""
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    cb = stream_state.get_callback("on_abort_command")
+    if cb:
+        cb()
+    _audit(request, "abort")
+    return {"status": "aborted"}
+
+
+@app.get("/api/approach")
+async def get_approach():
+    """Get approach controller status."""
+    cb = stream_state.get_callback("get_approach_status")
+    if cb:
+        return cb()
+    return {"mode": "idle"}
+
+
 @app.get("/api/detections")
 async def api_recent_detections():
     """Return recent detection log entries."""

--- a/hydra_detect/web/static/css/operations.css
+++ b/hydra_detect/web/static/css/operations.css
@@ -433,6 +433,45 @@
 .panel-target-actions {
     display: flex;
     gap: var(--gap-xs);
+    align-items: center;
+}
+
+.abort-btn {
+    background: var(--danger, #B60205);
+    color: white;
+    font-size: 18px;
+    font-weight: 700;
+    padding: 12px 24px;
+    border: none;
+    border-radius: 8px;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    font-family: 'Barlow Condensed', sans-serif;
+    transition: filter var(--transition-fast), transform var(--transition-fast);
+    box-shadow: 0 0 8px rgba(197, 48, 48, 0.3);
+    flex-shrink: 0;
+    margin-left: auto;
+}
+.abort-btn:hover {
+    filter: brightness(1.3);
+}
+.abort-btn:active {
+    transform: scale(0.95);
+}
+
+.approach-badge {
+    display: inline-block;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: var(--font-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--ls-condensed);
+    padding: 2px 6px;
+    border-radius: var(--radius-sm);
+    background: #1e3a5f;
+    color: #93c5fd;
+    animation: pulse-glow 2s ease-in-out infinite;
 }
 
 /* ── Pipeline / System Stats ── */

--- a/hydra_detect/web/static/js/operations.js
+++ b/hydra_detect/web/static/js/operations.js
@@ -201,6 +201,7 @@ const HydraOperations = (() => {
         addClick('ctrl-btn-lock', () => lockTarget());
         addClick('ctrl-btn-strike', () => showStrikeConfirm());
         addClick('ctrl-btn-release', () => unlockTarget());
+        addClick('ctrl-btn-abort', () => abortApproach());
 
         // Pipeline buttons
         addClick('ctrl-btn-pause', () => togglePause());
@@ -325,6 +326,7 @@ const HydraOperations = (() => {
             if (labelEl) labelEl.textContent = '#' + t.track_id + ' ' + (t.label || '');
             if (modeEl) modeEl.textContent = (t.mode || 'track').toUpperCase();
             el.classList.toggle('strike', t.mode === 'strike');
+            el.classList.toggle('follow', t.mode === 'follow');
         } else {
             el.style.display = 'none';
         }
@@ -494,6 +496,17 @@ const HydraOperations = (() => {
                     });
                     actions.appendChild(lockBtn);
 
+                    const followBtn = document.createElement('button');
+                    followBtn.className = 'btn btn-sm track-btn';
+                    followBtn.textContent = 'Follow';
+                    followBtn.style.borderColor = '#1e3a5f';
+                    followBtn.style.color = '#93c5fd';
+                    followBtn.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        startFollow(t.track_id);
+                    });
+                    actions.appendChild(followBtn);
+
                     const strikeBtn = document.createElement('button');
                     strikeBtn.className = 'btn btn-sm btn-danger track-btn';
                     strikeBtn.textContent = 'Strike';
@@ -520,6 +533,9 @@ const HydraOperations = (() => {
                 if (target.mode === 'strike') {
                     lockEl.className = 'panel-lock-indicator strike-active';
                     lockEl.textContent = 'STRIKE: #' + target.track_id + ' ' + (target.label || '');
+                } else if (target.mode === 'follow') {
+                    lockEl.className = 'panel-lock-indicator tracking';
+                    lockEl.textContent = 'FOLLOWING: #' + target.track_id + ' ' + (target.label || '');
                 } else {
                     lockEl.className = 'panel-lock-indicator tracking';
                     lockEl.textContent = 'TRACKING: #' + target.track_id + ' ' + (target.label || '');
@@ -909,6 +925,20 @@ const HydraOperations = (() => {
         if (strikeBtn) strikeBtn.disabled = true;
         if (releaseBtn) releaseBtn.disabled = true;
         if (lockIndicator) lockIndicator.style.display = 'none';
+    }
+
+    async function startFollow(trackId) {
+        const resp = await HydraApp.apiPost('/api/follow/' + trackId, {});
+        if (resp && resp.status === 'following') {
+            HydraApp.showToast('Follow mode started', 'success');
+        }
+    }
+
+    async function abortApproach() {
+        const resp = await HydraApp.apiPost('/api/abort', {});
+        if (resp && resp.status === 'aborted') {
+            HydraApp.showToast('ABORT \u2014 all approach cancelled', 'info');
+        }
     }
 
     function showStrikeConfirm() {

--- a/hydra_detect/web/templates/operations.html
+++ b/hydra_detect/web/templates/operations.html
@@ -82,6 +82,7 @@
             </div>
             <div class="panel-target-actions">
                 <button class="btn" id="ctrl-btn-release" disabled>Release Lock</button>
+                <button class="btn abort-btn" id="ctrl-btn-abort">ABORT</button>
             </div>
         </div>
     </div>

--- a/tests/test_approach_controller.py
+++ b/tests/test_approach_controller.py
@@ -1,0 +1,345 @@
+"""Tests for the approach controller."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+from hydra_detect.approach import (
+    ApproachConfig,
+    ApproachController,
+    ApproachMode,
+)
+from hydra_detect.tracker import TrackedObject
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mavlink(*, mode="AUTO"):
+    """Build a mock MAVLinkIO with configurable state."""
+    mav = MagicMock()
+    mav.get_vehicle_mode.return_value = mode
+    mav.set_mode.return_value = True
+    mav.estimate_target_position.return_value = (34.05001, -118.25001)
+    mav.command_guided_to.return_value = True
+    mav.command_do_change_speed.return_value = True
+    mav.send_statustext.return_value = None
+    return mav
+
+
+def _make_track(
+    track_id: int = 1,
+    x1: float = 200.0,
+    y1: float = 150.0,
+    x2: float = 300.0,
+    y2: float = 250.0,
+    label: str = "person",
+    confidence: float = 0.9,
+) -> TrackedObject:
+    """Build a TrackedObject for testing."""
+    return TrackedObject(
+        track_id=track_id,
+        x1=x1, y1=y1, x2=x2, y2=y2,
+        confidence=confidence,
+        class_id=0,
+        label=label,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestStartFollow:
+    """Test start_follow sets mode and track."""
+
+    def test_start_follow_sets_mode(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+
+        result = ctrl.start_follow(42)
+
+        assert result is True
+        assert ctrl.mode == ApproachMode.FOLLOW
+        assert ctrl.active is True
+        assert ctrl._target_track_id == 42
+
+    def test_start_follow_saves_vehicle_mode(self):
+        mav = _make_mavlink(mode="AUTO")
+        ctrl = ApproachController(mav)
+
+        ctrl.start_follow(1)
+
+        assert ctrl._pre_approach_mode == "AUTO"
+        mav.get_vehicle_mode.assert_called_once()
+
+    def test_start_follow_resets_waypoint_counter(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+        ctrl._waypoints_sent = 99
+
+        ctrl.start_follow(1)
+
+        assert ctrl._waypoints_sent == 0
+
+    def test_start_follow_records_active_since(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+
+        before = time.monotonic()
+        ctrl.start_follow(1)
+
+        assert ctrl._active_since is not None
+        assert ctrl._active_since >= before
+
+
+class TestCannotStartWhileActive:
+    """Test can't start follow while already active."""
+
+    def test_rejects_double_start(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+
+        assert ctrl.start_follow(1) is True
+        assert ctrl.start_follow(2) is False
+        assert ctrl._target_track_id == 1
+
+
+class TestAbort:
+    """Test abort returns to IDLE and sends LOITER."""
+
+    def test_abort_returns_to_idle(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+        ctrl.start_follow(1)
+
+        ctrl.abort()
+
+        assert ctrl.mode == ApproachMode.IDLE
+        assert ctrl.active is False
+        assert ctrl._target_track_id is None
+
+    def test_abort_sends_loiter(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+        ctrl.start_follow(1)
+
+        ctrl.abort()
+
+        mav.set_mode.assert_called_with("LOITER")
+
+    def test_abort_noop_when_idle(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+
+        ctrl.abort()
+
+        mav.set_mode.assert_not_called()
+
+
+class TestUpdateWithTrack:
+    """Test update with track sends waypoint."""
+
+    def test_sends_waypoint_at_update_hz(self):
+        mav = _make_mavlink()
+        cfg = ApproachConfig(update_hz=100.0)  # high Hz so first call triggers
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        track = _make_track(track_id=1, x1=200, y1=150, x2=300, y2=250)
+        ctrl.update(track, 640, 480)
+
+        mav.command_guided_to.assert_called_once()
+        assert ctrl._waypoints_sent == 1
+
+    def test_sends_speed_command(self):
+        mav = _make_mavlink()
+        cfg = ApproachConfig(update_hz=100.0)
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        track = _make_track(track_id=1, x1=200, y1=150, x2=300, y2=250)
+        ctrl.update(track, 640, 480)
+
+        mav.command_do_change_speed.assert_called_once()
+
+
+class TestUpdateWithoutTrack:
+    """Test update without track holds position."""
+
+    def test_no_waypoint_when_track_lost(self):
+        mav = _make_mavlink()
+        cfg = ApproachConfig(update_hz=100.0)
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        ctrl.update(None, 640, 480)
+
+        mav.command_guided_to.assert_not_called()
+        mav.command_do_change_speed.assert_not_called()
+        assert ctrl._waypoints_sent == 0
+
+
+class TestSpeedScaling:
+    """Test speed scales with bbox area."""
+
+    def test_far_target_gets_max_speed(self):
+        mav = _make_mavlink()
+        cfg = ApproachConfig(
+            update_hz=100.0,
+            follow_speed_max=5.0,
+            speed_scale_far=1.0,
+            speed_scale_near=0.3,
+            near_threshold_px=0.4,
+        )
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        # Small bbox = far target (~1% of frame)
+        track = _make_track(track_id=1, x1=310, y1=230, x2=330, y2=250)
+        ctrl.update(track, 640, 480)
+
+        speed_arg = mav.command_do_change_speed.call_args[0][0]
+        assert speed_arg > 4.0  # close to max speed
+
+    def test_near_target_gets_slow_speed(self):
+        mav = _make_mavlink()
+        cfg = ApproachConfig(
+            update_hz=100.0,
+            follow_speed_max=5.0,
+            speed_scale_far=1.0,
+            speed_scale_near=0.3,
+            near_threshold_px=0.1,
+        )
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        # bbox area ~30% of frame (above near_threshold but below 0.5 hold)
+        # 400*360 / (640*480) = 144000/307200 = 0.468
+        track = _make_track(track_id=1, x1=120, y1=60, x2=520, y2=420)
+        ctrl.update(track, 640, 480)
+
+        # This target is > near_threshold_px, so speed should be near scale
+        speed_arg = mav.command_do_change_speed.call_args[0][0]
+        assert speed_arg <= 5.0 * 0.3 + 0.01
+
+
+class TestVeryCloseTarget:
+    """Test very close target (large bbox) holds position."""
+
+    def test_holds_when_bbox_over_half_frame(self):
+        mav = _make_mavlink()
+        cfg = ApproachConfig(update_hz=100.0)
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        # bbox > 50% of frame area
+        track = _make_track(track_id=1, x1=0, y1=0, x2=600, y2=430)
+        ctrl.update(track, 640, 480)
+
+        mav.command_guided_to.assert_not_called()
+        mav.command_do_change_speed.assert_not_called()
+
+
+class TestWaypointCounter:
+    """Test waypoint counter increments."""
+
+    def test_counter_increments_each_update(self):
+        mav = _make_mavlink()
+        cfg = ApproachConfig(update_hz=100.0)
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        track = _make_track(track_id=1, x1=200, y1=150, x2=300, y2=250)
+
+        ctrl.update(track, 640, 480)
+        assert ctrl._waypoints_sent == 1
+
+        ctrl._last_update = 0.0  # reset rate limiter
+        ctrl.update(track, 640, 480)
+        assert ctrl._waypoints_sent == 2
+
+
+class TestGetStatus:
+    """Test get_status returns correct dict."""
+
+    def test_idle_status(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+
+        status = ctrl.get_status()
+
+        assert status["mode"] == "idle"
+        assert status["active"] is False
+        assert status["target_track_id"] is None
+        assert status["method"] == "gps_waypoint"
+        assert status["waypoints_sent"] == 0
+
+    def test_follow_status(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+        ctrl.start_follow(42)
+
+        status = ctrl.get_status()
+
+        assert status["mode"] == "follow"
+        assert status["active"] is True
+        assert status["target_track_id"] == 42
+        assert status["active_since"] is not None
+
+    def test_status_after_waypoints(self):
+        mav = _make_mavlink()
+        cfg = ApproachConfig(update_hz=100.0)
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        track = _make_track(track_id=1, x1=200, y1=150, x2=300, y2=250)
+        ctrl.update(track, 640, 480)
+
+        status = ctrl.get_status()
+        assert status["waypoints_sent"] == 1
+        assert status["bbox_area"] > 0
+
+
+class TestUpdateRateLimiting:
+    """Test the update rate limiter."""
+
+    def test_skips_when_too_soon(self):
+        mav = _make_mavlink()
+        cfg = ApproachConfig(update_hz=2.0)  # 0.5s interval
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        track = _make_track(track_id=1, x1=200, y1=150, x2=300, y2=250)
+        ctrl.update(track, 640, 480)  # First update
+        ctrl.update(track, 640, 480)  # Too soon, should skip
+
+        assert mav.command_guided_to.call_count == 1
+
+    def test_idle_skips_all(self):
+        mav = _make_mavlink()
+        ctrl = ApproachController(mav)
+
+        track = _make_track(track_id=1)
+        ctrl.update(track, 640, 480)
+
+        mav.command_guided_to.assert_not_called()
+
+
+class TestEstimateFailure:
+    """Test behaviour when GPS position estimate fails."""
+
+    def test_no_waypoint_when_estimate_returns_none(self):
+        mav = _make_mavlink()
+        mav.estimate_target_position.return_value = None
+        cfg = ApproachConfig(update_hz=100.0)
+        ctrl = ApproachController(mav, cfg)
+        ctrl.start_follow(1)
+
+        track = _make_track(track_id=1, x1=200, y1=150, x2=300, y2=250)
+        ctrl.update(track, 640, 480)
+
+        mav.command_guided_to.assert_not_called()
+        assert ctrl._waypoints_sent == 0


### PR DESCRIPTION
## Summary
The Week 4 "wow moment" — student locks a target, hits Follow, vehicle tracks and follows continuously.

- **Approach controller** — Unified architecture for Follow/Drop/Strike modes with pluggable approach methods (#65)
- **Follow mode** — Continuous GPS waypoint updates at 2 Hz, speed scales with distance, holds when close
- **Dashboard UI** — Follow button per track, big red ABORT button always visible
- **ABORT** — One-tap stops everything: approach, autonomous, servos, with STATUSTEXT alert
- **Speed control** — MAV_CMD_DO_CHANGE_SPEED scales from follow_speed_max down to 30% when close
- **21 new tests** covering approach lifecycle, speed scaling, rate limiting

## Issues
Closes #65

## Test plan
- [ ] 611 tests passing (21 new)
- [ ] SITL: lock a target, hit Follow — verify vehicle moves toward target
- [ ] Verify speed decreases as vehicle approaches (bbox grows)
- [ ] Verify ABORT stops vehicle and sends LOITER command
- [ ] Verify Follow button only appears for locked tracks
- [ ] Verify target loss holds position (no wild waypoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)