### PR TITLE
feat: SITL simulation mode with --sim flag

### DIFF
--- a/docs/sitl-testing.md
+++ b/docs/sitl-testing.md
@@ -1,0 +1,160 @@
+# SITL Testing Guide
+
+Test Hydra without hardware using ArduPilot Software-in-the-Loop.
+
+## Prerequisites
+
+- Python 3.10+ with Hydra dependencies installed
+- ArduPilot SITL (optional — Hydra works with sim GPS even without SITL)
+- A test video file (or webcam)
+
+## Quick Start (No SITL, Just Hydra)
+
+The `--sim` flag configures Hydra for simulation:
+
+```bash
+# With a test video file
+python -m hydra_detect --config config.ini --sim
+
+# With webcam (laptop camera as source)
+python -m hydra_detect --config config.ini --sim --camera-source 0
+```
+
+This gives you:
+- Detection and tracking on video/webcam
+- Web dashboard at http://localhost:8080
+- Simulated GPS at Oak Grove, NC (configurable)
+- TAK output (if enabled)
+- No MAVLink connection required
+
+## With ArduPilot SITL
+
+For full autonomous testing (follow mode, strike, waypoints):
+
+### 1. Install SITL
+
+```bash
+# Clone ArduPilot
+git clone --recurse-submodules https://github.com/ArduPilot/ardupilot.git
+cd ardupilot
+
+# Install dependencies
+Tools/environment_install/install-prereqs-ubuntu.sh -y
+. ~/.profile
+
+# Build SITL for your vehicle type
+./waf configure --board sitl
+./waf copter   # or rover, plane
+```
+
+### 2. Start SITL
+
+```bash
+# ArduCopter (drone)
+cd ArduCopter
+sim_vehicle.py -v ArduCopter --map --console
+
+# ArduRover (USV or UGV)
+cd ArduRover
+sim_vehicle.py -v Rover --map --console
+
+# ArduPlane (fixed wing)
+cd ArduPlane
+sim_vehicle.py -v ArduPlane --map --console
+```
+
+SITL listens on UDP port 14550 by default.
+
+### 3. Start Hydra
+
+```bash
+python -m hydra_detect --config config.ini --sim --vehicle drone
+```
+
+Hydra connects to SITL via MAVLink UDP. You can:
+- See detections on the dashboard
+- Lock targets and test follow mode
+- Test autonomous strike with geofence
+- Verify TAK markers on ATAK
+- Test abort and RTL behavior
+
+### 4. Connect GCS
+
+Mission Planner or QGroundControl can connect to SITL simultaneously:
+- SITL forwards to UDP 14551 for a second GCS
+- Or connect to TCP 5760
+
+## Multi-Vehicle SITL
+
+Test 5-team CULEX scenarios:
+
+```bash
+# Terminal 1: Vehicle 1 (drone)
+sim_vehicle.py -v ArduCopter --instance 0 --sysid 1
+
+# Terminal 2: Vehicle 2 (rover/USV)
+sim_vehicle.py -v Rover --instance 1 --sysid 2
+
+# Terminal 3: Vehicle 3 (rover/UGV)
+sim_vehicle.py -v Rover --instance 2 --sysid 3
+```
+
+Each instance uses a different port: 14550, 14560, 14570.
+
+```bash
+# Hydra instance 1
+python -m hydra_detect --sim --vehicle drone --config config-drone.ini
+
+# Hydra instance 2
+python -m hydra_detect --sim --vehicle usv --config config-usv.ini
+```
+
+## Test Scenarios
+
+### Follow Mode
+1. Start SITL ArduRover
+2. Start Hydra with `--sim --vehicle ugv`
+3. Open dashboard, point webcam at a person
+4. Lock the track, click Follow
+5. In SITL console, verify `GUIDED` mode and waypoint updates
+
+### Strike Safety Gates
+1. Start Hydra with `--sim --vehicle usv`
+2. Set geofence in config: small radius around SITL home
+3. Verify strike is rejected outside geofence
+4. Verify config freeze during active engagement
+
+### Camera Loss Recovery
+1. Start with webcam: `--sim --camera-source 0`
+2. Unplug webcam during detection
+3. Verify CAM LOST alert and degraded mode
+4. Replug — verify recovery
+
+### Multi-Instance Identity
+1. Start two Hydra instances with same callsign
+2. Verify duplicate callsign warning
+3. Start with different callsigns, test TAK command routing
+
+## Config Overrides for SITL
+
+The `--sim` flag sets these defaults (override in config.ini):
+
+| Setting | SITL Default | Normal Default |
+|---------|-------------|----------------|
+| camera.source_type | file | auto |
+| camera.source | sim_video.mp4 | auto |
+| mavlink.connection_string | udp:127.0.0.1:14550 | /dev/ttyTHS1 |
+| mavlink.baud | 115200 | 921600 |
+| mavlink.sim_gps_lat | 35.0527 | (none) |
+| mavlink.sim_gps_lon | -79.4927 | (none) |
+| osd.enabled | false | false |
+| servo_tracking.enabled | false | false |
+| rf_homing.enabled | false | false |
+
+## Troubleshooting
+
+**No MAVLink connection:** Check SITL is running and listening on 14550. Try `mavproxy.py --master=udp:127.0.0.1:14550` to verify.
+
+**No video:** Place a test video at `sim_video.mp4` in the project root, or use `--camera-source 0` for webcam.
+
+**GPS timeout:** If not running SITL, sim_gps provides fake coordinates. If running SITL, GPS fix takes ~10 seconds after SITL boot.

