### PR TITLE
Protect waypoint export endpoint with token auth

### DIFF
--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -2016,7 +2016,12 @@ async def api_export_logs(request: Request, authorization: str | None = Header(N
 
 
 @app.get("/api/export/waypoints")
-async def api_export_waypoints(request: Request, classes: str = "", alt_m: float = 15.0):
+async def api_export_waypoints(
+    request: Request,
+    classes: str = "",
+    alt_m: float = 15.0,
+    authorization: str | None = Header(None),
+):
     """Export GPS-tagged detections as a QGC WPL 110 waypoint file.
 
     Query params:
@@ -2028,6 +2033,10 @@ async def api_export_waypoints(request: Request, classes: str = "", alt_m: float
         format_wpl,
         tracks_to_waypoints,
     )
+
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
 
     cb = stream_state.get_callback("get_recent_detections")
     detections = cb() if cb else []

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -176,6 +176,50 @@ class TestAuthEnforcement:
             assert resp.status_code not in (401, 403), f"{url} returned {resp.status_code}"
 
 
+class TestWaypointExportAuth:
+    def test_waypoint_export_requires_auth_when_token_enabled(self, client):
+        stream_state.set_callbacks(
+            get_recent_detections=lambda: [
+                {"label": "person", "confidence": 0.9, "lat": 35.1, "lon": -117.2},
+            ],
+        )
+        configure_auth("secret-token-123")
+
+        resp = client.get("/api/export/waypoints")
+        assert resp.status_code == 401
+
+    def test_waypoint_export_rejects_wrong_token(self, client):
+        stream_state.set_callbacks(
+            get_recent_detections=lambda: [
+                {"label": "person", "confidence": 0.9, "lat": 35.1, "lon": -117.2},
+            ],
+        )
+        configure_auth("secret-token-123")
+
+        resp = client.get(
+            "/api/export/waypoints",
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        assert resp.status_code == 403
+
+    def test_waypoint_export_succeeds_with_valid_token(self, client):
+        stream_state.set_callbacks(
+            get_recent_detections=lambda: [
+                {"label": "person", "confidence": 0.9, "lat": 35.1, "lon": -117.2},
+            ],
+        )
+        configure_auth("secret-token-123")
+
+        resp = client.get(
+            "/api/export/waypoints",
+            headers={"Authorization": "Bearer secret-token-123"},
+        )
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("text/plain")
+        assert "hydra-waypoints.wpl" in resp.headers["content-disposition"]
+        assert resp.text.startswith("QGC WPL 110\n")
+
+
 # ---------------------------------------------------------------------------
 # Control endpoint behaviour
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Align the `/api/export/waypoints` endpoint with the security model used by other export/control endpoints by enforcing API token checks.
- Prevent unauthenticated external access to generated waypoint files while preserving dashboard/browser bypass behavior.

### Description
- Added `authorization: str | None = Header(None)` to the `api_export_waypoints` route signature in `hydra_detect/web/server.py`.
- Call `_check_auth(authorization, request)` at the start of `api_export_waypoints` and return early with the error response when auth fails.
- Added `TestWaypointExportAuth` tests to `tests/test_web_api.py` that assert unauthenticated requests return `401`, wrong tokens return `403`, and valid tokens still return `200` with a WPL payload and the `hydra-waypoints.wpl` content-disposition.

### Testing
- Ran `pytest -q tests/test_web_api.py -k waypoint_export` which failed during collection due to a missing test dependency (`httpx`), producing `ModuleNotFoundError: No module named 'httpx'` and preventing test execution in this environment.
- The new tests are present and should pass in an environment with `httpx` installed and normal test dependencies available (they assert `401`/`403`/`200` behavior and WPL response content).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d19405e3fc8328ae26e65453dcb7ef)