### PR TITLE
feat: zero-touch boot — setup wizard, factory reset, config recovery

### DIFF
--- a/config.ini.factory
+++ b/config.ini.factory
@@ -1,0 +1,182 @@
+[camera]
+source_type = auto
+source = auto
+width = 640
+height = 480
+fps = 30
+hfov_deg = 60.0
+video_standard = ntsc
+
+[detector]
+yolo_model = yolov8n.pt
+yolo_confidence = 0.45
+yolo_imgsz = 416
+yolo_classes = 
+
+[tracker]
+track_thresh = 0.5
+track_buffer = 30
+match_thresh = 0.8
+
+[mavlink]
+enabled = true
+connection_string = /dev/ttyTHS1
+baud = 921600
+source_system = 1
+min_gps_fix = 3
+alert_statustext = true
+alert_interval_sec = 5.0
+severity = 2
+alert_classes = person, car, motorcycle, truck, bus, boat, bicycle, airplane, backpack, suitcase, handbag, cell phone, laptop, dog, horse, knife, scissors, baseball bat, bottle, umbrella
+auto_loiter_on_detect = false
+guided_roi_on_detect = false
+strike_distance_m = 20.0
+geo_tracking = true
+geo_tracking_interval = 2.0
+sim_gps_lat =
+sim_gps_lon = 
+
+[alerts]
+light_bar_enabled = true
+light_bar_channel = 4
+light_bar_pwm_on = 1900
+light_bar_pwm_off = 1100
+light_bar_flash_sec = 0.5
+global_max_per_sec = 2                   ; max STATUSTEXT alerts/sec across all labels
+priority_labels =                        ; comma-separated labels that bypass global cap (e.g. person,vehicle)
+
+[web]
+enabled = true
+host = 0.0.0.0
+port = 8080
+mjpeg_quality = 70
+api_token =
+
+[osd]
+enabled = true
+mode = named_value
+update_interval = 2.0
+serial_port = /dev/ttyUSB0
+serial_baud = 115200
+canvas_cols = 50
+canvas_rows = 18
+
+[autonomous]
+enabled = false
+geofence_lat = 0.0
+geofence_lon = 0.0
+geofence_radius_m = 100.0
+geofence_polygon = 
+min_confidence = 0.85
+min_track_frames = 5
+allowed_classes = 
+strike_cooldown_sec = 30.0
+allowed_vehicle_modes = AUTO
+gps_max_stale_sec = 2.0                 ; abort if GPS data is older than this
+require_operator_lock = false            ; require explicit target lock before auto-strike
+
+[rf_homing]
+enabled = false
+mode = wifi
+target_bssid = 
+target_freq_mhz = 915.0
+kismet_host = http://localhost:2501
+kismet_user = kismet
+kismet_pass = kismet
+search_pattern = lawnmower
+search_area_m = 100.0
+search_spacing_m = 20.0
+search_alt_m = 15.0
+rssi_threshold_dbm = -80.0
+rssi_converge_dbm = -40.0
+rssi_window = 10
+gradient_step_m = 5.0
+gradient_rotation_deg = 45.0
+poll_interval_sec = 0.5
+arrival_tolerance_m = 3.0
+gps_required = false
+kismet_source = rtl433-0
+kismet_capture_dir = ./output_data/kismet
+kismet_max_capture_mb = 100
+kismet_auto_spawn = false
+
+[servo_tracking]
+enabled = false
+pan_channel = 1
+pan_pwm_center = 1500
+pan_pwm_range = 500
+pan_invert = false
+pan_dead_zone = 0.05
+pan_smoothing = 0.3
+strike_channel = 2
+strike_pwm_fire = 1900
+strike_pwm_safe = 1100
+strike_duration = 0.5
+replaces_yaw = false
+
+[logging]
+log_dir = ./output_data/logs
+log_format = jsonl
+save_images = true
+image_dir = ./output_data/images
+image_quality = 90
+save_crops = false
+crop_dir = ./output_data/crops
+max_log_size_mb = 10
+max_log_files = 20
+app_log_file = true
+app_log_level = INFO
+
+[watchdog]
+max_stall_sec = 30                      ; force-exit if no frame processed in this many seconds
+
+[rtsp]
+enabled = true
+port = 8554
+mount = /hydra
+bitrate = 2000000
+
+[mavlink_video]
+enabled = false
+width = 160
+height = 120
+jpeg_quality = 20
+max_fps = 2.0
+min_fps = 0.2
+link_budget_bytes_sec = 8000
+
+[tak]
+enabled = true
+callsign = HYDRA-1
+multicast_group = 239.2.3.1
+multicast_port = 6969
+unicast_targets = 100.78.5.101:4242, 100.64.82.98:4242
+emit_interval = 2.0
+sa_interval = 5.0
+stale_detection = 60.0
+stale_sa = 30.0
+advertise_host = 100.109.160.122
+listen_commands = true
+listen_port = 6969
+
+; ---------------------------------------------------------------------------
+; Vehicle profiles — override base sections via --vehicle <name> or HYDRA_VEHICLE
+; Keys use "section.option" format to override the matching base section.
+; ---------------------------------------------------------------------------
+
+[vehicle.drone]
+; camera.source = /dev/video0
+; autonomous.abort_action = rtl
+; alerts.priority_labels = person,vehicle
+
+[vehicle.usv]
+; camera.source = /dev/video2
+; autonomous.abort_action = hold
+; alerts.priority_labels = person,boat,kayak
+; tak.callsign = HYDRA-USV
+
+[vehicle.ugv]
+; camera.source = /dev/video0
+; autonomous.abort_action = cut_throttle
+; alerts.priority_labels = person,vehicle
+; tak.callsign = HYDRA-UGV