--- a/hydra_detect/__main__.py
+++ b/hydra_detect/__main__.py
@@ -1,9 +1,49 @@
 """Entry point: python -m hydra_detect [--config config.ini]"""
 
+from __future__ import annotations
+
 import argparse
+import configparser
+import logging
 import os
+from pathlib import Path
 
 from .pipeline import Pipeline
+
+logger = logging.getLogger(__name__)
+
+
+def _apply_sim_overrides(cfg: configparser.ConfigParser) -> None:
+    """Override config values for SITL simulation mode."""
+    cfg.set("camera", "source_type", "file")
+    cfg.set("camera", "source", "sim_video.mp4")
+    cfg.set("mavlink", "enabled", "true")
+    cfg.set("mavlink", "connection_string", "udp:127.0.0.1:14550")
+    cfg.set("mavlink", "baud", "115200")
+    # Sim GPS for when no SITL is running
+    if not cfg.has_option("mavlink", "sim_gps_lat") or not cfg.get("mavlink", "sim_gps_lat").strip():
+        cfg.set("mavlink", "sim_gps_lat", "35.0527")  # Oak Grove, NC
+    if not cfg.has_option("mavlink", "sim_gps_lon") or not cfg.get("mavlink", "sim_gps_lon").strip():
+        cfg.set("mavlink", "sim_gps_lon", "-79.4927")
+    # Disable hardware-dependent features
+    if cfg.has_section("osd"):
+        cfg.set("osd", "enabled", "false")
+    if cfg.has_section("servo_tracking"):
+        cfg.set("servo_tracking", "enabled", "false")
+    if cfg.has_section("rf_homing"):
+        cfg.set("rf_homing", "enabled", "false")
+    logger.info("SITL simulation mode — MAVLink UDP, file camera, sim GPS")
+
+
+def _apply_camera_source_override(cfg: configparser.ConfigParser, source: str) -> None:
+    """Override camera source and auto-detect source type."""
+    cfg.set("camera", "source", source)
+    if source.isdigit():
+        cfg.set("camera", "source_type", "usb")
+    elif source.startswith("rtsp"):
+        cfg.set("camera", "source_type", "rtsp")
+    elif Path(source).suffix in (".mp4", ".avi", ".mkv", ".mov"):
+        cfg.set("camera", "source_type", "file")
 
 
 def main():
@@ -20,9 +60,29 @@ def main():
              "Overrides base config with [vehicle.<name>] sections. "
              "Can also be set via HYDRA_VEHICLE env var.",
     )
