### PR TITLE
Harden API auth bypass checks for origin/session flows

### DIFF
--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -15,6 +15,7 @@ import threading
 import time
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
+from urllib.parse import urlsplit
 
 import cv2
 import numpy as np
@@ -154,17 +155,9 @@ def _check_auth(
     if _api_token is None:
         return None  # Auth disabled
 
-    # Same-origin requests from the built-in dashboard skip auth.
-    # Check multiple signals — browsers set these on fetch/XHR and they
-    # cannot be forged by external scripts or curl.
     if request is not None:
-        sec_fetch = request.headers.get("sec-fetch-site", "")
-        if sec_fetch in ("same-origin", "same-site"):
-            return None
-        # Fallback: check Origin header matches Host
         origin = request.headers.get("origin", "")
-        host = request.headers.get("host", "")
-        if origin and host and host in origin:
+        if origin and _origin_matches_request(origin, request):
             return None
         # Password-authenticated sessions also bypass Bearer token check
         cookie_header = request.headers.get("cookie", "")
@@ -197,6 +190,30 @@ def _check_auth(
         _auth_failures[client_ip].append(now)
         return JSONResponse({"error": "Invalid API token"}, status_code=403)
     return None
+
+
+def _origin_matches_request(origin: str, request: Request) -> bool:
+    """Return True when Origin exactly matches request scheme + host + port."""
+    try:
+        parsed = urlsplit(origin)
+    except ValueError:
+        return False
+    if not parsed.scheme or not parsed.netloc or parsed.hostname is None:
+        return False
+    if parsed.username or parsed.password:
+        return False
+
+    req_scheme = request.url.scheme
+    req_host = request.url.hostname
+    if not req_scheme or not req_host:
+        return False
+
+    origin_port = parsed.port or (443 if parsed.scheme == "https" else 80 if parsed.scheme == "http" else None)
+    req_port = request.url.port or (443 if req_scheme == "https" else 80 if req_scheme == "http" else None)
+    if origin_port is None or req_port is None:
+        return False
+
+    return parsed.scheme == req_scheme and parsed.hostname == req_host and origin_port == req_port
 
 
 # ── Web password session auth ────────────────────────────────────────

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -17,6 +17,7 @@ from hydra_detect.web.server import (
     _RESPONSE_CACHE_TTL,
     app,
     configure_auth,
+    configure_web_password,
     stream_state,
 )
 
@@ -25,6 +26,7 @@ from hydra_detect.web.server import (
 def _reset_state():
     """Reset stream_state and auth between tests."""
     configure_auth(None)
+    configure_web_password(None)
     _auth_failures.clear()
     _response_cache.clear()
     stream_state.target_lock = {"locked": False, "track_id": None, "mode": None, "label": None}
@@ -142,8 +144,7 @@ class TestAuthEnforcement:
                 resp = client.post(url, headers=headers)
             assert resp.status_code == 403, f"{url} should reject wrong token"
 
-    def test_same_origin_skips_auth(self, client):
-        """Dashboard requests with Sec-Fetch-Site: same-origin bypass auth."""
+    def test_forged_sec_fetch_site_does_not_bypass_token_checks(self, client):
         configure_auth("secret-token-123")
         headers = {"Sec-Fetch-Site": "same-origin"}
         for method, url, body in self.CONTROL_ENDPOINTS:
@@ -151,18 +152,31 @@ class TestAuthEnforcement:
                 resp = client.post(url, json=body, headers=headers)
             else:
                 resp = client.post(url, headers=headers)
-            assert resp.status_code != 401, f"{url} should skip auth for same-origin"
+            assert resp.status_code == 401, f"{url} should require auth despite forged sec-fetch-site"
 
-    def test_origin_header_skips_auth(self, client):
-        """Dashboard requests with matching Origin header bypass auth."""
+    def test_origin_subdomain_spoof_does_not_bypass_token_checks(self, client):
         configure_auth("secret-token-123")
-        headers = {"Origin": "http://testserver"}
+        headers = {"Origin": "https://testserver.evil.tld"}
         for method, url, body in self.CONTROL_ENDPOINTS:
             if body:
                 resp = client.post(url, json=body, headers=headers)
             else:
                 resp = client.post(url, headers=headers)
-            assert resp.status_code != 401, f"{url} should skip auth for matching origin"
+            assert resp.status_code == 401, f"{url} should require auth for spoofed origin"
+
+    def test_valid_session_cookie_bypasses_bearer_token(self, client):
+        configure_auth("secret-token-123")
+        configure_web_password("ui-password-1")
+        login_resp = client.post("/auth/login", json={"password": "ui-password-1"})
+        assert login_resp.status_code == 200
+        assert "hydra_session" in login_resp.headers.get("set-cookie", "")
+
+        for method, url, body in self.CONTROL_ENDPOINTS:
+            if body:
+                resp = client.post(url, json=body)
+            else:
+                resp = client.post(url)
+            assert resp.status_code not in (401, 403), f"{url} should accept valid session cookie"
 
     def test_correct_token_accepted(self, client):
         configure_auth("secret-token-123")


### PR DESCRIPTION
### Motivation
- Prevent forged browser headers or loose origin matching from bypassing Bearer-token auth for control endpoints.
- Ensure `Origin` header is validated strictly (scheme+host+port) before treating a request as same-origin.
- Preserve the existing `hydra_session` cookie bypass for legitimate browser UI flows but only after strict session validation.

### Description
- Removed the `Sec-Fetch-Site` based bypass from `_check_auth()` and replaced the loose `host in origin` check with a strict match via a new helper ` _origin_matches_request()` which parses `Origin` with `urlsplit` and compares scheme, hostname and effective port to the request URL.
- Kept the session-cookie bypass path but retained the requirement that `hydra_session` passes `_validate_session_cookie()` before skipping Bearer checks.
- Added `configure_web_password(None)` to the auth test fixture reset to avoid session state leakage between tests.
- Added regression tests in `tests/test_web_api.py` that assert a forged `Sec-Fetch-Site: same-origin` or a spoofed `Origin: https://<host>.evil.tld` do not bypass token checks, and that a valid `hydra_session` cookie still grants UI access.

### Testing
- Ran `pytest -q tests/test_web_api.py -k 'AuthEnforcement and (forged_sec_fetch_site or origin_subdomain_spoof or valid_session_cookie)'` which attempted to collect and run the new auth regression tests but failed during test collection because `fastapi.testclient` requires the `httpx` package which is not installed in this environment; tests did not execute.
- Local logic review and static inspection confirm the strict `Origin` parsing and session validation behavior was implemented as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1940088e083288b81ccb2cfaf93ca)