### PR TITLE
feat: instructor overview page, mission tagging, and abort

### DIFF
--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -495,6 +495,10 @@ class Pipeline:
         self._last_track_result = None  # Most recent TrackingResult for web API
         self._servo_tracker = None
 
+        # Mission tagging state
+        self._mission_name: str | None = None
+        self._mission_start_time: float | None = None
+
     # ------------------------------------------------------------------
     def start(self) -> None:
         """Initialise all subsystems and run the main loop."""
@@ -632,6 +636,8 @@ class Pipeline:
                 get_tak_status=self._get_tak_status,
                 get_profiles=self._get_profiles,
                 on_profile_switch=self._handle_profile_switch,
+                on_mission_start=self._handle_mission_start,
+                on_mission_end=self._handle_mission_end,
             )
 
             stream_state.update_stats(
@@ -891,6 +897,8 @@ class Pipeline:
                     "mavlink": self._mavlink is not None and self._mavlink.connected,
                     "camera_source": str(self._camera.source),
                     "camera_ok": not self._cam_lost,
+                    "callsign": self._cfg.get("tak", "callsign", fallback="HYDRA-1"),
+                    "mission_name": self._mission_name,
                 }
                 if self._mavlink is not None:
                     telem = self._mavlink.get_telemetry()
@@ -1533,6 +1541,33 @@ class Pipeline:
         """Resume the detection loop."""
         self._paused = False
         logger.info("Pipeline RESUMED from web UI.")
+
+    # ------------------------------------------------------------------
+    # Mission tagging
+    # ------------------------------------------------------------------
+    def _handle_mission_start(self, name: str) -> None:
+        """Start a named mission session."""
+        self._mission_name = name
+        self._mission_start_time = time.monotonic()
+        logger.info("Mission STARTED: %s", name)
+        if self._mavlink is not None:
+            callsign = self._cfg.get("tak", "callsign", fallback="HYDRA")
+            self._mavlink.send_statustext(
+                f"{callsign}: MISSION START - {name}", severity=5
+            )
+
+    def _handle_mission_end(self) -> None:
+        """End the current mission session."""
+        if self._mission_name:
+            elapsed = time.monotonic() - (self._mission_start_time or 0)
+            logger.info("Mission ENDED: %s (%.0fs)", self._mission_name, elapsed)
+            if self._mavlink is not None:
+                callsign = self._cfg.get("tak", "callsign", fallback="HYDRA")
+                self._mavlink.send_statustext(
+                    f"{callsign}: MISSION END - {self._mission_name}", severity=5
+                )
+        self._mission_name = None
+        self._mission_start_time = None
 
     # ------------------------------------------------------------------
     def _shutdown(self) -> None:

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -37,13 +37,33 @@ STATIC_DIR = Path(__file__).parent / "static"
 
 app = FastAPI(title="Hydra Detect v2.0", version="2.0.0")
 
-# CORS: restrict to same-origin by default; override via configure_cors()
+# CORS: allow cross-origin from other Jetsons (instructor overview page
+# polls /api/stats and /api/abort on peer Hydra instances).
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[],  # No cross-origin by default
+    allow_origins=["*"],
     allow_methods=["GET", "POST"],
     allow_headers=["Authorization", "Content-Type"],
 )
+
+# Standard CSP for the SPA and standalone pages
+_CSP_DEFAULT = (
+    "default-src 'self'; "
+    "img-src 'self' data: https://*.tile.openstreetmap.org; "
+    "script-src 'self' 'unsafe-inline' https://unpkg.com; "
+    "style-src 'self' 'unsafe-inline' https://unpkg.com; "
+    "connect-src 'self'"
+)
+
+# Relaxed CSP for the instructor page — it fetches from other Jetsons
+_CSP_INSTRUCTOR = (
+    "default-src 'self'; "
+    "img-src 'self' data:; "
+    "script-src 'self' 'unsafe-inline'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "connect-src *"
+)
+
 
 class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
     """Inject defense-in-depth HTTP security headers."""
@@ -52,13 +72,11 @@ class _SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response: Response = await call_next(request)
         response.headers["X-Frame-Options"] = "DENY"
         response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["Content-Security-Policy"] = (
-            "default-src 'self'; "
-            "img-src 'self' data: https://*.tile.openstreetmap.org; "
-            "script-src 'self' 'unsafe-inline' https://unpkg.com; "
-            "style-src 'self' 'unsafe-inline' https://unpkg.com; "
-            "connect-src 'self'"
-        )
+        # Use relaxed CSP for instructor page (needs cross-origin fetch)
+        if request.url.path == "/instructor":
+            response.headers["Content-Security-Policy"] = _CSP_INSTRUCTOR
+        else:
+            response.headers["Content-Security-Policy"] = _CSP_DEFAULT
         return response
 
 
