### PR TITLE
docs: add SORCC course context to CLAUDE.md and hydra skill

### DIFF
--- a/.claude/skills/hydra/SKILL.md
+++ b/.claude/skills/hydra/SKILL.md
@@ -73,6 +73,16 @@ Hydra serves three audiences — tag features and ideas by which they serve:
 - **Dev** — building and extending. Maintainable, testable, debuggable.
   (/jetson-check, test suite, Docker, sim GPS, debug logging, ML fine-tuning)
 
+## SORCC Course Context
+
+Hydra is built for **SORCC** (Special Operations Robotics Capabilities Course) —
+a 6-week SOF training program. 15 students in 5 teams operate drones, rovers,
+boats, and fixed-wing aircraft with Hydra payloads. Students interact only via
+the web dashboard (never SSH). Errors must be plain English. Up to 20 Hydra
+instances run simultaneously during exercises. See `CLAUDE.md` "SORCC Course
+Context" section for full details including platforms, workflow, vocabulary, and
+design implications.
+
 ## Constraints (Safety-Critical)
 
 - **Memory:** 4-8 GB shared CPU/GPU. Fixed-size ring buffers only. No unbounded caches.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,44 @@ Camera → Detector (YOLO) → ByteTrack Tracker → MAVLink Alerts
 - **Config:** `config.ini` (INI format, all tunables live here)
 - **Tests:** `pytest` — run with `python -m pytest tests/`
 
+## SORCC Course Context
+
+**SORCC** (Special Operations Robotics Capabilities Course) is a 6-week IQT
+program at Oak Grove, NC. 15 students in 5 teams of 3, active-duty SOF
+(SF, Rangers, SMU support). They are technically capable and mission-focused
+but most have never touched a Jetson, config file, or terminal before this course.
+
+### Platforms Per Team
+- 5" and 10" FPV quadcopters (ArduCopter)
+- Heewing T1 Ranger fixed wing (ArduPlane)
+- Traxxas Stampede UGV (ArduRover)
+- Bonzai Enforcer 48" USV (ArduRover boat mode)
+
+### How Students Use Hydra (Weeks 4-5)
+1. Receive a pre-configured Jetson Orin Nano
+2. Power on — Hydra auto-starts
+3. Open web dashboard on laptop/tablet
+4. Select mission profile (RECON/DELIVERY/STRIKE)
+5. Fly/drive/sail while Hydra detects and tracks targets
+6. Review detection logs after the sortie
+
+### Design Implications
+- **Students never need SSH** — dashboard is the only interface
+- **Config.ini is the user interface** — all student-facing options live there with sane defaults
+- **Errors must be plain English** — "Camera: not found on /dev/video0 — check USB"
+  not Python tracebacks
+- **Field conditions:** battery power, 50-100m WiFi, vibration, water, night ops
+- **3 instructors:** Kyle (lead/dev), Charles (platform SME), Vinnie (docs)
+- **20 potential Hydra instances** during CULEX (5 teams × 4 platforms)
+
+### Vocabulary
+- SORCC = "sork" (spoken as a word)
+- IQT = Initial Qualification Training
+- STX = Situational Training Exercise
+- CULEX = Culminating Exercise
+- EENT = End of Evening Nautical Twilight (night ops begin)
+- Use "uncrewed" not "unmanned"
+
 ## Jetson Deployment Constraints
 
 ### Memory (4–8 GB shared CPU/GPU RAM)


### PR DESCRIPTION
## Summary
- Add "SORCC Course Context" section to `CLAUDE.md` after "Project Context" — describes the 6-week SOF training program, student platforms, Hydra usage workflow, design implications, and vocabulary
- Add brief SORCC context to `.claude/skills/hydra/SKILL.md` referencing CLAUDE.md for full details
- Ensures all future development decisions are informed by who the end users are

Closes #76

## Test plan
- [x] `python -m pytest tests/ -x -q` — 590 passed
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Verify SKILL.md section appears in `/hydra` skill context

🤖 Generated with [Claude Code](https://claude.com/claude-code)