### PR TITLE
feat: after-action map replay with vehicle track and timeline

### DIFF
--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -955,12 +955,15 @@ async def review_page(request: Request):
 
 @app.get("/api/review/logs")
 async def api_review_logs():
-    """List available detection log files."""
+    """List available detection log files and event timeline files."""
+    import json as _json
+
     cb = stream_state.get_callback("get_log_dir")
     log_dir = cb() if cb else "/data/logs"
     image_dir_cb = stream_state.get_callback("get_image_dir")
     image_dir = image_dir_cb() if image_dir_cb else "/data/images"
     result = []
+    event_logs = []
     log_path = Path(log_dir)
     if log_path.is_dir():
         for f in sorted(log_path.iterdir(), reverse=True):
@@ -970,7 +973,21 @@ async def api_review_logs():
                     "size_kb": round(f.stat().st_size / 1024, 1),
                     "modified": f.stat().st_mtime,
                 })
-    return {"logs": result, "image_dir": image_dir}
+        # Scan for event timeline JSONL files
+        for f in sorted(log_path.glob("*.jsonl"), key=lambda p: p.stat().st_mtime, reverse=True):
+            try:
+                with open(f) as fh:
+                    first_line = fh.readline().strip()
+                    if first_line:
+                        record = _json.loads(first_line)
+                        if record.get("type") in ("mission_start", "track", "action", "state"):
+                            event_logs.append({
+                                "filename": f.name,
+                                "size_kb": round(f.stat().st_size / 1024, 1),
+                            })
+            except Exception:
+                continue
+    return {"logs": result, "event_logs": event_logs, "image_dir": image_dir}
 
 
 @app.get("/api/review/log/{filename}")
@@ -1019,6 +1036,36 @@ async def api_review_log(filename: str):
                 records.append(row)
 
     return {"filename": filename, "count": len(records), "detections": records}
+
+
+@app.get("/api/review/events/{filename}")
+async def api_review_events(filename: str):
+    """Return events from an event timeline JSONL file."""
+    import json as _json
+    if "/" in filename or "\\" in filename or ".." in filename:
+        return JSONResponse({"error": "invalid filename"}, status_code=400)
+
+    cb = stream_state.get_callback("get_log_dir")
+    log_dir = Path(cb() if cb else "/data/logs")
+    filepath = log_dir / filename
+
+    if not filepath.exists() or not filepath.suffix == ".jsonl":
+        return JSONResponse({"error": "not found"}, status_code=404)
+
+    events: list = []
+    try:
+        with open(filepath) as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    try:
+                        events.append(_json.loads(line))
+                    except _json.JSONDecodeError:
+                        continue
+    except Exception:
+        return JSONResponse({"error": "read error"}, status_code=500)
+
+    return {"events": events, "filename": filename}
 
 
 @app.get("/api/logs")