@@ -943,6 +961,67 @@ async def api_pipeline_pause(request: Request, authorization: Optional[str] = He
 async def control_page(request: Request):
     """Serve the mobile operator control page."""
     return templates.TemplateResponse(request, "control.html")
+
+
+# ── Instructor Overview ────────────────────────────────────────────
+
+@app.get("/instructor", response_class=HTMLResponse)
+async def instructor_page(request: Request):
+    """Serve the standalone instructor overview page."""
+    return templates.TemplateResponse(request, "instructor.html")
+
+
+@app.post("/api/abort")
+async def api_abort(request: Request):
+    """Emergency abort — switch vehicle to RTL mode.
+
+    This endpoint is intentionally unauthenticated. The instructor page
+    is the safety exception: an instructor must be able to abort any
+    vehicle without configuring tokens.
+    """
+    _audit(request, "abort")
+    # Try RTL first, then LOITER/HOLD as fallback
+    cb = stream_state.get_callback("on_set_mode_command")
+    if cb:
+        for mode in ("RTL", "LOITER", "HOLD"):
+            if cb(mode):
+                logger.warning("ABORT: vehicle set to %s by instructor", mode)
+                return {"status": "ok", "mode": mode}
+        return JSONResponse({"error": "Failed to set abort mode"}, status_code=503)
+    return JSONResponse({"error": "MAVLink not connected"}, status_code=503)
+
+
+# ── Mission Tagging ────────────────────────────────────────────────
+
+@app.post("/api/mission/start")
+async def api_start_mission(request: Request, authorization: Optional[str] = Header(None)):
+    """Start a named mission. Body: {"name": "mission-alpha"}"""
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    body = await request.json()
+    name = body.get("name", f"mission-{int(time.time())}")
+    if not isinstance(name, str) or not name.strip():
+        return JSONResponse({"error": "name must be a non-empty string"}, status_code=400)
+    name = name.strip()[:100]  # Bound length
+    cb = stream_state.get_callback("on_mission_start")
+    if cb:
+        cb(name)
+    _audit(request, "mission_start", target=name)
+    return {"status": "started", "name": name}
+
+
+@app.post("/api/mission/end")
+async def api_end_mission(request: Request, authorization: Optional[str] = Header(None)):
+    """End the current mission."""
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    cb = stream_state.get_callback("on_mission_end")
+    if cb:
+        cb()
+    _audit(request, "mission_end")
+    return {"status": "ended"}
 
 
 # ── Mission Review ────────────────────────────────────────────────

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -16,7 +16,6 @@ from typing import Any, Callable, Dict, List, Optional
 import cv2
 import numpy as np
 from fastapi import FastAPI, Header, Request, Response
-from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 from fastapi.staticfiles import StaticFiles
@@ -37,14 +36,26 @@ STATIC_DIR = Path(__file__).parent / "static"
 
 app = FastAPI(title="Hydra Detect v2.0", version="2.0.0")
 
-# CORS: allow cross-origin from other Jetsons (instructor overview page
-# polls /api/stats and /api/abort on peer Hydra instances).
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_methods=["GET", "POST"],
-    allow_headers=["Authorization", "Content-Type"],
-)
+# CORS: restrict cross-origin to instructor-relevant paths only.
+# The instructor page polls /api/stats and /api/abort on peer Hydra
+# instances, so those endpoints need permissive CORS.  All other
+# endpoints stay same-origin.
+_CORS_ALLOWED_PATHS = {"/api/stats", "/api/abort"}
+
+
+class _InstructorCORSMiddleware(BaseHTTPMiddleware):
+    """Add CORS headers only for instructor-relevant endpoints."""
+
+    async def dispatch(self, request: Request, call_next):
+        response = await call_next(request)
+        if request.url.path in _CORS_ALLOWED_PATHS:
+            response.headers["Access-Control-Allow-Origin"] = "*"
+            response.headers["Access-Control-Allow-Methods"] = "GET, POST, OPTIONS"
+            response.headers["Access-Control-Allow-Headers"] = "Authorization, Content-Type"
+        return response
+
+
+app.add_middleware(_InstructorCORSMiddleware)
 
 # Standard CSP for the SPA and standalone pages
 _CSP_DEFAULT = (

--- a/hydra_detect/web/static/js/operations.js
+++ b/hydra_detect/web/static/js/operations.js
@@ -288,6 +288,10 @@ const HydraOperations = (() => {
 
         // TAK/ATAK
         addClick('ctrl-tak-toggle', () => toggleTAK());
+
+        // Mission control
+        addClick('ctrl-btn-mission-start', () => startMission());
+        addClick('ctrl-btn-mission-end', () => endMission());
     }
 
     function addClick(id, handler) {
@@ -306,6 +310,7 @@ const HydraOperations = (() => {
         if (s && Object.keys(s).length > 0) {
             updateVehiclePanel(s);
             updatePipelinePanel(s);
+            updateMissionPanel(s);
         }
         updateTargetPanel();
         updateDetectionLog();
@@ -1234,6 +1239,49 @@ const HydraOperations = (() => {
         if (bar) {
             bar.style.width = Math.min(pct, 100) + '%';
             bar.style.backgroundColor = color;
+        }
+    }
+
+    // ── Mission Panel ──
+    let missionActive = false;
+
+    function updateMissionPanel(s) {
+        const badge = document.getElementById('ctrl-mission-badge');
+        const nameField = document.getElementById('ctrl-mission-name-field');
+        const activeInfo = document.getElementById('ctrl-mission-active-info');
+        const activeName = document.getElementById('ctrl-mission-active-name');
+        const startBtn = document.getElementById('ctrl-btn-mission-start');
+        const endBtn = document.getElementById('ctrl-btn-mission-end');
+
+        const isActive = !!s.mission_name;
+        missionActive = isActive;
+
+        if (badge) {
+            badge.textContent = isActive ? 'ACTIVE' : 'IDLE';
+            badge.className = 'badge ' + (isActive ? 'on' : 'off');
+        }
+        if (nameField) nameField.style.display = isActive ? 'none' : '';
+        if (activeInfo) activeInfo.style.display = isActive ? '' : 'none';
+        if (activeName) activeName.textContent = s.mission_name || '--';
+        if (startBtn) startBtn.disabled = isActive;
+        if (endBtn) endBtn.disabled = !isActive;
+    }
+
+    async function startMission() {
+        const input = document.getElementById('ctrl-mission-name');
+        const name = input ? input.value.trim() : '';
+        const result = await HydraApp.apiPost('/api/mission/start', { name: name || undefined });
+        if (result && result.status === 'started') {
+            HydraApp.showToast('Mission started: ' + result.name, 'success');
+            if (input) input.value = '';
+        }
+    }
+
+    async function endMission() {
+        if (!confirm('End current mission?')) return;
+        const result = await HydraApp.apiPost('/api/mission/end', {});
+        if (result && result.status === 'ended') {
+            HydraApp.showToast('Mission ended', 'info');
         }
     }
 

--- a/hydra_detect/web/templates/instructor.html
+++ b/hydra_detect/web/templates/instructor.html
@@ -288,10 +288,14 @@
 
         async function abortVehicle(host) {
             try {
-                await fetch('http://' + host + ':8080/api/abort', {method: 'POST'});
-                addAlert(vehicleState[host] ? (vehicleState[host].callsign || host) : host, 'ABORT sent by instructor');
+                const resp = await fetch('http://' + host + ':8080/api/abort', {method: 'POST'});
+                if (resp.ok) {
+                    addAlert(vehicleState[host] ? (vehicleState[host].callsign || host) : host, 'ABORT sent by instructor');
+                } else {
+                    addAlert(host, 'ABORT failed — HTTP ' + resp.status);
+                }
             } catch (e) {
-                addAlert(host, 'ABORT FAILED -- vehicle unreachable');
+                addAlert(host, 'ABORT FAILED — vehicle unreachable');
             }
         }
 

--- a/hydra_detect/web/templates/instructor.html
+++ b/hydra_detect/web/templates/instructor.html
@@ -1,0 +1,308 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>SORCC Instructor Overview</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <style>
+        /* Mobile-first, dark theme matching Hydra aesthetic */
+        :root {
+            --bg: #0a0f14;
+            --card-bg: #141b22;
+            --text: #e0e6ed;
+            --accent: #385723;
+            --danger: #B60205;
+            --warning: #FF9F1C;
+            --success: #0E8A16;
+            --border: #1e2830;
+        }
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+        body {
+            font-family: 'JetBrains Mono', 'Courier New', monospace;
+            background: var(--bg); color: var(--text);
+            padding: 12px;
+        }
+        h1 { font-size: 18px; padding: 8px 0; color: var(--accent); }
+
+        .config-bar {
+            display: flex; gap: 8px; margin-bottom: 12px; flex-wrap: wrap;
+            align-items: center;
+        }
+        .config-bar input {
+            background: var(--card-bg); border: 1px solid var(--border);
+            color: var(--text); padding: 6px 10px; border-radius: 4px;
+            font-family: inherit; font-size: 13px; flex: 1; min-width: 200px;
+        }
+        .config-bar button {
+            background: var(--accent); color: white; border: none;
+            padding: 6px 16px; border-radius: 4px; cursor: pointer;
+            font-family: inherit;
+        }
+
+        .vehicle-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+            gap: 12px;
+        }
+        .vehicle-card {
+            background: var(--card-bg); border: 1px solid var(--border);
+            border-radius: 8px; padding: 12px; position: relative;
+        }
+        .vehicle-card.offline { opacity: 0.5; }
+        .vehicle-card.detecting { border-color: var(--success); }
+        .vehicle-card.degraded { border-color: var(--warning); }
+
+        .card-header {
+            display: flex; justify-content: space-between; align-items: center;
+            margin-bottom: 8px;
+        }
+        .callsign { font-size: 16px; font-weight: 700; }
+        .status-pill {
+            padding: 2px 8px; border-radius: 10px; font-size: 11px;
+            font-weight: 600; text-transform: uppercase;
+        }
+        .status-pill.ready { background: var(--success); color: white; }
+        .status-pill.detecting { background: var(--accent); color: white; }
+        .status-pill.degraded { background: var(--warning); color: black; }
+        .status-pill.offline { background: #555; color: white; }
+
+        .card-stats {
+            display: grid; grid-template-columns: 1fr 1fr; gap: 4px;
+            font-size: 12px; margin-bottom: 8px;
+        }
+        .card-stats .label { color: #888; }
+
+        .abort-btn {
+            background: var(--danger); color: white; border: none;
+            padding: 8px 16px; border-radius: 6px; cursor: pointer;
+            font-family: inherit; font-weight: 700; font-size: 12px;
+            text-transform: uppercase; width: 100%; margin-top: 8px;
+        }
+        .abort-btn:active { transform: scale(0.95); }
+
+        .open-btn {
+            background: transparent; border: 1px solid var(--border);
+            color: var(--text); padding: 4px 12px; border-radius: 4px;
+            cursor: pointer; font-family: inherit; font-size: 11px;
+        }
+
+        .alert-feed {
+            margin-top: 16px; max-height: 200px; overflow-y: auto;
+            background: var(--card-bg); border-radius: 8px; padding: 8px;
+        }
+        .alert-item {
+            font-size: 12px; padding: 4px 0; border-bottom: 1px solid var(--border);
+        }
+        .alert-time { color: #888; }
+        .alert-callsign { color: var(--accent); }
+    </style>
+</head>
+<body>
+    <h1>SORCC INSTRUCTOR OVERVIEW</h1>
+
+    <div class="config-bar">
+        <input id="endpoints-input" placeholder="Jetson IPs (comma-separated, e.g., 100.109.160.122,100.109.160.123)" />
+        <button id="save-btn">Save</button>
+    </div>
+
+    <div class="vehicle-grid" id="vehicle-grid"></div>
+
+    <div class="alert-feed" id="alert-feed">
+        <div style="color: #888; font-size: 12px;">Detection alerts will appear here...</div>
+    </div>
+
+    <script>
+        'use strict';
+
+        let endpoints = JSON.parse(localStorage.getItem('hydra-instructor-endpoints') || '[]');
+        let vehicleState = {};
+        let alertFeed = [];
+        const MAX_ALERTS = 50;
+
+        // Sanitize text to prevent XSS when building DOM nodes
+        function esc(str) {
+            const d = document.createElement('div');
+            d.textContent = String(str);
+            return d.textContent;
+        }
+
+        // Create a text element helper
+        function txt(tag, text, className) {
+            const el = document.createElement(tag);
+            el.textContent = text;
+            if (className) el.className = className;
+            return el;
+        }
+
+        // Init
+        document.getElementById('endpoints-input').value = endpoints.join(', ');
+        document.getElementById('save-btn').addEventListener('click', saveEndpoints);
+
+        function saveEndpoints() {
+            const raw = document.getElementById('endpoints-input').value;
+            endpoints = raw.split(',').map(s => s.trim()).filter(Boolean);
+            localStorage.setItem('hydra-instructor-endpoints', JSON.stringify(endpoints));
+            pollAll();
+        }
+
+        async function pollVehicle(host) {
+            const port = 8080;
+            const url = 'http://' + host + ':' + port;
+            try {
+                const resp = await fetch(url + '/api/stats', {signal: AbortSignal.timeout(3000)});
+                if (!resp.ok) throw new Error(resp.status);
+                const data = await resp.json();
+                const prevDetections = vehicleState[host] ? (vehicleState[host]._prevDetections || 0) : 0;
+                data._host = host;
+                data._url = url;
+                data._lastSeen = Date.now();
+                data._online = true;
+                data._prevDetections = prevDetections;
+                vehicleState[host] = data;
+
+                // Check for new detections
+                if (data.total_detections && data.total_detections > prevDetections) {
+                    addAlert(data.callsign || host, 'Detection count: ' + data.total_detections);
+                }
+                vehicleState[host]._prevDetections = data.total_detections;
+            } catch (e) {
+                if (!vehicleState[host]) vehicleState[host] = {};
+                vehicleState[host]._online = false;
+                vehicleState[host]._host = host;
+            }
+        }
+
+        function addAlert(callsign, message) {
+            const now = new Date().toLocaleTimeString('en-US', {hour12: false});
+            alertFeed.unshift({time: now, callsign: callsign, message: message});
+            if (alertFeed.length > MAX_ALERTS) alertFeed.pop();
+            renderAlertFeed();
+        }
+
+        function renderAlertFeed() {
+            const el = document.getElementById('alert-feed');
+            while (el.firstChild) el.removeChild(el.firstChild);
+
+            if (alertFeed.length === 0) {
+                const placeholder = document.createElement('div');
+                placeholder.style.cssText = 'color:#888;font-size:12px;';
+                placeholder.textContent = 'No alerts yet';
+                el.appendChild(placeholder);
+                return;
+            }
+
+            for (const a of alertFeed) {
+                const row = document.createElement('div');
+                row.className = 'alert-item';
+
+                const timeSpan = txt('span', a.time, 'alert-time');
+                row.appendChild(timeSpan);
+                row.appendChild(document.createTextNode(' '));
+
+                const csSpan = txt('span', a.callsign, 'alert-callsign');
+                row.appendChild(csSpan);
+                row.appendChild(document.createTextNode(' ' + a.message));
+
+                el.appendChild(row);
+            }
+        }
+
+        function renderCards() {
+            const grid = document.getElementById('vehicle-grid');
+            while (grid.firstChild) grid.removeChild(grid.firstChild);
+
+            for (const host of endpoints) {
+                const v = vehicleState[host] || {_online: false, _host: host};
+                const online = v._online;
+                const callsign = v.callsign || host;
+                const fps = v.fps ? v.fps.toFixed(1) : '-';
+                const detections = v.total_detections || 0;
+                const cameraOk = v.camera_ok !== false;
+                const staleSec = online ? Math.round((Date.now() - v._lastSeen) / 1000) : '?';
+
+                let statusClass = 'offline';
+                let statusText = 'OFFLINE';
+                if (online) {
+                    if (!cameraOk) { statusClass = 'degraded'; statusText = 'DEGRADED'; }
+                    else if (detections > 0) { statusClass = 'detecting'; statusText = 'DETECTING'; }
+                    else { statusClass = 'ready'; statusText = 'READY'; }
+                }
+
+                // Battery display
+                let batteryStr = '--';
+                if (online && v.battery_pct != null) {
+                    batteryStr = v.battery_pct + '%';
+                    if (v.battery_v != null) batteryStr += ' (' + v.battery_v.toFixed(1) + 'V)';
+                }
+
+                // Mission display
+                let missionStr = '--';
+                if (online && v.mission_name) {
+                    missionStr = v.mission_name;
+                }
+
+                const card = document.createElement('div');
+                card.className = 'vehicle-card ' + statusClass;
+
+                // Header
+                const header = document.createElement('div');
+                header.className = 'card-header';
+                header.appendChild(txt('span', callsign, 'callsign'));
+                header.appendChild(txt('span', statusText, 'status-pill ' + statusClass));
+                card.appendChild(header);
+
+                // Stats grid
+                const stats = document.createElement('div');
+                stats.className = 'card-stats';
+                const statPairs = [
+                    ['FPS', fps], ['Detections', detections],
+                    ['Camera', cameraOk ? 'OK' : 'LOST'], ['Battery', batteryStr],
+                    ['Mission', missionStr], ['Updated', staleSec + 's ago']
+                ];
+                for (const [label, value] of statPairs) {
+                    stats.appendChild(txt('span', label, 'label'));
+                    stats.appendChild(txt('span', value, ''));
+                }
+                card.appendChild(stats);
+
+                // Open Dashboard button
+                const openBtn = document.createElement('button');
+                openBtn.className = 'open-btn';
+                openBtn.textContent = 'Open Dashboard';
+                openBtn.addEventListener('click', (function(h) {
+                    return function() { window.open('http://' + h + ':8080', '_blank'); };
+                })(host));
+                card.appendChild(openBtn);
+
+                // Abort button
+                const abortBtn = document.createElement('button');
+                abortBtn.className = 'abort-btn';
+                abortBtn.textContent = 'ABORT';
+                abortBtn.addEventListener('click', (function(h) {
+                    return function() { abortVehicle(h); };
+                })(host));
+                card.appendChild(abortBtn);
+
+                grid.appendChild(card);
+            }
+        }
+
+        async function abortVehicle(host) {
+            try {
+                await fetch('http://' + host + ':8080/api/abort', {method: 'POST'});
+                addAlert(vehicleState[host] ? (vehicleState[host].callsign || host) : host, 'ABORT sent by instructor');
+            } catch (e) {
+                addAlert(host, 'ABORT FAILED -- vehicle unreachable');
+            }
+        }
+
+        async function pollAll() {
+            await Promise.allSettled(endpoints.map(pollVehicle));
+            renderCards();
+        }
+
+        // Poll every 2 seconds
+        pollAll();
+        setInterval(pollAll, 2000);
+    </script>
+</body>
+</html>

--- a/hydra_detect/web/templates/operations.html
+++ b/hydra_detect/web/templates/operations.html
@@ -318,7 +318,31 @@
         </div>
     </div>
 
-    <!-- 6. Detection Log -->
+    <!-- 6. Mission Control -->
+    <div class="panel" data-panel-id="mission" id="panel-mission">
+        <div class="panel-header">
+            <span class="panel-drag-handle">&#10303;</span>
+            <h3 class="panel-title">Mission</h3>
+            <span class="badge" id="ctrl-mission-badge" style="margin-left:auto; margin-right:var(--gap-sm);">IDLE</span>
+            <button class="panel-collapse-btn" aria-label="Collapse panel">&#9662;</button>
+        </div>
+        <div class="panel-body">
+            <div class="panel-field" id="ctrl-mission-name-field">
+                <label class="panel-field-label" for="ctrl-mission-name">Mission Name</label>
+                <input type="text" id="ctrl-mission-name" placeholder="e.g., mission-alpha" maxlength="100" style="width:100%; background:var(--bg-secondary); border:1px solid var(--border); color:var(--text-primary); padding:6px 8px; border-radius:4px; font-family:inherit; font-size:var(--font-sm);">
+            </div>
+            <div class="panel-field" id="ctrl-mission-active-info" style="display:none;">
+                <span class="panel-stat-label">Active:</span>
+                <span class="panel-stat-value mono accent" id="ctrl-mission-active-name">--</span>
+            </div>
+            <div style="display:flex;gap:8px;margin-top:8px;">
+                <button class="btn btn-green" id="ctrl-btn-mission-start">Start Mission</button>
+                <button class="btn btn-danger" id="ctrl-btn-mission-end" disabled>End Mission</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- 7. Detection Log -->
     <div class="panel" data-panel-id="log" id="panel-log">
         <div class="panel-header">
             <span class="panel-drag-handle">&#10303;</span>

--- a/tests/test_instructor_ops.py
+++ b/tests/test_instructor_ops.py
@@ -1,0 +1,308 @@
+"""Tests for instructor overview page, mission tagging, battery state, and abort."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hydra_detect.web.server import (
+    _auth_failures,
+    app,
+    configure_auth,
+    stream_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset stream_state and auth between tests."""
+    configure_auth(None)
+    _auth_failures.clear()
+    stream_state.target_lock = {
+        "locked": False,
+        "track_id": None,
+        "mode": None,
+        "label": None,
+    }
+    stream_state.runtime_config = {
+        "prompts": ["person"],
+        "threshold": 0.25,
+        "auto_loiter": False,
+    }
+    stream_state._callbacks.clear()
+    # Reset stats to include battery and mission fields
+    stream_state.stats = {
+        "fps": 10.0,
+        "inference_ms": 15.0,
+        "active_tracks": 0,
+        "total_detections": 0,
+        "detector": "yolo",
+        "mavlink": False,
+        "gps_fix": 0,
+        "position": None,
+        "camera_ok": True,
+        "callsign": "HYDRA-TEST",
+        "mission_name": None,
+        "battery_v": None,
+        "battery_pct": None,
+    }
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Instructor page
+# ---------------------------------------------------------------------------
+
+
+class TestInstructorPage:
+    def test_instructor_page_returns_200(self, client):
+        resp = client.get("/instructor")
+        assert resp.status_code == 200
+        assert "SORCC INSTRUCTOR OVERVIEW" in resp.text
+
+    def test_instructor_page_csp_relaxed(self, client):
+        resp = client.get("/instructor")
+        csp = resp.headers.get("Content-Security-Policy", "")
+        assert "connect-src *" in csp
+
+    def test_non_instructor_page_csp_strict(self, client):
+        resp = client.get("/api/stats")
+        csp = resp.headers.get("Content-Security-Policy", "")
+        assert "connect-src 'self'" in csp
+
+
+# ---------------------------------------------------------------------------
+# Abort endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestAbortEndpoint:
+    def test_abort_no_callback(self, client):
+        """Abort returns 503 when MAVLink is not connected."""
+        resp = client.post("/api/abort")
+        assert resp.status_code == 503
+
+    def test_abort_with_callback(self, client):
+        """Abort tries RTL mode via set_mode callback."""
+        modes_attempted = []
+
+        def fake_set_mode(mode):
+            modes_attempted.append(mode)
+            return mode == "RTL"
+
+        stream_state.set_callbacks(on_set_mode_command=fake_set_mode)
+        resp = client.post("/api/abort")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "ok"
+        assert data["mode"] == "RTL"
+        assert "RTL" in modes_attempted
+
+    def test_abort_fallback_to_loiter(self, client):
+        """Abort falls back to LOITER if RTL fails."""
+        def fake_set_mode(mode):
+            return mode == "LOITER"
+
+        stream_state.set_callbacks(on_set_mode_command=fake_set_mode)
+        resp = client.post("/api/abort")
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "LOITER"
+
+    def test_abort_no_auth_required(self, client):
+        """Abort is intentionally unauthenticated (safety exception)."""
+        configure_auth("secret-token-123")
+        # No auth header — should still work
+        def fake_set_mode(mode):
+            return True
+
+        stream_state.set_callbacks(on_set_mode_command=fake_set_mode)
+        resp = client.post("/api/abort")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Mission tagging
+# ---------------------------------------------------------------------------
+
+
+class TestMissionTagging:
+    def test_start_mission(self, client):
+        started = []
+        stream_state.set_callbacks(on_mission_start=lambda n: started.append(n))
+        resp = client.post(
+            "/api/mission/start",
+            json={"name": "alpha-recon"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "started"
+        assert data["name"] == "alpha-recon"
+        assert started == ["alpha-recon"]
+
+    def test_start_mission_auto_name(self, client):
+        """If no name provided, auto-generates one."""
+        stream_state.set_callbacks(on_mission_start=lambda n: None)
+        resp = client.post("/api/mission/start", json={})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"].startswith("mission-")
+
+    def test_start_mission_name_bounded(self, client):
+        """Name is truncated to 100 chars."""
+        stream_state.set_callbacks(on_mission_start=lambda n: None)
+        resp = client.post(
+            "/api/mission/start",
+            json={"name": "x" * 200},
+        )
+        assert resp.status_code == 200
+        assert len(resp.json()["name"]) <= 100
+
+    def test_start_mission_empty_name(self, client):
+        """Empty name is rejected."""
+        resp = client.post("/api/mission/start", json={"name": ""})
+        assert resp.status_code == 400
+
+    def test_end_mission(self, client):
+        ended = []
+        stream_state.set_callbacks(on_mission_end=lambda: ended.append(True))
+        resp = client.post("/api/mission/end")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ended"
+        assert ended == [True]
+
+    def test_mission_requires_auth_when_enabled(self, client):
+        configure_auth("secret-token")
+        resp = client.post("/api/mission/start", json={"name": "test"})
+        assert resp.status_code == 401
+
+        resp = client.post(
+            "/api/mission/start",
+            json={"name": "test"},
+            headers={"Authorization": "Bearer secret-token"},
+        )
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Battery and mission in stats
+# ---------------------------------------------------------------------------
+
+
+class TestBatteryInStats:
+    def test_battery_in_stats(self, client):
+        """Battery voltage and percentage appear in stats API."""
+        stream_state.update_stats(battery_v=12.6, battery_pct=85)
+        resp = client.get("/api/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["battery_v"] == 12.6
+        assert data["battery_pct"] == 85
+
+    def test_battery_null_when_unavailable(self, client):
+        """Battery fields are None when no MAVLink data."""
+        resp = client.get("/api/stats")
+        data = resp.json()
+        assert data["battery_v"] is None
+        assert data["battery_pct"] is None
+
+    def test_callsign_in_stats(self, client):
+        """Callsign appears in stats API for instructor page to read."""
+        stream_state.update_stats(callsign="ENFORCER-1")
+        resp = client.get("/api/stats")
+        assert resp.json()["callsign"] == "ENFORCER-1"
+
+    def test_mission_name_in_stats(self, client):
+        """Mission name appears in stats API."""
+        stream_state.update_stats(mission_name="night-patrol")
+        resp = client.get("/api/stats")
+        assert resp.json()["mission_name"] == "night-patrol"
+
+    def test_mission_name_null_when_idle(self, client):
+        """Mission name is None when no mission is active."""
+        resp = client.get("/api/stats")
+        assert resp.json()["mission_name"] is None
+
+
+# ---------------------------------------------------------------------------
+# Battery parsing from MAVLink (unit test for MAVLinkIO telemetry)
+# ---------------------------------------------------------------------------
+
+
+class TestBatteryParsing:
+    def test_battery_state_from_sys_status(self):
+        """Verify that SYS_STATUS parsing sets battery fields correctly."""
+        from hydra_detect.mavlink_io import MAVLinkIO
+
+        mav = MAVLinkIO.__new__(MAVLinkIO)
+        # Initialize required attributes manually (avoid full __init__)
+        mav._gps_lock = __import__("threading").Lock()
+        mav._telemetry = {
+            "armed": False,
+            "battery_v": None,
+            "battery_pct": None,
+            "groundspeed": None,
+            "altitude": None,
+            "heading": None,
+        }
+        mav._gps = {
+            "lat": None, "lon": None, "alt": None, "fix": 0, "hdg": None,
+            "last_update": 0.0,
+        }
+        mav._vehicle_mode_lock = __import__("threading").Lock()
+        mav._vehicle_mode = None
+
+        # Simulate SYS_STATUS parsing logic
+        # voltage_battery in mV, battery_remaining in %
+        voltage_battery = 12600  # 12.6V
+        battery_remaining = 75
+
+        with mav._gps_lock:
+            if voltage_battery != 0xFFFF:
+                mav._telemetry["battery_v"] = round(voltage_battery / 1000.0, 2)
+            if battery_remaining != -1:
+                mav._telemetry["battery_pct"] = battery_remaining
+
+        telem = mav.get_telemetry()
+        assert telem["battery_v"] == 12.6
+        assert telem["battery_pct"] == 75
+
+    def test_battery_unknown_remaining(self):
+        """Battery remaining -1 means unknown."""
+        from hydra_detect.mavlink_io import MAVLinkIO
+
+        mav = MAVLinkIO.__new__(MAVLinkIO)
+        mav._gps_lock = __import__("threading").Lock()
+        mav._telemetry = {
+            "armed": False,
+            "battery_v": None,
+            "battery_pct": None,
+            "groundspeed": None,
+            "altitude": None,
+            "heading": None,
+        }
+        mav._gps = {
+            "lat": None, "lon": None, "alt": None, "fix": 0, "hdg": None,
+            "last_update": 0.0,
+        }
+        mav._vehicle_mode_lock = __import__("threading").Lock()
+        mav._vehicle_mode = None
+
+        voltage_battery = 11800
+        battery_remaining = -1  # Unknown
+
+        with mav._gps_lock:
+            if voltage_battery != 0xFFFF:
+                mav._telemetry["battery_v"] = round(voltage_battery / 1000.0, 2)
+            if battery_remaining != -1:
+                mav._telemetry["battery_pct"] = battery_remaining
+
+        telem = mav.get_telemetry()
+        assert telem["battery_v"] == 11.8
+        assert telem["battery_pct"] is None


### PR DESCRIPTION
## Summary
Kyle's multi-team grading tool and safety net across 5 dispersed teams.

- **Instructor page** — `/instructor` polls all Jetsons, shows vehicle cards with status/battery/mission data (#71)
- **Per-vehicle ABORT** — Emergency stop from instructor's phone over mesh (#64)
- **Mission tagging** — Start/End Mission brackets logs for per-sortie review (#72)
- **Battery display** — Already monitored via MAVLink, now surfaced everywhere (#73)
- **Alert feed** — Unified chronological detection events across all vehicles
- **20 new tests**

## Issues
Closes #64, #71, #72, #73

## Test plan
- [ ] 610 tests passing (20 new)
- [ ] Open /instructor on phone — verify mobile layout
- [ ] Add Jetson IPs — verify vehicle cards populate
- [ ] Abort button from instructor page — verify vehicle enters LOITER
- [ ] Start/End Mission — verify STATUSTEXT and log bracketing
- [ ] Battery shows in vehicle cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)