### PR TITLE
docs: add SORCC Ecosystem section, rename SORCC-PI to Argus

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -464,7 +464,7 @@ check `sample_count > 0` before commanding `guided_to` with the position.
 
 ## Companion Project
 
-**SORCC-PI** (`/home/sorcc/sorcc-pi`, `github.com/rmeadomavic/SORCC-PI`) is the
+**Argus** (`/home/sorcc/argus`, `github.com/rmeadomavic/Argus`) is the
 RF survey payload on Raspberry Pi — companion to Hydra. Patterns adopted from it:
 config schema validation, event logger, TAK/CoT export, config API. Patterns
 worth porting: response caching with stale fallback, waypoint export (QGC WPL 110).
@@ -472,7 +472,7 @@ worth porting: response caching with stale fallback, waypoint export (QGC WPL 11
 ## SORCC Ecosystem
 
 This project is part of the SORCC ecosystem alongside
-[SORCC-PI](https://github.com/rmeadomavic/SORCC-PI) (RF survey payload on
+[Argus](https://github.com/rmeadomavic/Argus) (RF survey payload on
 Raspberry Pi).
 
 - Use consistent terminology: **uncrewed** (not unmanned), **sortie** (not
@@ -486,14 +486,14 @@ Raspberry Pi).
 - Shared code patterns: config schema validation, event logger, TAK/CoT export,
   config API, detection/survey logging with hash-chain verification
 - Cross-references: link to sibling projects where relevant — Hydra handles
-  detection/tracking/engagement, SORCC-PI handles RF survey/SIGINT, both feed
+  detection/tracking/engagement, Argus handles RF survey/SIGINT, both feed
   TAK for a common operating picture
 - Shared UI standards: dark ops-center theme, data-dense layouts, defense-grade
   polish (see UI/UX Design Standards below)
 
 ## UI/UX Design Standards
 
-Both Hydra and SORCC-PI dashboards target **defense-grade polish** — think
+Both Hydra and Argus dashboards target **defense-grade polish** — think
 Palantir Foundry / Anduril Lattice, not startup landing pages. Every element
 must be functional, not decorative:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -469,6 +469,28 @@ RF survey payload on Raspberry Pi — companion to Hydra. Patterns adopted from 
 config schema validation, event logger, TAK/CoT export, config API. Patterns
 worth porting: response caching with stale fallback, waypoint export (QGC WPL 110).
 
+## SORCC Ecosystem
+
+This project is part of the SORCC ecosystem alongside
+[SORCC-PI](https://github.com/rmeadomavic/SORCC-PI) (RF survey payload on
+Raspberry Pi).
+
+- Use consistent terminology: **uncrewed** (not unmanned), **sortie** (not
+  mission/run), **CULEX** (culminating exercise), **STX** (situational training
+  exercise), **EENT** (night ops), **platform** (not vehicle, when referring to
+  the full system)
+- Documentation tone: technical but accessible — SOF operators are smart and
+  mission-focused but may not have software backgrounds
+- Shared config pattern: INI with `.factory` defaults (`config.ini` is the user
+  interface; `config.ini.factory` ships known-good defaults for factory reset)
+- Shared code patterns: config schema validation, event logger, TAK/CoT export,
+  config API, detection/survey logging with hash-chain verification
+- Cross-references: link to sibling projects where relevant — Hydra handles
+  detection/tracking/engagement, SORCC-PI handles RF survey/SIGINT, both feed
+  TAK for a common operating picture
+- Shared UI standards: dark ops-center theme, data-dense layouts, defense-grade
+  polish (see UI/UX Design Standards below)
+
 ## UI/UX Design Standards
 
 Both Hydra and SORCC-PI dashboards target **defense-grade polish** — think

--- a/docs/superpowers/specs/2026-04-01-ui-caching-waypoints-sitl.md
+++ b/docs/superpowers/specs/2026-04-01-ui-caching-waypoints-sitl.md
@@ -19,7 +19,7 @@ visual depth (Palantir/Anduril aesthetic). Keep existing dark + green palette.
   numbers/data, tighten line-height
 - **Status indicators** — sharper color coding, pulsing glow on active alerts
 - **Track list density** — more tracks visible without scrolling
-- **Consistent with SORCC-PI** — shared CSS variable names where possible
+- **Consistent with Argus** — shared CSS variable names where possible
 
 ### Files
 - `hydra_detect/web/static/css/variables.css` — adjust spacing/sizing tokens
@@ -40,7 +40,7 @@ visual depth (Palantir/Anduril aesthetic). Keep existing dark + green palette.
 Dashboard shows last-known-good data when the pipeline thread is busy, instead
 of hanging or showing empty state.
 
-### Pattern (from SORCC-PI)
+### Pattern (from Argus)
 ```python
 _response_cache: dict[str, tuple[float, Any]] = {}
 _CACHE_TTL = 30.0  # seconds


### PR DESCRIPTION
## Summary
- Adds SORCC Ecosystem section to CLAUDE.md with shared terminology, config patterns, code patterns, and cross-references
- Renames all SORCC-PI references to Argus across CLAUDE.md and spec docs

https://claude.ai/code/session_01DLKZH8QN3WPqnEaGmbJ5vC