### PR TITLE
feat: TAK unicast dashboard management and auto-manifest generation

### DIFF
--- a/hydra_detect/model_manifest.py
+++ b/hydra_detect/model_manifest.py
@@ -96,6 +96,46 @@ def generate_manifest(*model_dirs: str) -> list[dict[str, Any]]:
     return entries
 
 
+def auto_update_manifest(models_dir: Path) -> bool:
+    """Scan models directory and add any new .pt files to manifest.json.
+
+    Returns True if manifest was updated.
+    """
+    if not models_dir.is_dir():
+        return False
+
+    manifest_path = models_dir / MANIFEST_FILENAME
+    manifest = load_manifest(manifest_path) or []
+    existing_files = {e["filename"] for e in manifest}
+
+    updated = False
+    for pt_file in sorted(models_dir.glob("*.pt")):
+        if pt_file.name not in existing_files:
+            file_hash = compute_file_hash(pt_file)
+            size_mb = round(pt_file.stat().st_size / (1024 * 1024), 1)
+            entry = {
+                "filename": pt_file.name,
+                "sha256": file_hash,
+                "size_mb": size_mb,
+                "input_size": 416,
+                "classes": [],
+            }
+            manifest.append(entry)
+            updated = True
+            logger.info(
+                "Auto-manifest: added %s (%.1f MB)", pt_file.name, size_mb
+            )
+
+    if updated:
+        with open(manifest_path, "w") as f:
+            json.dump(manifest, f, indent=2)
+        logger.info(
+            "Manifest updated: %s (%d models)", manifest_path, len(manifest)
+        )
+
+    return updated
+
+
 def main() -> None:
     """CLI: generate or update manifest.json in a models directory."""
     import sys

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -18,7 +18,12 @@ from .camera import Camera, list_video_sources
 from .rf.hunt import RFHuntController
 from .rf.kismet_manager import KismetManager
 from .detection_logger import DetectionLogger
-from .model_manifest import load_manifest, validate_model, MANIFEST_FILENAME
+from .model_manifest import (
+    auto_update_manifest,
+    load_manifest,
+    validate_model,
+    MANIFEST_FILENAME,
+)
 from .detectors.yolo_detector import YOLODetector
 from .mavlink_io import MAVLinkIO
 from .osd import FpvOsd, build_osd_state
@@ -527,6 +532,9 @@ class Pipeline:
 
         logger.info("=== Hydra Detect v2.0 starting ===")
 
+        # Auto-update model manifest with any new .pt files
+        auto_update_manifest(self._models_dir)
+
         # Init subsystems — clean up on partial failure
         try:
             self._detector.load()
@@ -630,6 +638,9 @@ class Pipeline:
                 get_mavlink_video_status=self._get_mavlink_video_status,
                 on_tak_toggle=self._handle_tak_toggle,
                 get_tak_status=self._get_tak_status,
+                get_tak_targets=self._get_tak_targets,
+                add_tak_target=self._add_tak_target,
+                remove_tak_target=self._remove_tak_target,
                 get_profiles=self._get_profiles,
                 on_profile_switch=self._handle_profile_switch,
             )
@@ -1016,6 +1027,9 @@ class Pipeline:
             self._mavlink.send_statustext(
                 f"TGT LOCK: #{track_id} {t.label} [{mode.upper()}]", severity=5
             )
+        self._event_logger.log_action("lock", {
+            "track_id": track_id, "label": t.label, "mode": mode,
+        })
         return True
 
     def _handle_target_unlock(self, reason: str = "") -> None:
@@ -1032,6 +1046,9 @@ class Pipeline:
         if self._autonomous is not None:
             self._autonomous._operator_locked_track = None
         if prev_id is not None:
+            self._event_logger.log_action("unlock", {
+                "track_id": prev_id, "reason": reason or "operator",
+            })
             if reason == "lost":
                 logger.warning(
                     "Locked target #%d lost from tracker — auto-unlocking.",
@@ -1518,6 +1535,22 @@ class Pipeline:
             "callsign": self._cfg.get("tak", "callsign", fallback="HYDRA-1"),
             "events_sent": 0,
         }