--- a/hydra_detect/web/config_api.py
+++ b/hydra_detect/web/config_api.py
@@ -137,3 +137,24 @@ def has_backup() -> bool:
     """Check if a config backup exists."""
     path = get_config_path()
     return Path(str(path) + ".bak").exists()
+
+
+def has_factory() -> bool:
+    """Check if factory defaults file exists."""
+    path = get_config_path()
+    return Path(str(path) + ".factory").exists()
+
+
+def restore_factory() -> bool:
+    """Restore config.ini from config.ini.factory. Returns True on success."""
+    path = get_config_path()
+    factory_path = Path(str(path) + ".factory")
+    if not factory_path.exists():
+        return False
+    # Back up current config before overwriting
+    bak_path = Path(str(path) + ".bak")
+    if path.exists():
+        shutil.copy2(path, bak_path)
+    shutil.copy2(factory_path, path)
+    logger.info("Config restored from factory defaults: %s", factory_path)
+    return True

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -25,8 +25,10 @@ from fastapi.templating import Jinja2Templates
 from hydra_detect.web.config_api import (
     MAX_BODY_SIZE,
     has_backup,
+    has_factory,
     read_config,
     restore_backup,
+    restore_factory,
     write_config,
 )
 
@@ -1189,6 +1191,154 @@ async def api_restore_config_backup(request: Request, authorization: str | None 
     except Exception as e:
         logger.error("Failed to restore config backup: %s", e)
         return JSONResponse({"error": f"Failed to restore: {e}"}, status_code=500)
+
+
+@app.post("/api/config/factory-reset")
+async def api_factory_reset(request: Request, authorization: str | None = Header(None)):
+    """Restore factory defaults from config.ini.factory."""
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    if not has_factory():
+        return JSONResponse({"error": "No factory defaults available"}, status_code=404)
+    try:
+        restore_factory()
+        _audit(request, "config_factory_reset")
+        # Trigger pipeline restart
+        cb = stream_state.get_callback("on_restart_command")
+        if cb:
+            cb()
+        return {"status": "ok", "message": "Factory defaults restored"}
+    except Exception as e:
+        logger.error("Failed to restore factory defaults: %s", e)
+        return JSONResponse({"error": f"Failed to restore: {e}"}, status_code=500)
+
+
+@app.get("/api/config/export")
+async def api_config_export(request: Request, authorization: str | None = Header(None)):
+    """Export current config as JSON download."""
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    try:
+        config = read_config()
+        _audit(request, "config_export")
+        return config
+    except Exception as e:
+        logger.error("Failed to export config: %s", e)
+        return JSONResponse({"error": "Failed to export configuration"}, status_code=500)
+
+
+@app.post("/api/config/import")
+async def api_config_import(request: Request, authorization: str | None = Header(None)):
+    """Import config from uploaded JSON."""
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    import json as _json
+    body_bytes = await request.body()
+    if len(body_bytes) > MAX_BODY_SIZE:
+        return JSONResponse({"error": "Request body too large"}, status_code=413)
+    try:
+        body = _json.loads(body_bytes)
+    except (ValueError, _json.JSONDecodeError):
+        return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+    if not isinstance(body, dict):
+        return JSONResponse({"error": "Expected JSON object with config sections"}, status_code=400)
+    try:
+        result = write_config(body)
+        _audit(request, "config_import", target=str(len(body)))
+        return {"status": "imported", **result}
+    except Exception as e:
+        logger.error("Failed to import config: %s", e)
+        return JSONResponse({"error": f"Failed to import configuration: {e}"}, status_code=500)
+
+
+# ── Setup Wizard ─────────────────────────────────────────────────────
+
+@app.get("/setup", response_class=HTMLResponse)
+async def setup_page(request: Request):
+    """Serve the first-boot setup wizard page."""
+    return templates.TemplateResponse(request, "setup.html")
+
+
+@app.get("/api/setup/devices")
+async def api_setup_devices():
+    """List available cameras and serial ports for setup wizard."""
+    import glob
+    cameras = []
+    serial_ports = []
+
+    # Detect V4L2 cameras
+    for dev in sorted(glob.glob("/dev/video*")):
+        cameras.append({"path": dev, "name": dev})
+
+    # Detect serial ports (potential Pixhawk connections)
+    for dev in sorted(glob.glob("/dev/tty*")):
+        if any(prefix in dev for prefix in ["ttyACM", "ttyUSB", "ttyTHS", "ttyAMA"]):
+            serial_ports.append({"path": dev, "name": dev})
+
+    return {"cameras": cameras, "serial_ports": serial_ports}
+
+
+@app.post("/api/setup/save")
+async def api_setup_save(request: Request):
+    """Save setup wizard configuration and trigger restart."""
+    import json as _json
+    body_bytes = await request.body()
+    if len(body_bytes) > MAX_BODY_SIZE:
+        return JSONResponse({"error": "Request body too large"}, status_code=413)
+    try:
+        body = _json.loads(body_bytes)
+    except (ValueError, _json.JSONDecodeError):
+        return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+
+    camera_source = body.get("camera_source", "auto")
+    serial_port = body.get("serial_port", "/dev/ttyTHS1")
+    vehicle_type = body.get("vehicle_type", "")
+    team_number = body.get("team_number", "")
+    callsign = body.get("callsign", "")
+
+    # Validate inputs — bounded lengths
+    if len(camera_source) > 200:
+        return JSONResponse({"error": "camera_source too long"}, status_code=400)
+    if len(serial_port) > 200:
+        return JSONResponse({"error": "serial_port too long"}, status_code=400)
+    if len(vehicle_type) > 20:
+        return JSONResponse({"error": "vehicle_type too long"}, status_code=400)
+    if len(team_number) > 20:
+        return JSONResponse({"error": "team_number too long"}, status_code=400)
+    if len(callsign) > 50:
+        return JSONResponse({"error": "callsign too long"}, status_code=400)
+    if vehicle_type and vehicle_type not in ("drone", "usv", "ugv", "fw"):
+        return JSONResponse({"error": "vehicle_type must be drone, usv, ugv, or fw"}, status_code=400)
+
+    # Build callsign from team + vehicle if not explicitly set
+    if not callsign and team_number and vehicle_type:
+        callsign = f"HYDRA-{team_number}-{vehicle_type.upper()}"
+
+    # Write to config
+    updates: dict[str, dict[str, str]] = {
+        "camera": {"source": camera_source},
+        "mavlink": {"connection_string": serial_port},
+    }
+    if callsign:
+        updates["tak"] = {"callsign": callsign}
+
+    try:
+        result = write_config(updates)
+    except Exception as e:
+        logger.error("Setup save failed: %s", e)
+        return JSONResponse({"error": f"Failed to save: {e}"}, status_code=500)
+
+    _audit(request, "setup_save", target=callsign or "no-callsign")
+
+    # Trigger pipeline restart
+    cb = stream_state.get_callback("on_restart_command")
+    if cb:
+        cb()
+
+    return {"status": "saved", "callsign": callsign, **result}
 
 
 # ── Server launcher ──────────────────────────────────────────────────

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -1282,8 +1282,16 @@ async def api_setup_devices():
 
 
 @app.post("/api/setup/save")
-async def api_setup_save(request: Request):
-    """Save setup wizard configuration and trigger restart."""
+async def api_setup_save(request: Request, authorization: Optional[str] = Header(None)):
+    """Save setup wizard configuration and trigger restart.
+
+    Auth is enforced when a token is configured (post-first-boot).
+    On first boot (no token), the setup wizard works without auth.
+    """
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+
     import json as _json
     body_bytes = await request.body()
     if len(body_bytes) > MAX_BODY_SIZE:
@@ -1298,6 +1306,11 @@ async def api_setup_save(request: Request):
     vehicle_type = body.get("vehicle_type", "")
     team_number = body.get("team_number", "")
     callsign = body.get("callsign", "")
+
+    # Validate field types before length checks
+    for field in [camera_source, serial_port, vehicle_type, team_number, callsign]:
+        if not isinstance(field, str):
+            return JSONResponse({"error": "All fields must be strings"}, status_code=400)
 
     # Validate inputs — bounded lengths
     if len(camera_source) > 200:

--- a/hydra_detect/web/static/css/settings.css
+++ b/hydra_detect/web/static/css/settings.css
@@ -193,6 +193,43 @@
     text-decoration: underline;
 }
 