--- a/hydra_detect/web/templates/review.html
+++ b/hydra_detect/web/templates/review.html
@@ -35,6 +35,7 @@
         .btn { background: #1a1a1a; color: #00ff88; border: 1px solid #00ff88; padding: 6px 12px; cursor: pointer; font-family: inherit; font-size: 12px; margin-top: 4px; }
         .btn:hover { background: #00ff88; color: #000; }
         .popup-img { max-width: 280px; margin-top: 6px; border: 1px solid #444; }
+        .timeline-event { padding: 2px 0; border-bottom: 1px solid #222; color: #aaa; }
         .leaflet-popup-content-wrapper { background: #1a1a1a; color: #e0e0e0; border-radius: 4px; }
         .leaflet-popup-tip { background: #1a1a1a; }
         .leaflet-popup-content { font-family: 'Courier New', monospace; font-size: 12px; }
@@ -72,6 +73,25 @@
                     <input type="checkbox" id="showMarkers" checked>
                     <label for="showMarkers">Show markers</label>
                 </div>
+            </div>
+            <div class="section">
+                <h3>VEHICLE TRACK</h3>
+                <select id="eventSelect"><option value="">-- Select event log --</option></select>
+                <div class="toggle-row">
+                    <input type="checkbox" id="showVehicleTrack" checked>
+                    <label for="showVehicleTrack">Show vehicle path</label>
+                </div>
+                <div class="toggle-row">
+                    <input type="checkbox" id="showEvents" checked>
+                    <label for="showEvents">Show operator actions</label>
+                </div>
+            </div>
+            <div class="section">
+                <h3>TIMELINE</h3>
+                <input type="range" id="timeSlider" min="0" max="100" value="100" step="1">
+                <div class="stat">Time: <span id="timeValue">--:--:--</span></div>
+                <div class="stat">Events: <span id="eventCount">-</span></div>
+                <div id="eventList" style="max-height: 150px; overflow-y: auto; font-size: 11px; margin-top: 8px;"></div>
             </div>
             <div class="section">
                 <h3>SUMMARY</h3>
@@ -305,6 +325,146 @@
             URL.revokeObjectURL(url);
         }
 
+        // --- Vehicle track / timeline ---
+        let allEvents = [];
+        let vehicleTrackLayer = L.layerGroup().addTo(map);
+        let eventMarkerLayer = L.layerGroup().addTo(map);
+        let vehicleMarker = null;
+
+        async function loadEventLogList() {
+            const res = await fetch('/api/review/logs');
+            const data = await res.json();
+            const sel = document.getElementById('eventSelect');
+            sel.textContent = '';
+            const defOpt = document.createElement('option');
+            defOpt.value = '';
+            defOpt.textContent = '-- Select event log --';
+            sel.appendChild(defOpt);
+            for (const log of (data.event_logs || [])) {
+                const opt = document.createElement('option');
+                opt.value = log.filename;
+                opt.textContent = log.filename;
+                sel.appendChild(opt);
+            }
+        }
+
+        async function loadEventLog(filename) {
+            if (!filename) return;
+            const res = await fetch(`/api/review/events/${encodeURIComponent(filename)}`);
+            const data = await res.json();
+            allEvents = data.events || [];
+
+            document.getElementById('eventCount').textContent = allEvents.length;
+
+            const slider = document.getElementById('timeSlider');
+            slider.max = allEvents.length > 0 ? allEvents.length - 1 : 0;
+            slider.value = slider.max;
+
+            renderVehicleTrack();
+            renderTimeline(parseInt(slider.max));
+        }
+
+        function renderVehicleTrack() {
+            vehicleTrackLayer.clearLayers();
+            eventMarkerLayer.clearLayers();
+
+            const showTrack = document.getElementById('showVehicleTrack').checked;
+            const showEvts = document.getElementById('showEvents').checked;
+
+            // Extract track points
+            const trackPoints = allEvents
+                .filter(e => e.type === 'track' && e.lat != null && e.lon != null)
+                .map(e => [e.lat, e.lon]);
+
+            if (showTrack && trackPoints.length > 1) {
+                L.polyline(trackPoints, {
+                    color: '#00aaff',
+                    weight: 3,
+                    opacity: 0.7,
+                }).addTo(vehicleTrackLayer);
+            }
+
+            // Event markers (actions)
+            if (showEvts) {
+                const actionEvents = allEvents.filter(e =>
+                    e.type === 'action' || e.type === 'state' || e.type === 'mission_start' || e.type === 'mission_end'
+                );
+                const trackEvts = allEvents.filter(e => e.type === 'track');
+                for (const evt of actionEvents) {
+                    let closest = null;
+                    let minDiff = Infinity;
+                    for (const t of trackEvts) {
+                        const diff = Math.abs((t.ts || 0) - (evt.ts || 0));
+                        if (diff < minDiff) { minDiff = diff; closest = t; }
+                    }
+                    if (closest && closest.lat && closest.lon) {
+                        const label = evt.action || evt.state || evt.type;
+                        const marker = L.circleMarker([closest.lat, closest.lon], {
+                            radius: 8,
+                            fillColor: '#ffaa00',
+                            color: '#fff',
+                            weight: 2,
+                            fillOpacity: 0.9,
+                        });
+                        const time = new Date((evt.ts || 0) * 1000).toLocaleTimeString('en-US', {hour12: false});
+                        marker.bindPopup(`<b>${esc(label)}</b><br>Time: ${time}`);
+                        eventMarkerLayer.addLayer(marker);
+                    }
+                }
+            }
+
+            if (trackPoints.length > 0) {
+                map.fitBounds(trackPoints, { padding: [30, 30] });
+            }
+        }
+
+        function renderTimeline(index) {
+            if (allEvents.length === 0) return;
+
+            const idx = Math.min(index, allEvents.length - 1);
+            const evt = allEvents[idx];
+
+            if (evt.ts) {
+                const time = new Date(evt.ts * 1000).toLocaleTimeString('en-US', {hour12: false});
+                document.getElementById('timeValue').textContent = time;
+            }
+
+            // Move vehicle marker to current position
+            const trackUpTo = allEvents.slice(0, idx + 1).filter(e => e.type === 'track');
+            if (trackUpTo.length > 0) {
+                const last = trackUpTo[trackUpTo.length - 1];
+                if (last.lat && last.lon) {
+                    if (vehicleMarker) {
+                        vehicleMarker.setLatLng([last.lat, last.lon]);
+                    } else {
+                        vehicleMarker = L.marker([last.lat, last.lon], {
+                            icon: L.divIcon({
+                                html: '<div style="width:12px;height:12px;background:#00ff88;border:2px solid #fff;border-radius:50%;"></div>',
+                                iconSize: [12, 12],
+                                iconAnchor: [6, 6],
+                            }),
+                        }).addTo(map);
+                    }
+                }
+            }
+
+            // Show recent events in list
+            const recentEvents = allEvents.slice(Math.max(0, idx - 10), idx + 1)
+                .filter(e => e.type !== 'track')
+                .reverse();
+
+            const list = document.getElementById('eventList');
+            list.textContent = '';
+            for (const e of recentEvents) {
+                const div = document.createElement('div');
+                div.className = 'timeline-event';
+                const time = e.ts ? new Date(e.ts * 1000).toLocaleTimeString('en-US', {hour12: false}) : '';
+                const label = e.action || e.state || e.name || e.type;
+                div.textContent = `${time} ${label}`;
+                list.appendChild(div);
+            }
+        }
+
         // --- Event listeners ---
         document.getElementById('logSelect').onchange = e => loadLog(e.target.value);
         document.getElementById('confSlider').oninput = e => {
@@ -313,9 +473,14 @@
         };
         document.getElementById('showTrails').onchange = renderMap;
         document.getElementById('showMarkers').onchange = renderMap;
+        document.getElementById('eventSelect').onchange = e => loadEventLog(e.target.value);
+        document.getElementById('timeSlider').oninput = e => renderTimeline(parseInt(e.target.value));
+        document.getElementById('showVehicleTrack').onchange = renderVehicleTrack;
+        document.getElementById('showEvents').onchange = renderVehicleTrack;
 
         // --- Init ---
         loadLogList();
+        loadEventLogList();
     </script>
 </body>
 </html>

--- a/tests/test_map_replay.py
+++ b/tests/test_map_replay.py
@@ -1,0 +1,151 @@
+"""Tests for after-action review map replay (event timeline API endpoints)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hydra_detect.web.server import app, configure_auth, _auth_failures, stream_state
+
+
+SAMPLE_EVENT_TIMELINE = [
+    {"type": "mission_start", "ts": 1711720000, "name": "patrol-alpha"},
+    {"type": "track", "ts": 1711720001, "lat": 34.050, "lon": -118.250, "alt": 10.0, "hdg": 90},
+    {"type": "track", "ts": 1711720002, "lat": 34.051, "lon": -118.251, "alt": 10.0, "hdg": 92},
+    {"type": "action", "ts": 1711720002.5, "action": "target_lock", "track_id": 3},
+    {"type": "track", "ts": 1711720003, "lat": 34.052, "lon": -118.252, "alt": 10.0, "hdg": 95},
+    {"type": "state", "ts": 1711720004, "state": "loiter"},
+    {"type": "track", "ts": 1711720005, "lat": 34.053, "lon": -118.253, "alt": 10.0, "hdg": 100},
+    {"type": "mission_end", "ts": 1711720006},
+]
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset stream_state and auth between tests."""
+    configure_auth(None)
+    _auth_failures.clear()
+    stream_state._callbacks.clear()
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def event_log_dir(tmp_path):
+    """Create a temp log dir with an event timeline JSONL file."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    # Write event timeline file
+    event_file = log_dir / "HYDRA-1_20260329_143207_patrol.jsonl"
+    with open(event_file, "w") as f:
+        for evt in SAMPLE_EVENT_TIMELINE:
+            f.write(json.dumps(evt) + "\n")
+    # Write a detection log (not an event timeline) to verify it's excluded
+    det_file = log_dir / "detections_20260329.jsonl"
+    with open(det_file, "w") as f:
+        f.write(json.dumps({"timestamp": "2026-03-29T14:00:00Z", "frame": 1,
+                            "track_id": 1, "label": "person", "confidence": 0.9,
+                            "chain_hash": "abc123"}) + "\n")
+    # Set the callback so server finds this dir
+    stream_state.set_callbacks(get_log_dir=lambda: str(log_dir))
+    return log_dir
+
+
+# ---------------------------------------------------------------------------
+# GET /api/review/events/{filename}
+# ---------------------------------------------------------------------------
+
+class TestReviewEvents:
+    def test_returns_events(self, client, event_log_dir):
+        resp = client.get("/api/review/events/HYDRA-1_20260329_143207_patrol.jsonl")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["filename"] == "HYDRA-1_20260329_143207_patrol.jsonl"
+        assert len(data["events"]) == len(SAMPLE_EVENT_TIMELINE)
+        # Check first event
+        assert data["events"][0]["type"] == "mission_start"
+        assert data["events"][0]["name"] == "patrol-alpha"
+        # Check track events have lat/lon
+        track_events = [e for e in data["events"] if e["type"] == "track"]
+        assert len(track_events) == 4
+        assert track_events[0]["lat"] == 34.050
+
+    def test_invalid_filename_dotdot(self, client, event_log_dir):
+        resp = client.get("/api/review/events/..secret.jsonl")
+        assert resp.status_code == 400
+        assert "invalid filename" in resp.json()["error"]
+
+    def test_invalid_filename_traversal(self, client, event_log_dir):
+        """Path traversal with encoded slashes should be blocked."""
+        resp = client.get("/api/review/events/foo%2F..%2Fbar.jsonl")
+        # Starlette may normalize or reject — either 400 or 404 is acceptable
+        assert resp.status_code in (400, 404)
+
+    def test_invalid_filename_backslash(self, client, event_log_dir):
+        resp = client.get("/api/review/events/foo%5Cbar.jsonl")
+        assert resp.status_code in (400, 404)
+
+    def test_missing_file_404(self, client, event_log_dir):
+        resp = client.get("/api/review/events/nonexistent.jsonl")
+        assert resp.status_code == 404
+        assert "not found" in resp.json()["error"]
+
+    def test_non_jsonl_404(self, client, event_log_dir):
+        """Non-.jsonl files should return 404 even if they exist."""
+        # Create a .csv file
+        (event_log_dir / "test.csv").write_text("a,b,c\n1,2,3\n")
+        resp = client.get("/api/review/events/test.csv")
+        assert resp.status_code == 404
+
+    def test_malformed_lines_skipped(self, client, event_log_dir):
+        """Malformed JSON lines should be skipped without error."""
+        bad_file = event_log_dir / "bad_events.jsonl"
+        with open(bad_file, "w") as f:
+            f.write(json.dumps({"type": "mission_start", "ts": 1000}) + "\n")
+            f.write("this is not valid json\n")
+            f.write("\n")  # empty line
+            f.write(json.dumps({"type": "track", "ts": 1001, "lat": 34.0, "lon": -118.0}) + "\n")
+        resp = client.get("/api/review/events/bad_events.jsonl")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["events"]) == 2
+        assert data["events"][0]["type"] == "mission_start"
+        assert data["events"][1]["type"] == "track"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/review/logs — event_logs field
+# ---------------------------------------------------------------------------
+
+class TestReviewLogsEventLogs:
+    def test_includes_event_logs_field(self, client, event_log_dir):
+        resp = client.get("/api/review/logs")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "event_logs" in data
+
+    def test_event_timeline_listed(self, client, event_log_dir):
+        resp = client.get("/api/review/logs")
+        data = resp.json()
+        event_filenames = [e["filename"] for e in data["event_logs"]]
+        assert "HYDRA-1_20260329_143207_patrol.jsonl" in event_filenames
+
+    def test_detection_log_not_in_event_logs(self, client, event_log_dir):
+        """Detection logs (chain_hash) should not appear in event_logs."""
+        resp = client.get("/api/review/logs")
+        data = resp.json()
+        event_filenames = [e["filename"] for e in data["event_logs"]]
+        assert "detections_20260329.jsonl" not in event_filenames
+
+    def test_event_log_has_size(self, client, event_log_dir):
+        resp = client.get("/api/review/logs")
+        data = resp.json()
+        for el in data["event_logs"]:
+            assert "size_kb" in el
+            assert el["size_kb"] >= 0


### PR DESCRIPTION
## Summary
- Add vehicle GPS track polyline overlay on the /review Leaflet map from event timeline JSONL files
- Add timeline slider to scrub through mission events with a moving vehicle position marker
- Add operator action markers (target_lock, loiter, mission_start/end) placed at nearest GPS position
- New `GET /api/review/events/{filename}` endpoint to read event timeline JSONL files
- Update `GET /api/review/logs` to include `event_logs` list (separate from detection logs)
- New sidebar sections: VEHICLE TRACK (event log selector + toggle controls) and TIMELINE (slider + event list)

## Test plan
- [x] `test_map_replay.py` — 11 tests covering events endpoint, path traversal, malformed JSONL, event_logs listing
- [x] Full test suite passes (601 tests)
- [ ] Load a real event timeline JSONL on /review and verify track renders on map
- [ ] Scrub timeline slider and confirm vehicle marker moves along track
- [ ] Toggle vehicle path and operator action checkboxes

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)