+    parser.add_argument(
+        "--sim",
+        action="store_true",
+        help="SITL simulation mode — auto-configures for ArduPilot SITL",
+    )
+    parser.add_argument(
+        "--camera-source",
+        help="Override camera source (e.g., 0 for webcam, path to video file)",
+    )
     args = parser.parse_args()
 
-    pipeline = Pipeline(config_path=args.config, vehicle=args.vehicle)
+    # Pre-load config so we can apply --sim and --camera-source overrides
+    # before Pipeline.__init__ reads the values.
+    cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    cfg.read(args.config)
+
+    if args.sim:
+        _apply_sim_overrides(cfg)
+
+    if args.camera_source:
+        _apply_camera_source_override(cfg, args.camera_source)
+
+    pipeline = Pipeline(config_path=args.config, vehicle=args.vehicle, cfg_override=cfg)
     pipeline.start()
 
     # Hard exit to prevent "terminate called without an active exception"

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -81,9 +81,17 @@ def _build_detector(cfg: configparser.ConfigParser, models_dir: Path | None = No
 class Pipeline:
     """Top-level orchestrator that ties all modules together."""
 
-    def __init__(self, config_path: str = "config.ini", vehicle: str | None = None):
-        self._cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
-        self._cfg.read(config_path)
+    def __init__(
+        self,
+        config_path: str = "config.ini",
+        vehicle: str | None = None,
+        cfg_override: configparser.ConfigParser | None = None,
+    ):
+        if cfg_override is not None:
+            self._cfg = cfg_override
+        else:
+            self._cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+            self._cfg.read(config_path)
 
         # Apply vehicle-specific overrides from [vehicle.<name>] sections.
         # Keys use dotted notation: "camera.source" → override [camera] source.

--- a/tests/test_sitl_mode.py
+++ b/tests/test_sitl_mode.py
@@ -1,0 +1,135 @@
+"""Tests for --sim (SITL simulation mode) and --camera-source CLI flags."""
+
+from __future__ import annotations
+
+import configparser
+
+from hydra_detect.__main__ import _apply_sim_overrides, _apply_camera_source_override
+
+
+def _base_cfg() -> configparser.ConfigParser:
+    """Return a minimal config with required sections."""
+    cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    cfg.read_dict({
+        "camera": {"source_type": "auto", "source": "auto"},
+        "mavlink": {
+            "enabled": "false",
+            "connection_string": "/dev/ttyTHS1",
+            "baud": "921600",
+            "sim_gps_lat": "",
+            "sim_gps_lon": "",
+        },
+        "osd": {"enabled": "true"},
+        "servo_tracking": {"enabled": "true"},
+        "rf_homing": {"enabled": "true"},
+    })
+    return cfg
+
+
+class TestSimMode:
+    def test_sim_sets_camera_to_file(self):
+        cfg = _base_cfg()
+        _apply_sim_overrides(cfg)
+        assert cfg.get("camera", "source_type") == "file"
+        assert cfg.get("camera", "source") == "sim_video.mp4"
+
+    def test_sim_sets_mavlink_udp(self):
+        cfg = _base_cfg()
+        _apply_sim_overrides(cfg)
+        assert cfg.get("mavlink", "enabled") == "true"
+        assert cfg.get("mavlink", "connection_string") == "udp:127.0.0.1:14550"
+        assert cfg.get("mavlink", "baud") == "115200"
+
+    def test_sim_sets_default_gps(self):
+        cfg = _base_cfg()
+        _apply_sim_overrides(cfg)
+        assert cfg.get("mavlink", "sim_gps_lat") == "35.0527"
+        assert cfg.get("mavlink", "sim_gps_lon") == "-79.4927"
+
+    def test_sim_preserves_existing_gps(self):
+        cfg = _base_cfg()
+        cfg.set("mavlink", "sim_gps_lat", "40.0")
+        cfg.set("mavlink", "sim_gps_lon", "-80.0")
+        _apply_sim_overrides(cfg)
+        assert cfg.get("mavlink", "sim_gps_lat") == "40.0"
+        assert cfg.get("mavlink", "sim_gps_lon") == "-80.0"
+
+    def test_sim_disables_osd(self):
+        cfg = _base_cfg()
+        _apply_sim_overrides(cfg)
+        assert cfg.get("osd", "enabled") == "false"
+
+    def test_sim_disables_servo_tracking(self):
+        cfg = _base_cfg()
+        _apply_sim_overrides(cfg)
+        assert cfg.get("servo_tracking", "enabled") == "false"
+
+    def test_sim_disables_rf_homing(self):
+        cfg = _base_cfg()
+        _apply_sim_overrides(cfg)
+        assert cfg.get("rf_homing", "enabled") == "false"
+
+    def test_sim_works_without_hardware_sections(self):
+        """Sim mode should not crash if osd/servo/rf sections are missing."""
+        cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+        cfg.read_dict({
+            "camera": {"source_type": "auto", "source": "auto"},
+            "mavlink": {
+                "enabled": "false",
+                "connection_string": "/dev/ttyTHS1",
+                "baud": "921600",
+                "sim_gps_lat": "",
+                "sim_gps_lon": "",
+            },
+        })
+        _apply_sim_overrides(cfg)
+        assert cfg.get("camera", "source_type") == "file"
+        assert cfg.get("mavlink", "connection_string") == "udp:127.0.0.1:14550"
+
+
+class TestCameraSourceOverride:
+    def test_webcam_digit(self):
+        cfg = _base_cfg()
+        _apply_camera_source_override(cfg, "0")
+        assert cfg.get("camera", "source") == "0"
+        assert cfg.get("camera", "source_type") == "usb"
+
+    def test_video_file_mp4(self):
+        cfg = _base_cfg()
+        _apply_camera_source_override(cfg, "test_video.mp4")
+        assert cfg.get("camera", "source") == "test_video.mp4"
+        assert cfg.get("camera", "source_type") == "file"
+
+    def test_video_file_avi(self):
+        cfg = _base_cfg()
+        _apply_camera_source_override(cfg, "recording.avi")
+        assert cfg.get("camera", "source") == "recording.avi"
+        assert cfg.get("camera", "source_type") == "file"
+
+    def test_video_file_mkv(self):
+        cfg = _base_cfg()
+        _apply_camera_source_override(cfg, "footage.mkv")
+        assert cfg.get("camera", "source") == "footage.mkv"
+        assert cfg.get("camera", "source_type") == "file"
+
+    def test_video_file_mov(self):
+        cfg = _base_cfg()
+        _apply_camera_source_override(cfg, "clip.mov")
+        assert cfg.get("camera", "source") == "clip.mov"
+        assert cfg.get("camera", "source_type") == "file"
+
+    def test_rtsp_stream(self):
+        cfg = _base_cfg()
+        _apply_camera_source_override(cfg, "rtsp://192.168.1.10:554/stream")
+        assert cfg.get("camera", "source") == "rtsp://192.168.1.10:554/stream"
+        assert cfg.get("camera", "source_type") == "rtsp"
+
+    def test_camera_source_overrides_sim_default(self):
+        """--camera-source should override the --sim default file source."""
+        cfg = _base_cfg()
+        _apply_sim_overrides(cfg)
+        assert cfg.get("camera", "source") == "sim_video.mp4"
+        # Now apply camera-source override (like CLI ordering: --sim then --camera-source)
+        _apply_camera_source_override(cfg, "0")
+        assert cfg.get("camera", "source") == "0"
+        assert cfg.get("camera", "source_type") == "usb"


### PR DESCRIPTION
## Summary
Test everything without hardware using ArduPilot SITL.

- **--sim flag** — Auto-configures MAVLink UDP, file camera, sim GPS, disables hardware features
- **--camera-source** — Override camera source with auto-type detection (webcam/file/RTSP)
- **SITL testing guide** — Step-by-step docs for single and multi-vehicle SITL testing
- **15 new tests**

## Test plan
- [ ] `python -m hydra_detect --sim` starts with sim config
- [ ] `python -m hydra_detect --sim --camera-source 0` uses webcam
- [ ] Dashboard accessible at localhost:8080 in sim mode
- [ ] Connect to ArduPilot SITL — verify MAVLink telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)