### PR TITLE
feat: event timeline and vehicle track logging for after-action review

### DIFF
--- a/hydra_detect/event_logger.py
+++ b/hydra_detect/event_logger.py
@@ -1,0 +1,155 @@
+"""Event timeline logger — records operator actions and vehicle telemetry for after-action review."""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class EventLogger:
+    """Append-only JSONL logger for mission events and vehicle track.
+
+    Events include: operator actions (lock, unlock, follow, strike, abort,
+    mode changes), system state changes (camera lost, low light), and
+    vehicle telemetry (GPS position at 1 Hz).
+    """
+
+    def __init__(self, log_dir: str | Path, callsign: str = "HYDRA"):
+        self._log_dir = Path(log_dir)
+        self._log_dir.mkdir(parents=True, exist_ok=True)
+        self._callsign = callsign
+        self._mission_name: str | None = None
+        self._file = None
+        self._lock = threading.Lock()
+        self._track_interval = 1.0  # GPS logging interval seconds
+        self._last_track_time = 0.0
+
+    def start_mission(self, name: str) -> None:
+        """Begin a new mission — opens a new JSONL event file."""
+        with self._lock:
+            self._close_file()
+            self._mission_name = name
+            ts = time.strftime("%Y%m%d_%H%M%S")
+            filename = f"{self._callsign}_{ts}_{name}.jsonl"
+            filepath = self._log_dir / filename
+            self._file = open(filepath, "a")
+            self._log_event("mission_start", {"name": name})
+            logger.info("Event timeline started: %s", filepath)
+
+    def end_mission(self) -> None:
+        """End the current mission."""
+        with self._lock:
+            if self._mission_name:
+                self._log_event("mission_end", {"name": self._mission_name})
+            self._close_file()
+            self._mission_name = None
+
+    def log_action(self, action: str, details: dict[str, Any] | None = None) -> None:
+        """Log an operator action (lock, unlock, follow, strike, abort, etc.)."""
+        with self._lock:
+            self._log_event("action", {"action": action, **(details or {})})
+
+    def log_vehicle_track(self, lat: float, lon: float, alt: float,
+                          heading: float | None = None,
+                          speed: float | None = None,
+                          mode: str | None = None) -> None:
+        """Log vehicle position at 1 Hz rate limit."""
+        now = time.monotonic()
+        if now - self._last_track_time < self._track_interval:
+            return
+        self._last_track_time = now
+
+        with self._lock:
+            data: dict[str, Any] = {"lat": lat, "lon": lon, "alt": alt}
+            if heading is not None:
+                data["heading"] = heading
+            if speed is not None:
+                data["speed"] = speed
+            if mode is not None:
+                data["mode"] = mode
+            self._log_event("track", data)
+
+    def log_detection(self, track_id: int, label: str, confidence: float,
+                      lat: float | None = None, lon: float | None = None) -> None:
+        """Log a detection event."""
+        with self._lock:
+            self._log_event("detection", {
+                "track_id": track_id, "label": label,
+                "confidence": round(confidence, 3),
+                "lat": lat, "lon": lon,
+            })
+
+    def log_state_change(self, state: str, details: dict[str, Any] | None = None) -> None:
+        """Log a system state change (camera_lost, camera_restored, low_light, etc.)."""
+        with self._lock:
+            self._log_event("state", {"state": state, **(details or {})})
+
+    def _log_event(self, event_type: str, data: dict[str, Any]) -> None:
+        """Write a single event record to the JSONL file."""
+        if self._file is None:
+            return
+        record = {
+            "ts": time.time(),
+            "type": event_type,
+            "callsign": self._callsign,
+            **data,
+        }
+        try:
+            self._file.write(json.dumps(record) + "\n")
+            self._file.flush()
+        except Exception as exc:
+            logger.debug("Event logger write error: %s", exc)
+
+    def _close_file(self) -> None:
+        if self._file is not None:
+            try:
+                self._file.close()
+            except Exception:
+                pass
+            self._file = None
+
+    def stop(self) -> None:
+        """Close any open mission file."""
+        self.end_mission()
+
+    def get_status(self) -> dict:
+        """Return status for web API."""
+        return {
+            "mission_active": self._mission_name is not None,
+            "mission_name": self._mission_name,
+        }
+
+    def get_recent_events(self, max_events: int = 200) -> list[dict]:
+        """Read the last N events from the current mission file.
+
+        Returns events in chronological order. Reads from the current open
+        file (by reopening in read mode) so we don't disturb the append handle.
+        """
+        with self._lock:
+            if self._file is None:
+                return []
+            filepath = self._file.name
+        # Read from disk — the file is flushed after every write
+        try:
+            path = Path(filepath)
+            if not path.exists():
+                return []
+            lines = path.read_text().strip().splitlines()
+            # Take last N lines
+            recent = lines[-max_events:]
+            events = []
+            for line in recent:
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+            return events
+        except Exception as exc:
+            logger.debug("Event logger read error: %s", exc)
+            return []

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -18,6 +18,7 @@ from .camera import Camera, list_video_sources
 from .rf.hunt import RFHuntController
 from .rf.kismet_manager import KismetManager
 from .detection_logger import DetectionLogger
