### PR TITLE
fix: address pixel-lock code review items

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -112,6 +112,7 @@ max_lat_speed = 2.0                      ; max lateral speed (m/s)
 max_vert_speed = 1.5                     ; max vertical speed (m/s)
 max_yaw_rate = 45.0                      ; max yaw rate (deg/s)
 deadzone = 0.05                          ; ignore errors below this (0..1)
+smoothing = 0.4                          ; EMA alpha (0..1, higher = less smoothing)
 target_bbox_ratio = 0.15                 ; stop approaching when target fills this fraction of frame
 lost_track_timeout_s = 2.0               ; abort after this many seconds with no track
 min_altitude_m = 5.0                     ; minimum altitude floor (metres)

--- a/hydra_detect/approach.py
+++ b/hydra_detect/approach.py
@@ -83,6 +83,7 @@ class ApproachController:
 
         # Pixel-lock guidance controller
         self._guidance = GuidanceController(cfg.guidance_cfg)
+        self._last_vel_log_time: float = 0.0
 
     # ------------------------------------------------------------------
     # Public — start modes
@@ -170,9 +171,14 @@ class ApproachController:
 
         # Switch to GUIDED mode for velocity commands
         try:
-            self._mavlink.set_mode("GUIDED")
-        except Exception:
-            pass
+            ok = self._mavlink.set_mode("GUIDED")
+            if not ok:
+                logger.warning(
+                    "Pixel-lock: GUIDED mode switch failed — "
+                    "vehicle may not respond to velocity commands"
+                )
+        except Exception as exc:
+            logger.warning("Pixel-lock: GUIDED mode switch error: %s", exc)
 
         self._guidance.start()
         logger.info("Pixel-lock mode STARTED for track #%d", track_id)
@@ -298,6 +304,11 @@ class ApproachController:
             result["track_lost"] = self._guidance.track_lost
 
         return result
+
+    @property
+    def active(self) -> bool:
+        with self._lock:
+            return self._mode != ApproachMode.IDLE
 
     @property
     def mode(self) -> ApproachMode:
@@ -493,12 +504,32 @@ class ApproachController:
 
         cmd = self._guidance.update(error_x, error_y, bbox_ratio)
 
+        # Enforce minimum altitude floor — prevent descent below threshold.
+        # In NED, positive vz = descend.  Clamp to zero if near floor.
+        vz = cmd.vz
+        if vz > 0 and self._cfg.guidance_cfg is not None:
+            min_alt = self._cfg.guidance_cfg.min_altitude_m
+            pos = self._mavlink.get_lat_lon()
+            if pos is not None:
+                _, _, cur_alt = pos
+                if cur_alt is not None and cur_alt <= min_alt:
+                    vz = 0.0
+
         try:
-            self._mavlink.send_velocity_ned(cmd.vx, cmd.vy, cmd.vz, cmd.yaw_rate)
+            self._mavlink.send_velocity_ned(cmd.vx, cmd.vy, vz, cmd.yaw_rate)
             with self._lock:
                 self._waypoints_sent += 1
         except Exception as exc:
             logger.warning("Pixel-lock: velocity command failed: %s", exc)
+
+        # Periodic audit log (every 2 seconds) for post-sortie tuning
+        now = time.monotonic()
+        if now - self._last_vel_log_time >= 2.0:
+            self._last_vel_log_time = now
+            audit_log.info(
+                "PIXEL_LOCK VEL: vx=%.2f vy=%.2f vz=%.2f yaw=%.1f",
+                cmd.vx, cmd.vy, vz, cmd.yaw_rate,
+            )
 
         # Auto-abort if track lost beyond timeout
         if self._guidance.track_lost:

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -219,6 +219,7 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
         "max_vert_speed": FieldSpec(FieldType.FLOAT, min_val=0.1, max_val=10.0, default=1.5, description="Max vertical speed m/s"),
         "max_yaw_rate": FieldSpec(FieldType.FLOAT, min_val=1.0, max_val=180.0, default=45.0, description="Max yaw rate deg/s"),
         "deadzone": FieldSpec(FieldType.FLOAT, min_val=0.0, max_val=0.5, default=0.05, description="Error deadzone fraction"),