+
+    def _get_tak_targets(self) -> list[dict]:
+        """Return current TAK unicast targets."""
+        if self._tak is not None:
+            return self._tak.get_unicast_targets()
+        return []
+
+    def _add_tak_target(self, host: str, port: int) -> None:
+        """Add a TAK unicast target at runtime."""
+        if self._tak is not None:
+            self._tak.add_unicast_target(host, port)
+
+    def _remove_tak_target(self, host: str, port: int) -> None:
+        """Remove a TAK unicast target at runtime."""
+        if self._tak is not None:
+            self._tak.remove_unicast_target(host, port)
 
     def _handle_stop_command(self) -> None:
         """Stop the pipeline gracefully from the web UI."""

--- a/hydra_detect/tak/tak_output.py
+++ b/hydra_detect/tak/tak_output.py
@@ -152,6 +152,27 @@ class TAKOutput:
         }
 
     # ------------------------------------------------------------------
+    # Runtime unicast target management
+    # ------------------------------------------------------------------
+    def add_unicast_target(self, host: str, port: int) -> None:
+        """Add a unicast target at runtime."""
+        target = (host, port)
+        if target not in self._unicast_targets:
+            self._unicast_targets.append(target)
+            logger.info("TAK unicast target added: %s:%d", host, port)
+
+    def remove_unicast_target(self, host: str, port: int) -> None:
+        """Remove a unicast target at runtime."""
+        target = (host, port)
+        if target in self._unicast_targets:
+            self._unicast_targets.remove(target)
+            logger.info("TAK unicast target removed: %s:%d", host, port)
+
+    def get_unicast_targets(self) -> list[dict]:
+        """Return current unicast targets for API."""
+        return [{"host": h, "port": p} for h, p in self._unicast_targets]
+
+    # ------------------------------------------------------------------
     # Sender thread
     # ------------------------------------------------------------------
     def _sender_loop(self) -> None:

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -872,6 +872,55 @@ async def api_tak_toggle(request: Request, authorization: Optional[str] = Header
     return JSONResponse({"error": "TAK output not available"}, status_code=503)
 
 
+@app.get("/api/tak/targets")
+async def api_get_tak_targets():
+    """List current TAK unicast targets."""
+    cb = stream_state.get_callback("get_tak_targets")
+    if cb:
+        return {"targets": cb()}
+    return {"targets": []}
+
+
+@app.post("/api/tak/targets")
+async def api_add_tak_target(
+    request: Request, authorization: Optional[str] = Header(None),
+):
+    """Add a TAK unicast target. Body: {"host": "ip", "port": 6969}"""
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    body = await request.json()
+    host = body.get("host", "").strip()
+    port = int(body.get("port", 6969))
+    if not host:
+        return JSONResponse({"error": "host required"}, status_code=400)
+    cb = stream_state.get_callback("add_tak_target")
+    if cb:
+        cb(host, port)
+        _audit(request, "add_tak_target", target=f"{host}:{port}")
+        return {"status": "added", "host": host, "port": port}
+    return JSONResponse({"error": "TAK not available"}, status_code=503)
+
+
+@app.delete("/api/tak/targets")
+async def api_remove_tak_target(
+    request: Request, authorization: Optional[str] = Header(None),
+):
+    """Remove a TAK unicast target. Body: {"host": "ip", "port": 6969}"""
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    body = await request.json()
+    host = body.get("host", "").strip()
+    port = int(body.get("port", 6969))
+    cb = stream_state.get_callback("remove_tak_target")
+    if cb:
+        cb(host, port)
+        _audit(request, "remove_tak_target", target=f"{host}:{port}")
+        return {"status": "removed"}
+    return JSONResponse({"error": "TAK not available"}, status_code=503)
+
+
 @app.post("/api/mavlink-video/tune")
 async def api_mavlink_video_tune(request: Request, authorization: Optional[str] = Header(None)):
     """Live-tune MAVLink video params. Body: {width, height, quality, max_fps} (all optional)"""

--- a/tests/test_tak_unicast_manifest.py
+++ b/tests/test_tak_unicast_manifest.py
@@ -1,0 +1,239 @@
+"""Tests for TAK unicast target management and auto-manifest generation (PR #14)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from hydra_detect.model_manifest import auto_update_manifest, load_manifest
+from hydra_detect.tak.tak_output import TAKOutput
+
+
+# =====================================================================
+# TAK unicast target management
+# =====================================================================
+
+class TestTAKUnicastTargets:
+    def _make_tak(self) -> TAKOutput:
+        mav = MagicMock()
+        return TAKOutput(mav)
+
+    def test_add_unicast_target(self):
+        tak = self._make_tak()
+        tak.add_unicast_target("10.0.0.1", 6969)
+        targets = tak.get_unicast_targets()
+        assert len(targets) == 1
+        assert targets[0] == {"host": "10.0.0.1", "port": 6969}
+
+    def test_add_duplicate_ignored(self):
+        tak = self._make_tak()
+        tak.add_unicast_target("10.0.0.1", 6969)
+        tak.add_unicast_target("10.0.0.1", 6969)
+        assert len(tak.get_unicast_targets()) == 1
+
+    def test_add_multiple_targets(self):
+        tak = self._make_tak()
+        tak.add_unicast_target("10.0.0.1", 6969)
+        tak.add_unicast_target("10.0.0.2", 4242)
+        targets = tak.get_unicast_targets()
+        assert len(targets) == 2
+
+    def test_remove_unicast_target(self):
+        tak = self._make_tak()
+        tak.add_unicast_target("10.0.0.1", 6969)
+        tak.add_unicast_target("10.0.0.2", 4242)
+        tak.remove_unicast_target("10.0.0.1", 6969)
+        targets = tak.get_unicast_targets()
+        assert len(targets) == 1
+        assert targets[0] == {"host": "10.0.0.2", "port": 4242}
+
+    def test_remove_nonexistent_is_noop(self):
+        tak = self._make_tak()
+        tak.add_unicast_target("10.0.0.1", 6969)
+        tak.remove_unicast_target("192.168.1.1", 9999)
+        assert len(tak.get_unicast_targets()) == 1
+
+    def test_get_empty_targets(self):
+        tak = self._make_tak()
+        assert tak.get_unicast_targets() == []
+
+    def test_different_ports_are_distinct(self):
+        tak = self._make_tak()
+        tak.add_unicast_target("10.0.0.1", 6969)
+        tak.add_unicast_target("10.0.0.1", 4242)
+        assert len(tak.get_unicast_targets()) == 2
+
+
+# =====================================================================
+# TAK unicast API endpoints
+# =====================================================================
+
+class TestTAKUnicastAPI:
+    @pytest.fixture
+    def client(self):
+        from hydra_detect.web.server import app, stream_state
+        from starlette.testclient import TestClient
+
+        # Wire up mock TAK callbacks
+        targets: list[tuple[str, int]] = []
+
+        def get_targets():
+            return [{"host": h, "port": p} for h, p in targets]
+
+        def add_target(host, port):
+            t = (host, port)
+            if t not in targets:
+                targets.append(t)
+
+        def remove_target(host, port):
+            t = (host, port)
+            if t in targets:
+                targets.remove(t)
+
+        stream_state.set_callbacks(
+            get_tak_targets=get_targets,
+            add_tak_target=add_target,
+            remove_tak_target=remove_target,
+        )
+        yield TestClient(app)
+        # Clean up callbacks
+        stream_state._callbacks.pop("get_tak_targets", None)
+        stream_state._callbacks.pop("add_tak_target", None)
+        stream_state._callbacks.pop("remove_tak_target", None)
+
+    def test_get_empty_targets(self, client):
+        resp = client.get("/api/tak/targets")
+        assert resp.status_code == 200
+        assert resp.json() == {"targets": []}
+
+    def test_add_target(self, client):
+        resp = client.post("/api/tak/targets", json={"host": "10.0.0.1", "port": 6969})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "added"
+
+    def test_add_then_get(self, client):
+        client.post("/api/tak/targets", json={"host": "10.0.0.1", "port": 6969})
+        resp = client.get("/api/tak/targets")
+        targets = resp.json()["targets"]
+        assert len(targets) == 1
+        assert targets[0]["host"] == "10.0.0.1"
+
+    def test_add_requires_host(self, client):
+        resp = client.post("/api/tak/targets", json={"port": 6969})
+        assert resp.status_code == 400
+
+    def test_remove_target(self, client):
+        client.post("/api/tak/targets", json={"host": "10.0.0.1", "port": 6969})
+        resp = client.request("DELETE", "/api/tak/targets", json={"host": "10.0.0.1", "port": 6969})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "removed"
+
+    def test_get_no_callback_returns_empty(self):
+        """When no callbacks are wired, GET returns empty targets."""
+        from hydra_detect.web.server import app, stream_state
+        from starlette.testclient import TestClient
+
+        stream_state._callbacks.pop("get_tak_targets", None)
+        client = TestClient(app)
+        resp = client.get("/api/tak/targets")
+        assert resp.status_code == 200
+        assert resp.json() == {"targets": []}
+
+
+# =====================================================================
+# Auto-manifest generation
+# =====================================================================
+
+class TestAutoUpdateManifest:
+    def test_adds_new_models(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            (d / "yolov8n.pt").write_bytes(b"fake model 1")
+            (d / "yolov8s.pt").write_bytes(b"fake model 2")
+
+            result = auto_update_manifest(d)
+            assert result is True
+
+            manifest = load_manifest(d / "manifest.json")
+            assert manifest is not None
+            assert len(manifest) == 2
+            names = {e["filename"] for e in manifest}
+            assert names == {"yolov8n.pt", "yolov8s.pt"}
+
+    def test_skips_existing_models(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            (d / "yolov8n.pt").write_bytes(b"fake model 1")
+
+            # First scan
+            auto_update_manifest(d)
+            manifest_before = load_manifest(d / "manifest.json")
+
+            # Second scan -- should not update
+            result = auto_update_manifest(d)
+            assert result is False
+
+            manifest_after = load_manifest(d / "manifest.json")
+            assert manifest_before == manifest_after
+
+    def test_creates_manifest_if_missing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            (d / "test.pt").write_bytes(b"model data")
+
+            manifest_path = d / "manifest.json"
+            assert not manifest_path.exists()
+
+            auto_update_manifest(d)
+            assert manifest_path.exists()
+            manifest = json.loads(manifest_path.read_text())
+            assert len(manifest) == 1
+            assert manifest[0]["filename"] == "test.pt"
+
+    def test_adds_only_new_to_existing_manifest(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            (d / "existing.pt").write_bytes(b"existing model")
+
+            # Create initial manifest
+            auto_update_manifest(d)
+
+            # Add a new model
+            (d / "new_model.pt").write_bytes(b"new model data")
+            result = auto_update_manifest(d)
+            assert result is True
+
+            manifest = load_manifest(d / "manifest.json")
+            assert len(manifest) == 2
+            names = {e["filename"] for e in manifest}
+            assert "existing.pt" in names
+            assert "new_model.pt" in names
+
+    def test_entry_has_expected_fields(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            (d / "model.pt").write_bytes(b"x" * 1024)
+
+            auto_update_manifest(d)
+            manifest = load_manifest(d / "manifest.json")
+            entry = manifest[0]
+            assert "filename" in entry
+            assert "sha256" in entry
+            assert "size_mb" in entry
+            assert "input_size" in entry
+            assert "classes" in entry
+            assert len(entry["sha256"]) == 64
+
+    def test_nonexistent_directory_returns_false(self):
+        result = auto_update_manifest(Path("/nonexistent/path"))
+        assert result is False
+
+    def test_empty_directory_no_update(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            d = Path(tmpdir)
+            result = auto_update_manifest(d)
+            assert result is False


### PR DESCRIPTION
## Summary
- **TAK unicast target management** (Issue #62): Add/remove/list unicast CoT targets at runtime via `GET/POST/DELETE /api/tak/targets` endpoints, wired through pipeline callbacks to `TAKOutput.add_unicast_target()`, `remove_unicast_target()`, and `get_unicast_targets()` methods
- **Auto-manifest generation** (Issue #61): New `auto_update_manifest()` function scans `models/` on startup and adds any new `.pt` files to `manifest.json` with hash, size, and default metadata -- no manual manifest updates needed when dropping in new models
- **20 new tests** covering unicast target add/remove/get on TAKOutput, API endpoint validation, and auto-manifest create/update/skip/edge-case behavior

## Test plan
- [x] `pytest tests/test_tak_unicast_manifest.py -v` -- 20/20 pass
- [x] `pytest tests/test_tak.py tests/test_model_manifest.py -v` -- existing TAK and manifest tests still pass
- [x] Full suite (`pytest tests/ -x -q`) -- 581 passed
- [ ] Deploy to Jetson and verify TAK target add/remove from ops dashboard
- [ ] Drop a new `.pt` file into `models/` and confirm auto-manifest picks it up on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)