+from .event_logger import EventLogger
 from .model_manifest import load_manifest, validate_model, MANIFEST_FILENAME
 from .detectors.yolo_detector import YOLODetector
 from .mavlink_io import MAVLinkIO
@@ -450,6 +451,15 @@ class Pipeline:
             model_hash=_model_hash,
         )
 
+        # Event timeline logger (operator actions + vehicle track)
+        self._event_logger = EventLogger(
+            log_dir=self._cfg.get(
+                "logging", "log_dir", fallback="./output_data/logs"
+            ),
+            callsign=self._cfg.get("tak", "callsign", fallback="HYDRA"),
+        )
+        self._event_logger.start_mission("default")
+
         # Web UI
         self._web_enabled = self._cfg.getboolean("web", "enabled", fallback=True)
         self._web_host = self._cfg.get("web", "host", fallback="0.0.0.0")
@@ -632,6 +642,8 @@ class Pipeline:
                 get_tak_status=self._get_tak_status,
                 get_profiles=self._get_profiles,
                 on_profile_switch=self._handle_profile_switch,
+                get_events=self._get_events,
+                get_event_status=self._event_logger.get_status,
             )
 
             stream_state.update_stats(
@@ -729,6 +741,7 @@ class Pipeline:
             if self._cam_fail_count >= self._CAM_FAIL_THRESHOLD and not self._cam_lost:
                 self._cam_lost = True
                 logger.warning("Camera lost — entering degraded mode.")
+                self._event_logger.log_state_change("camera_lost")
                 if self._mavlink is not None:
                     self._mavlink.send_statustext("HYDRA: CAM LOST", severity=4)
                 if self._autonomous is not None:
@@ -739,6 +752,7 @@ class Pipeline:
             self._cam_lost = False
             self._cam_fail_count = 0
             logger.info("Camera restored — exiting degraded mode.")
+            self._event_logger.log_state_change("camera_restored")
             if self._mavlink is not None:
                 self._mavlink.send_statustext("HYDRA: CAM RESTORED", severity=5)
             if self._autonomous is not None:
@@ -777,6 +791,18 @@ class Pipeline:
             gps = None
             if self._mavlink is not None:
                 gps = self._mavlink.get_gps()
+
+            # Vehicle track logging at 1 Hz (rate-limited inside)
+            if gps is not None and gps.get("fix", 0) >= 3:
+                telem = self._mavlink.get_telemetry()
+                self._event_logger.log_vehicle_track(
+                    lat=gps.get("lat", 0.0),
+                    lon=gps.get("lon", 0.0),
+                    alt=gps.get("alt", 0.0),
+                    heading=telem.get("heading"),
+                    speed=telem.get("groundspeed"),
+                    mode=telem.get("vehicle_mode"),
+                )
 
             # MAVLink alerts (per-label throttled)
             if self._mavlink is not None and len(track_result) > 0:
@@ -1016,6 +1042,9 @@ class Pipeline:
             self._mavlink.send_statustext(
                 f"TGT LOCK: #{track_id} {t.label} [{mode.upper()}]", severity=5
             )
+        self._event_logger.log_action("lock", {
+            "track_id": track_id, "label": t.label, "mode": mode,
+        })
         return True
 
     def _handle_target_unlock(self, reason: str = "") -> None:
@@ -1032,6 +1061,9 @@ class Pipeline:
         if self._autonomous is not None:
             self._autonomous._operator_locked_track = None
         if prev_id is not None:
+            self._event_logger.log_action("unlock", {
+                "track_id": prev_id, "reason": reason or "operator",
+            })
             if reason == "lost":
                 logger.warning(
                     "Locked target #%d lost from tracker — auto-unlocking.",
@@ -1072,6 +1104,9 @@ class Pipeline:
             self._locked_track_id = track_id
             self._lock_mode = "strike"
         logger.info("STRIKE LOCK: #%d (%s)", track_id, target_track.label)
+        self._event_logger.log_action("strike", {
+            "track_id": track_id, "label": target_track.label,
+        })
 
         # If no MAVLink, just visual — no vehicle command
         if self._mavlink is None:
@@ -1142,6 +1177,12 @@ class Pipeline:
             }
             for t in result
         ]