+        "smoothing": FieldSpec(FieldType.FLOAT, min_val=0.01, max_val=1.0, default=0.4, description="EMA smoothing alpha (higher = less smoothing)"),
         "target_bbox_ratio": FieldSpec(FieldType.FLOAT, min_val=0.01, max_val=1.0, default=0.15, description="Target bbox/frame ratio for approach"),
         "lost_track_timeout_s": FieldSpec(FieldType.FLOAT, min_val=0.1, max_val=30.0, default=2.0, description="Track loss timeout seconds"),
         "min_altitude_m": FieldSpec(FieldType.FLOAT, min_val=0.0, max_val=500.0, default=5.0, description="Minimum altitude floor metres"),

--- a/hydra_detect/guidance.py
+++ b/hydra_detect/guidance.py
@@ -27,6 +27,7 @@ class GuidanceConfig:
     max_yaw_rate: float = 45.0  # deg/s
 
     deadzone: float = 0.05      # ignore error below this magnitude
+    smoothing: float = 0.4      # EMA alpha (higher = less smoothing)
     target_bbox_ratio: float = 0.15  # desired target-fills-frame fraction
     lost_track_timeout_s: float = 2.0  # seconds before declaring track lost
     min_altitude_m: float = 5.0  # vz clamped to prevent ground collision
@@ -57,7 +58,7 @@ class GuidanceController:
         # EMA-smoothed errors (reduces jitter)
         self._smooth_ex: float = 0.0
         self._smooth_ey: float = 0.0
-        self._alpha: float = 0.4  # EMA factor (higher = less smoothing)
+        self._alpha: float = self._cfg.smoothing
         # Track loss timer
         self._last_track_time: float = 0.0
         self._active: bool = False

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -418,6 +418,7 @@ class Pipeline:
                     max_vert_speed=self._cfg.getfloat("guidance", "max_vert_speed", fallback=1.5),
                     max_yaw_rate=self._cfg.getfloat("guidance", "max_yaw_rate", fallback=45.0),
                     deadzone=self._cfg.getfloat("guidance", "deadzone", fallback=0.05),