+/* ── Recovery Tools ── */
+.settings-recovery {
+    margin-top: var(--gap-md);
+    padding-top: var(--gap-md);
+    border-top: 2px dashed var(--card-border);
+}
+.settings-recovery-label {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-size: var(--font-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: var(--ls-condensed);
+    color: var(--text-dim);
+    margin-bottom: var(--gap-sm);
+}
+.settings-recovery-actions {
+    display: flex;
+    gap: var(--gap-sm);
+    flex-wrap: wrap;
+}
+.btn-recovery {
+    font-size: var(--font-xs);
+    padding: 6px 12px;
+    opacity: 0.7;
+    transition: opacity var(--transition-fast);
+}
+.btn-recovery:hover {
+    opacity: 1;
+}
+.btn-danger-outline {
+    border-color: var(--danger);
+    color: var(--danger);
+}
+.btn-danger-outline:hover {
+    background: var(--danger-bg);
+}
+
 /* ── Responsive ── */
 @media (max-width: 1279px) {
     .settings-nav {

--- a/hydra_detect/web/static/js/settings.js
+++ b/hydra_detect/web/static/js/settings.js
@@ -154,10 +154,20 @@ const HydraSettings = (() => {
         const applyBtn = document.getElementById('settings-apply');
         const resetBtn = document.getElementById('settings-reset');
         const restoreBtn = document.getElementById('settings-restore');
+        const factoryBtn = document.getElementById('settings-factory-reset');
+        const exportBtn = document.getElementById('settings-export');
+        const importBtn = document.getElementById('settings-import');
+        const importFile = document.getElementById('settings-import-file');
 
         if (applyBtn) applyBtn.addEventListener('click', handleApply);
         if (resetBtn) resetBtn.addEventListener('click', handleReset);
         if (restoreBtn) restoreBtn.addEventListener('click', handleRestore);
+        if (factoryBtn) factoryBtn.addEventListener('click', handleFactoryReset);
+        if (exportBtn) exportBtn.addEventListener('click', handleExport);
+        if (importBtn) importBtn.addEventListener('click', function() {
+            if (importFile) importFile.click();
+        });
+        if (importFile) importFile.addEventListener('change', handleImportFile);
     }
 
     function clearElement(el) {
@@ -372,6 +382,62 @@ const HydraSettings = (() => {
             await loadConfig();
             HydraApp.showToast('Configuration restored from backup', 'success');
         }
+    }
+
+    async function handleFactoryReset() {
+        if (!confirm('FACTORY RESET: This will restore all settings to factory defaults and restart the pipeline. Continue?')) return;
+        if (!confirm('Are you sure? All custom configuration will be lost.')) return;
+        const result = await HydraApp.apiPost('/api/config/factory-reset', {});
+        if (result) {
+            hasUnsavedChanges = false;
+            await loadConfig();
+            HydraApp.showToast('Factory defaults restored — restarting pipeline', 'success');
+        }
+    }
+
+    async function handleExport() {
+        const config = await HydraApp.apiGet('/api/config/export');
+        if (!config) return;
+        const blob = new Blob([JSON.stringify(config, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'hydra-config-' + new Date().toISOString().slice(0, 10) + '.json';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        HydraApp.showToast('Config exported', 'success');
+    }
+
+    async function handleImportFile(event) {
+        const file = event.target.files && event.target.files[0];
+        if (!file) return;
+        if (!confirm('Import configuration from ' + file.name + '? This will overwrite current settings.')) {
+            event.target.value = '';
+            return;
+        }
+        try {
+            const text = await file.text();
+            const data = JSON.parse(text);
+            const result = await HydraApp.apiPost('/api/config/import', data);
+            if (result) {
+                hasUnsavedChanges = false;
+                await loadConfig();
+                HydraApp.showToast('Configuration imported', 'success');
+                if (result.restart_required && result.restart_required.length > 0) {
+                    const restart = document.getElementById('settings-restart');
+                    const fields = document.getElementById('restart-fields');
+                    if (restart && fields) {
+                        fields.textContent = result.restart_required.join(', ');
+                        restart.style.display = '';
+                    }
+                }
+            }
+        } catch (err) {
+            HydraApp.showToast('Invalid config file: ' + err.message, 'error');
+        }
+        event.target.value = '';
     }
 
     // Power User easter egg — uses event delegation for reliable click handling

--- a/hydra_detect/web/templates/settings.html
+++ b/hydra_detect/web/templates/settings.html
@@ -38,6 +38,17 @@
         <button class="btn" id="settings-restore" title="Restore from last backup">Restore Backup</button>
     </div>
 
+    <!-- Recovery Tools — visually separated from normal settings -->
+    <div class="settings-recovery">
+        <div class="settings-recovery-label">Recovery Tools</div>
+        <div class="settings-recovery-actions">
+            <button class="btn btn-recovery btn-danger-outline" id="settings-factory-reset" title="Restore factory default configuration">Factory Reset</button>
+            <button class="btn btn-recovery" id="settings-export" title="Download current config as JSON">Export Config</button>
+            <button class="btn btn-recovery" id="settings-import" title="Upload a JSON config file">Import Config</button>
+            <input type="file" id="settings-import-file" accept=".json" style="display:none;">
+        </div>
+    </div>
+
     <div class="settings-footer" id="settings-power-footer" style="display:none;">
         <span class="settings-footer-link" id="settings-power-user">Power User Options</span>
     </div>

--- a/hydra_detect/web/templates/setup.html
+++ b/hydra_detect/web/templates/setup.html
@@ -1,0 +1,327 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HYDRA DETECT -- Setup Wizard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link href="https://fonts.googleapis.com/css2?family=Barlow+Condensed:wght@500;600;700&family=Barlow:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --ogt-green: #385723;
+            --ogt-green-dark: #2a4118;
+            --ogt-muted: #A6BC92;
+            --ogt-warm: #D8E2D0;
+            --ogt-light: #EFF5EB;
+            --panel-bg: #0c0c0c;
+            --card-bg: #1c1c1c;
+            --card-border: #262626;
+            --text-primary: #e8e8e8;
+            --text-secondary: #888;
+            --danger: #c53030;
+            --danger-bg: #2a1010;
+            --success: #385723;
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: 'Barlow', sans-serif;
+            background: var(--panel-bg);
+            color: var(--text-primary);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+        }
+        .setup-container {
+            background: var(--card-bg);
+            border: 1px solid var(--card-border);
+            border-radius: 12px;
+            padding: 40px;
+            max-width: 520px;
+            width: 100%;
+        }
+        .setup-header {
+            text-align: center;
+            margin-bottom: 32px;
+        }
+        .setup-badge {
+            display: inline-block;
+            width: 48px;
+            height: 48px;
+            margin-bottom: 12px;
+        }
+        .setup-title {
+            font-family: 'Barlow Condensed', sans-serif;
+            font-size: 1.5rem;
+            font-weight: 700;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+            color: var(--ogt-muted);
+        }
+        .setup-subtitle {
+            font-size: 0.85rem;
+            color: var(--text-secondary);
+            margin-top: 4px;
+        }
+        .setup-form {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+        .setup-field {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+        .setup-field label {
+            font-family: 'Barlow Condensed', sans-serif;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--text-secondary);
+        }
+        .setup-field select,
+        .setup-field input {
+            background: #111;
+            color: var(--text-primary);
+            border: 1px solid var(--card-border);
+            border-radius: 6px;
+            padding: 10px 12px;
+            font-family: 'JetBrains Mono', monospace;
+            font-size: 0.85rem;
+            width: 100%;
+        }
+        .setup-field select:focus,
+        .setup-field input:focus {
+            outline: none;
+            border-color: var(--ogt-green);
+            box-shadow: 0 0 0 2px rgba(56, 87, 35, 0.3);
+        }
+        .setup-row {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 16px;
+        }
+        .setup-actions {
+            margin-top: 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        .btn-save {
+            background: var(--ogt-green);
+            color: var(--ogt-light);
+            border: none;
+            border-radius: 6px;
+            padding: 14px 24px;
+            font-family: 'Barlow Condensed', sans-serif;
+            font-size: 1rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            cursor: pointer;
+            transition: background 0.15s, box-shadow 0.15s;
+        }
+        .btn-save:hover {
+            background: #4a6e30;
+            box-shadow: 0 0 16px rgba(56, 87, 35, 0.4);
+        }
+        .btn-save:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+        .btn-skip {
+            background: transparent;
+            color: var(--text-secondary);
+            border: 1px solid var(--card-border);
+            border-radius: 6px;
+            padding: 10px 24px;
+            font-family: 'Barlow Condensed', sans-serif;
+            font-size: 0.85rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            cursor: pointer;
+            transition: border-color 0.15s;
+        }
+        .btn-skip:hover {
+            border-color: var(--text-secondary);
+        }
+        .setup-status {
+            text-align: center;
+            font-size: 0.8rem;
+            min-height: 1.2em;
+        }
+        .setup-status.error {
+            color: var(--danger);
+        }
+        .setup-status.success {
+            color: var(--ogt-muted);
+        }
+        .setup-loading {
+            color: var(--text-secondary);
+            font-style: italic;
+        }
+    </style>
+</head>
+<body>
+    <div class="setup-container">
+        <div class="setup-header">
+            <svg class="setup-badge" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <rect x="24" y="3" width="29" height="29" rx="3" transform="rotate(45 24 3)" fill="#385723" stroke="#A6BC92" stroke-width="1.5"/>
+                <text x="24" y="28" text-anchor="middle" fill="#EFF5EB" font-family="Barlow Condensed" font-size="10" font-weight="700" letter-spacing="0.08em">SORCC</text>
+            </svg>
+            <h1 class="setup-title">Hydra Detect Setup</h1>
+            <p class="setup-subtitle">Configure hardware and identity for this unit</p>
+        </div>
+
+        <div class="setup-form" id="setup-form">
+            <div class="setup-field">
+                <label for="setup-camera">Camera Source</label>
+                <select id="setup-camera">
+                    <option value="auto">Auto Detect</option>
+                </select>
+            </div>
+
+            <div class="setup-field">
+                <label for="setup-serial">Serial Port (Pixhawk)</label>
+                <select id="setup-serial">
+                    <option value="/dev/ttyTHS1">/dev/ttyTHS1 (default)</option>
+                </select>
+            </div>
+
+            <div class="setup-field">
+                <label for="setup-vehicle">Vehicle Type</label>
+                <select id="setup-vehicle">
+                    <option value="">-- Select --</option>
+                    <option value="drone">Drone (Multirotor)</option>
+                    <option value="usv">USV (Boat)</option>
+                    <option value="ugv">UGV (Rover)</option>
+                    <option value="fw">Fixed Wing</option>
+                </select>
+            </div>
+
+            <div class="setup-row">
+                <div class="setup-field">
+                    <label for="setup-team">Team Number</label>
+                    <input type="text" id="setup-team" placeholder="e.g. 1" maxlength="20">
+                </div>
+                <div class="setup-field">
+                    <label for="setup-callsign">Callsign (optional)</label>
+                    <input type="text" id="setup-callsign" placeholder="e.g. HYDRA-1-DRONE" maxlength="50">
+                </div>
+            </div>
+
+            <p class="setup-status" id="setup-status"></p>
+
+            <div class="setup-actions">
+                <button class="btn-save" id="setup-save">Save &amp; Start</button>
+                <button class="btn-skip" id="setup-skip" onclick="window.location='/'">Skip to Dashboard</button>
+            </div>
+        </div>
+    </div>
+
+    <script>
+    (function() {
+        'use strict';
+
+        var cameraSelect = document.getElementById('setup-camera');
+        var serialSelect = document.getElementById('setup-serial');
+        var saveBtn = document.getElementById('setup-save');
+        var statusEl = document.getElementById('setup-status');
+
+        function clearSelect(sel) {
+            while (sel.firstChild) {
+                sel.removeChild(sel.firstChild);
+            }
+        }
+
+        // Populate device dropdowns on load
+        async function loadDevices() {
+            statusEl.textContent = 'Detecting devices...';
+            statusEl.className = 'setup-status setup-loading';
+            try {
+                var resp = await fetch('/api/setup/devices');
+                if (!resp.ok) throw new Error('Failed to fetch devices');
+                var data = await resp.json();
+
+                // Populate cameras
+                if (data.cameras && data.cameras.length > 0) {
+                    data.cameras.forEach(function(cam) {
+                        var opt = document.createElement('option');
+                        opt.value = cam.path;
+                        opt.textContent = cam.name;
+                        cameraSelect.appendChild(opt);
+                    });
+                }
+
+                // Populate serial ports
+                if (data.serial_ports && data.serial_ports.length > 0) {
+                    clearSelect(serialSelect);
+                    data.serial_ports.forEach(function(port) {
+                        var opt = document.createElement('option');
+                        opt.value = port.path;
+                        opt.textContent = port.name;
+                        serialSelect.appendChild(opt);
+                    });
+                    // Pre-select ttyTHS1 if present
+                    var tths1 = Array.from(serialSelect.options).find(
+                        function(o) { return o.value === '/dev/ttyTHS1'; }
+                    );
+                    if (tths1) tths1.selected = true;
+                }
+
+                statusEl.textContent = '';
+                statusEl.className = 'setup-status';
+            } catch (err) {
+                statusEl.textContent = 'Could not detect devices. Enter values manually.';
+                statusEl.className = 'setup-status error';
+            }
+        }
+
+        // Save configuration
+        saveBtn.addEventListener('click', async function() {
+            saveBtn.disabled = true;
+            statusEl.textContent = 'Saving configuration...';
+            statusEl.className = 'setup-status setup-loading';
+
+            var payload = {
+                camera_source: cameraSelect.value,
+                serial_port: serialSelect.value,
+                vehicle_type: document.getElementById('setup-vehicle').value,
+                team_number: document.getElementById('setup-team').value.trim(),
+                callsign: document.getElementById('setup-callsign').value.trim(),
+            };
+
+            try {
+                var resp = await fetch('/api/setup/save', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify(payload),
+                });
+                var data = await resp.json();
+                if (!resp.ok) {
+                    throw new Error(data.error || 'Save failed');
+                }
+                var msg = 'Configuration saved';
+                if (data.callsign) {
+                    msg += ' (' + data.callsign + ')';
+                }
+                msg += '. Redirecting...';
+                statusEl.textContent = msg;
+                statusEl.className = 'setup-status success';
+                setTimeout(function() { window.location = '/'; }, 2000);
+            } catch (err) {
+                statusEl.textContent = err.message;
+                statusEl.className = 'setup-status error';
+                saveBtn.disabled = false;
+            }
+        });
+
+        loadDevices();
+    })();
+    </script>
+</body>
+</html>

--- a/scripts/hydra-launch.sh
+++ b/scripts/hydra-launch.sh
@@ -8,7 +8,7 @@ URL="http://localhost:${PORT}"
 
 cd "$HYDRA_DIR"
 
-# Start Hydra in the background
+# Start Hydra in the background (native mode, not Docker)
 sudo python3 -m hydra_detect --config config.ini &
 HYDRA_PID=$!
 

--- a/scripts/hydra-setup.sh
+++ b/scripts/hydra-setup.sh
@@ -408,7 +408,7 @@ if [ "$MAVLINK_ENABLED" = true ] && [ -n "$MAVLINK_DEVICE" ]; then
     DEVICE_FLAGS+=" --device $MAVLINK_DEVICE:$MAVLINK_DEVICE"
 fi
 
-DOCKER_CMD="docker run --rm --privileged --runtime nvidia \
+DOCKER_CMD="docker run --restart unless-stopped --privileged --runtime nvidia \
 $DEVICE_FLAGS \
   -v $HYDRA_DIR/config.ini:/app/config.ini:ro \
   -v /usr/sbin/nvpmodel:/usr/sbin/nvpmodel:ro \

--- a/tests/test_zero_touch.py
+++ b/tests/test_zero_touch.py
@@ -1,0 +1,307 @@
+"""Tests for zero-touch boot and student experience features (PR 11)."""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hydra_detect.web.server import app, configure_auth, stream_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset stream_state and auth between tests."""
+    configure_auth(None)
+    stream_state._callbacks.clear()
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def tmp_config(tmp_path):
+    """Create a temporary config.ini for testing."""
+    config = configparser.ConfigParser()
+    config["camera"] = {"source": "auto", "width": "640", "height": "480"}
+    config["detector"] = {"yolo_model": "yolov8n.pt", "yolo_confidence": "0.45"}
+    config["mavlink"] = {"connection_string": "/dev/ttyTHS1", "baud": "921600"}
+    config["tak"] = {"callsign": "HYDRA-1", "enabled": "true"}
+    config["web"] = {"host": "0.0.0.0", "port": "8080", "api_token": ""}
+    config["tracker"] = {"track_thresh": "0.5"}
+    path = tmp_path / "config.ini"
+    with open(path, "w") as f:
+        config.write(f)
+    return path
+
+
+@pytest.fixture
+def tmp_factory(tmp_config):
+    """Create a factory defaults file next to the config."""
+    factory_path = Path(str(tmp_config) + ".factory")
+    config = configparser.ConfigParser()
+    config["camera"] = {"source": "auto", "width": "640", "height": "480"}
+    config["detector"] = {"yolo_model": "yolov8n.pt", "yolo_confidence": "0.45"}
+    config["mavlink"] = {"connection_string": "/dev/ttyTHS1", "baud": "921600"}
+    config["tak"] = {"callsign": "HYDRA-FACTORY", "enabled": "true"}
+    config["web"] = {"host": "0.0.0.0", "port": "8080", "api_token": ""}
+    config["tracker"] = {"track_thresh": "0.5"}
+    with open(factory_path, "w") as f:
+        config.write(f)
+    return factory_path
+
+
+# ── Setup Page ────────────────────────────────────────────────
+
+class TestSetupPage:
+    def test_setup_page_returns_200(self, client):
+        resp = client.get("/setup")
+        assert resp.status_code == 200
+        assert "Setup" in resp.text
+
+    def test_setup_page_contains_form_elements(self, client):
+        resp = client.get("/setup")
+        assert "setup-camera" in resp.text
+        assert "setup-serial" in resp.text
+        assert "setup-vehicle" in resp.text
+        assert "setup-team" in resp.text
+
+
+# ── Setup Devices API ─────────────────────────────────────────
+
+class TestSetupDevices:
+    def test_devices_returns_cameras_and_serial(self, client):
+        with patch("glob.glob") as mock_glob:
+            def glob_side_effect(pattern):
+                if "video" in pattern:
+                    return ["/dev/video0", "/dev/video1"]
+                if "tty" in pattern:
+                    return ["/dev/ttyACM0", "/dev/ttyTHS1", "/dev/ttyS0"]
+                return []
+            mock_glob.side_effect = glob_side_effect
+            resp = client.get("/api/setup/devices")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "cameras" in data
+        assert "serial_ports" in data
+        assert len(data["cameras"]) == 2
+        # ttyS0 should be filtered out
+        assert len(data["serial_ports"]) == 2
+        assert data["serial_ports"][0]["path"] == "/dev/ttyACM0"
+
+    def test_devices_empty_when_none_found(self, client):
+        with patch("glob.glob", return_value=[]):
+            resp = client.get("/api/setup/devices")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["cameras"] == []
+        assert data["serial_ports"] == []
+
+
+# ── Setup Save API ─────────────────────────────────────────────
+
+class TestSetupSave:
+    def test_save_writes_config(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/setup/save", json={
+                "camera_source": "/dev/video2",
+                "serial_port": "/dev/ttyACM0",
+                "vehicle_type": "usv",
+                "team_number": "3",
+                "callsign": "",
+            })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "saved"
+        assert data["callsign"] == "HYDRA-3-USV"
+
+        # Verify config was written
+        config = configparser.ConfigParser()
+        config.read(tmp_config)
+        assert config["camera"]["source"] == "/dev/video2"
+        assert config["mavlink"]["connection_string"] == "/dev/ttyACM0"
+        assert config["tak"]["callsign"] == "HYDRA-3-USV"
+
+    def test_save_with_explicit_callsign(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/setup/save", json={
+                "camera_source": "auto",
+                "serial_port": "/dev/ttyTHS1",
+                "vehicle_type": "drone",
+                "team_number": "1",
+                "callsign": "MY-CUSTOM-NAME",
+            })
+        assert resp.status_code == 200
+        assert resp.json()["callsign"] == "MY-CUSTOM-NAME"
+
+    def test_save_triggers_restart_callback(self, client, tmp_config):
+        restart_cb = MagicMock()
+        stream_state.set_callbacks(on_restart_command=restart_cb)
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/setup/save", json={
+                "camera_source": "auto",
+                "serial_port": "/dev/ttyTHS1",
+            })
+        assert resp.status_code == 200
+        restart_cb.assert_called_once()
+
+    def test_save_rejects_invalid_vehicle_type(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/setup/save", json={
+                "camera_source": "auto",
+                "serial_port": "/dev/ttyTHS1",
+                "vehicle_type": "submarine",
+            })
+        assert resp.status_code == 400
+
+    def test_save_rejects_oversized_input(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/setup/save", json={
+                "camera_source": "x" * 201,
+                "serial_port": "/dev/ttyTHS1",
+            })
+        assert resp.status_code == 400
+
+
+# ── Factory Reset ─────────────────────────────────────────────
+
+class TestFactoryReset:
+    def test_factory_reset_restores_defaults(self, client, tmp_config, tmp_factory):
+        # First modify the config
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            client.post("/api/config/full", json={"tak": {"callsign": "MODIFIED"}})
+            # Now factory reset
+            resp = client.post("/api/config/factory-reset")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+
+        # Verify factory defaults are restored
+        config = configparser.ConfigParser()
+        config.read(tmp_config)
+        assert config["tak"]["callsign"] == "HYDRA-FACTORY"
+
+    def test_factory_reset_no_factory_file(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/factory-reset")
+        assert resp.status_code == 404
+        assert "No factory defaults" in resp.json()["error"]
+
+    def test_factory_reset_creates_backup(self, client, tmp_config, tmp_factory):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/factory-reset")
+        assert resp.status_code == 200
+        assert Path(str(tmp_config) + ".bak").exists()
+
+    def test_factory_reset_triggers_restart(self, client, tmp_config, tmp_factory):
+        restart_cb = MagicMock()
+        stream_state.set_callbacks(on_restart_command=restart_cb)
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/factory-reset")
+        assert resp.status_code == 200
+        restart_cb.assert_called_once()
+
+    def test_factory_reset_requires_auth_when_enabled(self, client, tmp_config, tmp_factory):
+        configure_auth("secret-token")
+        resp = client.post("/api/config/factory-reset")
+        assert resp.status_code == 401
+
+
+# ── Restore Backup ────────────────────────────────────────────
+
+class TestRestoreBackup:
+    def test_restore_backup_works(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            # Make a change (creates backup)
+            client.post("/api/config/full", json={"tak": {"callsign": "CHANGED"}})
+            # Restore backup
+            resp = client.post("/api/config/restore-backup")
+        assert resp.status_code == 200
+        config = configparser.ConfigParser()
+        config.read(tmp_config)
+        assert config["tak"]["callsign"] == "HYDRA-1"
+
+    def test_restore_backup_no_backup(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/restore-backup")
+        assert resp.status_code == 404
+
+
+# ── Config Export ─────────────────────────────────────────────
+
+class TestConfigExport:
+    def test_export_returns_config_dict(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.get("/api/config/export")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "camera" in data
+        assert "mavlink" in data
+        assert data["camera"]["source"] == "auto"
+
+    def test_export_requires_auth_when_enabled(self, client, tmp_config):
+        configure_auth("secret-token")
+        resp = client.get("/api/config/export")
+        assert resp.status_code == 401
+
+
+# ── Config Import ─────────────────────────────────────────────
+
+class TestConfigImport:
+    def test_import_writes_config(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/import", json={
+                "camera": {"source": "/dev/video4"},
+                "tak": {"callsign": "IMPORTED"},
+            })
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "imported"
+
+        config = configparser.ConfigParser()
+        config.read(tmp_config)
+        assert config["camera"]["source"] == "/dev/video4"
+        assert config["tak"]["callsign"] == "IMPORTED"
+
+    def test_import_returns_restart_required(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/import", json={
+                "camera": {"source": "/dev/video4"},
+            })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "restart_required" in data
+        assert any("source" in f for f in data["restart_required"])
+
+    def test_import_rejects_invalid_json(self, client, tmp_config):
+        resp = client.post("/api/config/import", content=b"not json",
+                          headers={"Content-Type": "application/json"})
+        assert resp.status_code == 400
+
+    def test_import_rejects_oversized_body(self, client, tmp_config):
+        huge = {"camera": {"source": "x" * 70000}}
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/import", json=huge)
+        assert resp.status_code == 413
+
+    def test_import_requires_auth_when_enabled(self, client, tmp_config):
+        configure_auth("secret-token")
+        resp = client.post("/api/config/import", json={"camera": {"source": "auto"}})
+        assert resp.status_code == 401
+
+
+# ── Systemd Service File ─────────────────────────────────────
+
+class TestServiceFile:
+    def test_service_has_auto_start_directives(self):
+        service_path = Path(__file__).parent.parent / "scripts" / "hydra-detect.service"
+        content = service_path.read_text()
+        assert "WantedBy=multi-user.target" in content
+        assert "Restart=" in content
+        assert "RestartSec=" in content
+        assert "After=network.target" in content


### PR DESCRIPTION
## Summary
Students power on the Jetson, open the dashboard, and go. No SSH needed.

- **Setup wizard** — `/setup` page with auto-detected cameras/serial ports, vehicle type, team/callsign (#56)
- **Factory reset** — Dashboard button restores config.ini.factory with double confirmation (#75)
- **Config export/import** — Download/upload config JSON for cross-Jetson portability (#75)
- **Auto-start** — systemd + Docker --restart unless-stopped (#56)
- **24 new tests**

## Issues
Closes #56, #75

## Test plan
- [ ] 614 tests passing (24 new)
- [ ] Power on Jetson — verify Hydra auto-starts
- [ ] Open /setup — verify cameras and serial ports detected
- [ ] Save setup — verify config written and pipeline restarts
- [ ] Factory reset — verify config.ini.factory restored
- [ ] Export config — verify JSON download
- [ ] Import config — verify upload and restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)