+
+    def _get_events(self) -> dict:
+        """Return recent events from the current mission."""
+        events = self._event_logger.get_recent_events(max_events=200)
+        status = self._event_logger.get_status()
+        return {"events": events, **status}
 
     def _get_camera_sources(self) -> list[dict]:
         """Return available video sources with current source marked."""
@@ -1554,6 +1595,7 @@ class Pipeline:
         self._camera.close()
         self._detector.unload()
         self._det_logger.stop()
+        self._event_logger.stop()
         if self._mavlink is not None:
             self._mavlink.close()
         logger.info("=== Hydra Detect stopped ===")

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -536,6 +536,24 @@ async def api_recent_detections():
     return []
 
 
+@app.get("/api/events")
+async def api_events():
+    """Get event timeline for the current or most recent mission."""
+    cb = stream_state.get_callback("get_events")
+    if cb:
+        return cb()
+    return {"events": []}
+
+
+@app.get("/api/events/status")
+async def api_events_status():
+    """Get event logger mission status."""
+    cb = stream_state.get_callback("get_event_status")
+    if cb:
+        return cb()
+    return {"mission_active": False, "mission_name": None}
+
+
 @app.get("/api/camera/sources")
 async def api_camera_sources():
     """Return available video sources."""

--- a/tests/test_camera_loss.py
+++ b/tests/test_camera_loss.py
@@ -39,6 +39,7 @@ def _make_pipeline(**overrides) -> Pipeline:
     p._cam_fail_count = 0
     p._cam_lost = False
     p._CAM_FAIL_THRESHOLD = 2
+    p._event_logger = MagicMock()
     return p
 
 