+                    smoothing=self._cfg.getfloat("guidance", "smoothing", fallback=0.4),
                     target_bbox_ratio=self._cfg.getfloat(
                         "guidance", "target_bbox_ratio", fallback=0.15),
                     lost_track_timeout_s=self._cfg.getfloat(
@@ -1210,13 +1211,6 @@ class Pipeline:
                     # then auto-aborts).  Other modes unlock immediately.
                     if current_lock_mode != "pixel_lock":
                         self._handle_target_unlock(reason="lost")
-
-            # Approach controller update (Follow / Drop / Strike)
-            if self._approach is not None and current_lock_id is not None:
-                locked_track = track_result.find(current_lock_id)
-                self._approach.update(
-                    locked_track, frame.shape[1], frame.shape[0],
-                )
 
             # Log with GPS data
             self._det_logger.log(track_result, frame, gps=gps)

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -13,6 +14,7 @@ from hydra_detect.guidance import (
     _clamp,
     _deadzone,
 )
+from hydra_detect.approach import ApproachConfig, ApproachController, ApproachMode
 
 
 # ------------------------------------------------------------------
@@ -240,3 +242,111 @@ class TestGuidanceStartStop:
         assert gc.active
         gc.stop()
         assert not gc.active
+
+
+# ------------------------------------------------------------------
+# Integration: ApproachController pixel-lock auto-abort chain
+# ------------------------------------------------------------------
+
+class TestPixelLockApproachIntegration:
+    """Test the full track-loss → zero-velocity → timeout → abort chain."""
+
+    def setup_method(self):
+        self.mavlink = MagicMock()
+        self.mavlink.get_vehicle_mode.return_value = "LOITER"
+        self.mavlink.set_mode.return_value = True
+        self.mavlink.send_velocity_ned.return_value = True
+        self.mavlink.get_lat_lon.return_value = (35.0, -79.0, 30.0)
+
+        self.cfg = ApproachConfig(
+            guidance_cfg=GuidanceConfig(
+                lost_track_timeout_s=0.5,
+                min_altitude_m=5.0,
+            ),
+        )
+        self.ctrl = ApproachController(self.mavlink, self.cfg)
+
+    def _make_track(self, cx=320, cy=240, size=50):
+        """Create a mock TrackedObject."""
+        track = MagicMock()
+        track.x1 = cx - size
+        track.y1 = cy - size
+        track.x2 = cx + size
+        track.y2 = cy + size
+        return track
+
+    def test_pixel_lock_starts_and_sends_velocity(self):
+        """Pixel-lock starts, sends velocity commands on update."""
+        assert self.ctrl.start_pixel_lock(1)
+        assert self.ctrl.mode == ApproachMode.PIXEL_LOCK
+        assert self.ctrl.active
+
+        self.ctrl.update(self._make_track(), 640, 480)
+        self.mavlink.send_velocity_ned.assert_called()
+
+    def test_pixel_lock_sends_zero_on_track_loss(self):
+        """Track loss sends zero velocity (brake)."""
+        self.ctrl.start_pixel_lock(1)
+        self.ctrl.update(self._make_track(), 640, 480)
+
+        # Lose the track
+        self.ctrl.update(None, 640, 480)
+        last_call = self.mavlink.send_velocity_ned.call_args
+        assert last_call[0] == (0.0, 0.0, 0.0, 0.0)
+
+    def test_pixel_lock_aborts_after_timeout(self):
+        """After track-loss timeout, approach aborts to LOITER."""
+        self.ctrl.start_pixel_lock(1)
+        self.ctrl.update(self._make_track(), 640, 480)
+
+        # Simulate timeout by backdating the guidance timer
+        self.ctrl._guidance._last_track_time = time.monotonic() - 1.0
+
+        # Next update with None should trigger abort
+        self.ctrl.update(None, 640, 480)
+        assert self.ctrl.mode == ApproachMode.IDLE
+        self.mavlink.set_mode.assert_called_with("LOITER")
+
+    def test_pixel_lock_abort_sends_zero_velocity(self):
+        """Abort sends a final zero-velocity brake command."""
+        self.ctrl.start_pixel_lock(1)
+        self.ctrl.abort()
+        # Should send zero velocity on abort
+        self.mavlink.send_velocity_ned.assert_called_with(0, 0, 0, 0)
+
+    def test_pixel_lock_min_altitude_clamps_descent(self):
+        """Descent is clamped when at or below min altitude."""
+        # Vehicle at min altitude
+        self.mavlink.get_lat_lon.return_value = (35.0, -79.0, 5.0)
+        self.ctrl.start_pixel_lock(1)
+
+        # Target below centre → guidance wants positive vz (descend)
+        track = self._make_track(cx=320, cy=400)  # below centre
+        self.ctrl.update(track, 640, 480)
+
+        # The vz sent should be 0 (clamped), not positive
+        last_call = self.mavlink.send_velocity_ned.call_args
+        vz_sent = last_call[0][2]
+        assert vz_sent == 0.0
+
+    def test_pixel_lock_allows_descent_above_min_altitude(self):
+        """Descent is allowed when well above min altitude."""
+        # Vehicle well above min altitude
+        self.mavlink.get_lat_lon.return_value = (35.0, -79.0, 50.0)
+        self.ctrl.start_pixel_lock(1)
+
+        # Target well below centre
+        track = self._make_track(cx=320, cy=400)
+        self.ctrl.update(track, 640, 480)
+
+        last_call = self.mavlink.send_velocity_ned.call_args
+        vz_sent = last_call[0][2]
+        assert vz_sent > 0.0  # descent allowed
+
+    def test_guided_mode_failure_logs_warning(self):
+        """GUIDED mode switch failure is logged (not silent)."""
+        self.mavlink.set_mode.return_value = False
+        # Should still start (degraded) but set_mode was called
+        result = self.ctrl.start_pixel_lock(1)
+        assert result is True
+        self.mavlink.set_mode.assert_called_with("GUIDED")


### PR DESCRIPTION
## Summary

- Enforce `min_altitude_m` — clamp descent velocity to zero at/below altitude floor
- Log warning on GUIDED mode switch failure (was silently swallowed)
- Add missing `ApproachController.active` property (pre-existing bug — first approach update path never fired)
- Remove duplicate `approach.update()` call in pipeline hot loop (pre-existing, masked by `.active` bug)
- Make EMA smoothing alpha configurable via `[guidance] smoothing` param
- Add periodic velocity audit log (every 2s) for post-sortie tuning review
- 7 new integration tests for pixel-lock approach controller

## Test plan

- [x] 945 tests pass (7 new integration tests)
- [x] flake8 clean on changed files
- [ ] SITL validation of altitude floor enforcement
- [ ] Verify audit log entries appear in hydra.log during pixel-lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)