--- a/tests/test_event_logger.py
+++ b/tests/test_event_logger.py
@@ -1,0 +1,341 @@
+"""Tests for EventLogger — operator action and vehicle track logging."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from hydra_detect.event_logger import EventLogger
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_logger(tmp_path: Path, **kwargs) -> EventLogger:
+    """Create an EventLogger writing to tmp_path with test defaults."""
+    defaults = dict(
+        log_dir=str(tmp_path / "events"),
+        callsign="TEST",
+    )
+    defaults.update(kwargs)
+    return EventLogger(**defaults)
+
+
+def _read_events(tmp_path: Path) -> list[dict]:
+    """Read all JSONL event files from the events directory."""
+    events_dir = tmp_path / "events"
+    if not events_dir.exists():
+        return []
+    events = []
+    for f in sorted(events_dir.glob("*.jsonl")):
+        for line in f.read_text().strip().splitlines():
+            events.append(json.loads(line))
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Tests: mission start/end
+# ---------------------------------------------------------------------------
+
+class TestMissionLifecycle:
+    def test_start_end_mission_creates_file(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("patrol_alpha")
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        assert len(events) == 2
+        assert events[0]["type"] == "mission_start"
+        assert events[0]["name"] == "patrol_alpha"
+        assert events[0]["callsign"] == "TEST"
+        assert events[1]["type"] == "mission_end"
+        assert events[1]["name"] == "patrol_alpha"
+
+    def test_start_mission_closes_previous(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("mission_1")
+        el.start_mission("mission_2")
+        el.end_mission()
+
+        events_dir = tmp_path / "events"
+        files = list(events_dir.glob("*.jsonl"))
+        assert len(files) == 2
+
+    def test_stop_ends_mission(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        el.stop()
+
+        events = _read_events(tmp_path)
+        types = [e["type"] for e in events]
+        assert "mission_end" in types
+
+
+# ---------------------------------------------------------------------------
+# Tests: log_action
+# ---------------------------------------------------------------------------
+
+class TestLogAction:
+    def test_log_action_writes_to_file(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        el.log_action("lock", {"track_id": 5, "label": "person"})
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        actions = [e for e in events if e["type"] == "action"]
+        assert len(actions) == 1
+        assert actions[0]["action"] == "lock"
+        assert actions[0]["track_id"] == 5
+        assert actions[0]["label"] == "person"
+
+    def test_log_action_with_no_details(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        el.log_action("abort")
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        actions = [e for e in events if e["type"] == "action"]
+        assert len(actions) == 1
+        assert actions[0]["action"] == "abort"
+
+
+# ---------------------------------------------------------------------------
+# Tests: log_vehicle_track (1 Hz rate limit)
+# ---------------------------------------------------------------------------
+
+class TestVehicleTrack:
+    def test_track_respects_rate_limit(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+
+        # First call should write
+        el.log_vehicle_track(lat=35.0, lon=-80.0, alt=100.0)
+        # Immediate second call should be rate-limited
+        el.log_vehicle_track(lat=35.001, lon=-80.001, alt=101.0)
+
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        tracks = [e for e in events if e["type"] == "track"]
+        assert len(tracks) == 1
+        assert tracks[0]["lat"] == 35.0
+
+    def test_track_writes_after_interval(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el._track_interval = 0.01  # Override to 10ms for fast test
+        el.start_mission("test")
+
+        el.log_vehicle_track(lat=35.0, lon=-80.0, alt=100.0)
+        time.sleep(0.02)  # Wait past interval
+        el.log_vehicle_track(lat=35.001, lon=-80.001, alt=101.0)
+
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        tracks = [e for e in events if e["type"] == "track"]
+        assert len(tracks) == 2
+
+    def test_track_includes_optional_fields(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+
+        el.log_vehicle_track(
+            lat=35.0, lon=-80.0, alt=100.0,
+            heading=270.0, speed=5.5, mode="AUTO",
+        )
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        tracks = [e for e in events if e["type"] == "track"]
+        assert len(tracks) == 1
+        assert tracks[0]["heading"] == 270.0
+        assert tracks[0]["speed"] == 5.5
+        assert tracks[0]["mode"] == "AUTO"
+
+    def test_track_omits_none_optional_fields(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+
+        el.log_vehicle_track(lat=35.0, lon=-80.0, alt=100.0)
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        tracks = [e for e in events if e["type"] == "track"]
+        assert "heading" not in tracks[0]
+        assert "speed" not in tracks[0]
+        assert "mode" not in tracks[0]
+
+
+# ---------------------------------------------------------------------------
+# Tests: log_detection
+# ---------------------------------------------------------------------------
+
+class TestLogDetection:
+    def test_log_detection_writes_correct_fields(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        el.log_detection(
+            track_id=3, label="car", confidence=0.87654,
+            lat=35.1, lon=-80.2,
+        )
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        dets = [e for e in events if e["type"] == "detection"]
+        assert len(dets) == 1
+        assert dets[0]["track_id"] == 3
+        assert dets[0]["label"] == "car"
+        assert dets[0]["confidence"] == 0.877  # rounded to 3 decimal
+        assert dets[0]["lat"] == 35.1
+        assert dets[0]["lon"] == -80.2
+
+
+# ---------------------------------------------------------------------------
+# Tests: log_state_change
+# ---------------------------------------------------------------------------
+
+class TestLogStateChange:
+    def test_log_state_change_writes(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        el.log_state_change("camera_lost")
+        el.log_state_change("camera_restored", {"downtime_sec": 5.2})
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        states = [e for e in events if e["type"] == "state"]
+        assert len(states) == 2
+        assert states[0]["state"] == "camera_lost"
+        assert states[1]["state"] == "camera_restored"
+        assert states[1]["downtime_sec"] == 5.2
+
+
+# ---------------------------------------------------------------------------
+# Tests: no write when no mission active
+# ---------------------------------------------------------------------------
+
+class TestNoMissionGuard:
+    def test_no_write_without_mission(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        # No mission started
+        el.log_action("lock", {"track_id": 1})
+        el.log_vehicle_track(lat=0.0, lon=0.0, alt=0.0)
+        el.log_detection(track_id=1, label="person", confidence=0.9)
+        el.log_state_change("camera_lost")
+
+        events = _read_events(tmp_path)
+        assert len(events) == 0
+
+    def test_no_write_after_mission_ended(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        el.end_mission()
+
+        el.log_action("lock", {"track_id": 1})
+
+        events = _read_events(tmp_path)
+        # Only mission_start and mission_end
+        assert len(events) == 2
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_status
+# ---------------------------------------------------------------------------
+
+class TestGetStatus:
+    def test_status_no_mission(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        status = el.get_status()
+        assert status["mission_active"] is False
+        assert status["mission_name"] is None
+
+    def test_status_active_mission(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("recon_bravo")
+        status = el.get_status()
+        assert status["mission_active"] is True
+        assert status["mission_name"] == "recon_bravo"
+        el.stop()
+
+    def test_status_after_end(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        el.end_mission()
+        status = el.get_status()
+        assert status["mission_active"] is False
+        assert status["mission_name"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: get_recent_events
+# ---------------------------------------------------------------------------
+
+class TestGetRecentEvents:
+    def test_get_recent_events_returns_events(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        el.log_action("lock", {"track_id": 1})
+        el.log_action("unlock", {"track_id": 1})
+
+        events = el.get_recent_events()
+        assert len(events) == 3  # mission_start + 2 actions
+        assert events[0]["type"] == "mission_start"
+        assert events[1]["action"] == "lock"
+        assert events[2]["action"] == "unlock"
+        el.stop()
+
+    def test_get_recent_events_empty_when_no_mission(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        events = el.get_recent_events()
+        assert events == []
+
+    def test_get_recent_events_respects_max(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        for i in range(10):
+            el.log_action("test", {"i": i})
+
+        events = el.get_recent_events(max_events=3)
+        assert len(events) == 3
+        el.stop()
+
+
+# ---------------------------------------------------------------------------
+# Tests: event record format
+# ---------------------------------------------------------------------------
+
+class TestEventFormat:
+    def test_event_has_timestamp(self, tmp_path: Path):
+        el = _make_logger(tmp_path)
+        el.start_mission("test")
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        for e in events:
+            assert "ts" in e
+            assert isinstance(e["ts"], float)
+
+    def test_event_has_callsign(self, tmp_path: Path):
+        el = _make_logger(tmp_path, callsign="HYDRA-USV")
+        el.start_mission("test")
+        el.end_mission()
+
+        events = _read_events(tmp_path)
+        for e in events:
+            assert e["callsign"] == "HYDRA-USV"
+
+    def test_file_naming_convention(self, tmp_path: Path):
+        el = _make_logger(tmp_path, callsign="HYDRA")
+        el.start_mission("patrol")
+        el.stop()
+
+        events_dir = tmp_path / "events"
+        files = list(events_dir.glob("*.jsonl"))
+        assert len(files) == 1
+        name = files[0].name
+        assert name.startswith("HYDRA_")
+        assert "_patrol.jsonl" in name

--- a/tests/test_pipeline_callbacks.py
+++ b/tests/test_pipeline_callbacks.py
@@ -38,6 +38,7 @@ def _make_pipeline(**overrides) -> Pipeline:
     p._camera.width = 640
     p._mavlink = None
     p._autonomous = None
+    p._event_logger = MagicMock()
     p._init_target_state()
     p._running = False
     return p


### PR DESCRIPTION
## Summary
- Add `EventLogger` module that records operator actions (lock, unlock, strike), vehicle telemetry at 1 Hz, and system state changes (camera loss/restore) to append-only JSONL files per mission
- Integrate with pipeline: GPS track logging, lock/unlock/strike handlers, camera loss/restore state changes, mission lifecycle (auto-start default mission)
- Add REST API endpoints `GET /api/events` and `GET /api/events/status` for web UI consumption
- 22 unit tests covering all event types, 1 Hz rate limiting, mission lifecycle, and edge cases

## Test plan
- [x] All 612 existing tests pass (0 regressions)
- [x] 22 new tests for EventLogger pass
- [ ] Verify JSONL files written to `output_data/logs/` during live run
- [ ] Confirm `GET /api/events` returns timeline data in browser
- [ ] Validate 1 Hz GPS track rate on Jetson with real GPS fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)