### PR TITLE
Add pre-write schema validation for config mutation APIs

### DIFF
--- a/hydra_detect/web/config_api.py
+++ b/hydra_detect/web/config_api.py
@@ -11,6 +11,8 @@ import shutil
 from pathlib import Path
 from typing import Any, Callable
 
+from hydra_detect.config_schema import SCHEMA, FieldType
+
 logger = logging.getLogger(__name__)
 audit_log = logging.getLogger("hydra.audit")
 
@@ -185,6 +187,72 @@ def write_config(updates: dict[str, dict[str, str]]) -> dict[str, Any]:
         "updated": updated, "restart_required": restart_needed,
         "skipped": skipped, "locked": locked,
     }
+
+
+def validate_config_updates(updates: dict[str, dict[str, Any]]) -> dict[str, str]:
+    """Validate update payload values against schema field specs.
+
+    Returns a dict of field errors keyed as "section.key".
+    Unknown fields are ignored here and still handled by write_config().
+    """
+    field_errors: dict[str, str] = {}
+    for section, fields in updates.items():
+        if not isinstance(fields, dict):
+            continue
+        schema_fields = SCHEMA.get(section)
+        if not schema_fields:
+            continue
+
+        for key, value in fields.items():
+            spec = schema_fields.get(key)
+            if spec is None:
+                continue
+
+            # Preserve existing redacted secret behavior.
+            if section in REDACTED_FIELDS and key in REDACTED_FIELDS[section] and value == REDACTED_VALUE:
+                continue
+
+            raw = value if isinstance(value, str) else str(value)
+            raw = raw.strip()
+            field_path = f"{section}.{key}"
+
+            if spec.type == FieldType.BOOL:
+                if raw.lower() not in ("true", "false", "yes", "no", "1", "0", "on", "off"):
+                    field_errors[field_path] = "must be a boolean (true/false)"
+                continue
+
+            if spec.type == FieldType.ENUM:
+                if spec.choices and raw.lower() not in [c.lower() for c in spec.choices]:
+                    choices = ", ".join(spec.choices)
+                    field_errors[field_path] = f"must be one of: {choices}"
+                continue
+
+            if spec.type == FieldType.INT:
+                try:
+                    num = int(raw)
+                except ValueError:
+                    field_errors[field_path] = "must be an integer"
+                    continue
+                if spec.min_val is not None and num < spec.min_val:
+                    field_errors[field_path] = f"must be >= {int(spec.min_val)}"
+                    continue
+                if spec.max_val is not None and num > spec.max_val:
+                    field_errors[field_path] = f"must be <= {int(spec.max_val)}"
+                continue
+
+            if spec.type == FieldType.FLOAT:
+                try:
+                    num = float(raw)
+                except ValueError:
+                    field_errors[field_path] = "must be a number"
+                    continue
+                if spec.min_val is not None and num < spec.min_val:
+                    field_errors[field_path] = f"must be >= {spec.min_val}"
+                    continue
+                if spec.max_val is not None and num > spec.max_val:
+                    field_errors[field_path] = f"must be <= {spec.max_val}"
+
+    return field_errors
 
 
 def restore_backup() -> bool:

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -32,6 +32,7 @@ from hydra_detect.web.config_api import (
     restore_backup,
     restore_factory,
     write_config,
+    validate_config_updates,
 )
 from hydra_detect.config_schema import SCHEMA as CONFIG_SCHEMA
 
@@ -2290,6 +2291,12 @@ async def api_set_full_config(request: Request, authorization: str | None = Head
         body = _json.loads(body_bytes)
     except (ValueError, _json.JSONDecodeError):
         return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+    field_errors = validate_config_updates(body)
+    if field_errors:
+        return JSONResponse(
+            {"error": "Validation failed", "field_errors": field_errors},
+            status_code=400,
+        )
     try:
         result = write_config(body)
         _audit(request, "config_update", target=str(len(body)))
@@ -2368,6 +2375,12 @@ async def api_config_import(request: Request, authorization: str | None = Header
         return JSONResponse({"error": "Invalid JSON"}, status_code=400)
     if not isinstance(body, dict):
         return JSONResponse({"error": "Expected JSON object with config sections"}, status_code=400)
+    field_errors = validate_config_updates(body)
+    if field_errors:
+        return JSONResponse(
+            {"error": "Validation failed", "field_errors": field_errors},
+            status_code=400,
+        )
     try:
         result = write_config(body)
         _audit(request, "config_import", target=str(len(body)))
@@ -2463,6 +2476,13 @@ async def api_setup_save(request: Request, authorization: Optional[str] = Header
     }
     if callsign:
         updates["tak"] = {"callsign": callsign}
+
+    field_errors = validate_config_updates(updates)
+    if field_errors:
+        return JSONResponse(
+            {"error": "Validation failed", "field_errors": field_errors},
+            status_code=400,
+        )
 
     try:
         result = write_config(updates)

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -124,6 +124,25 @@ class TestConfigPostEndpoint:
         data = resp.json()
         assert len(data["skipped"]) == 2
 
+    @pytest.mark.parametrize(
+        ("payload", "field"),
+        [
+            ({"camera": {"fps": "not-an-int"}}, "camera.fps"),
+            ({"detector": {"yolo_confidence": "not-a-float"}}, "detector.yolo_confidence"),
+            ({"mavlink": {"enabled": "not-a-bool"}}, "mavlink.enabled"),
+            ({"camera": {"video_standard": "secam"}}, "camera.video_standard"),
+        ],
+    )
+    def test_post_config_rejects_invalid_schema_values(self, client, tmp_config, payload, field):
+        original_content = tmp_config.read_text()
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/full", json=payload)
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["error"] == "Validation failed"
+        assert field in data["field_errors"]
+        assert tmp_config.read_text() == original_content
+
 
 class TestConfigAuthPositiveCases:
     def test_get_config_with_valid_token(self, client, tmp_config):
@@ -171,3 +190,25 @@ class TestConfigRestoreBackup:
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
             resp = client.post("/api/config/restore-backup")
         assert resp.status_code == 404
+
+
+class TestConfigImportValidation:
+    @pytest.mark.parametrize(
+        ("payload", "field"),
+        [
+            ({"camera": {"fps": "bad-int"}}, "camera.fps"),
+            ({"detector": {"yolo_confidence": "bad-float"}}, "detector.yolo_confidence"),
+            ({"mavlink": {"enabled": "bad-bool"}}, "mavlink.enabled"),
+            ({"camera": {"video_standard": "bad-enum"}}, "camera.video_standard"),
+        ],
+    )
+    def test_import_rejects_invalid_schema_values(self, client, tmp_config, payload, field):
+        original_content = tmp_config.read_text()
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/import", json=payload)
+        assert resp.status_code == 400
+        data = resp.json()
+        assert data["error"] == "Validation failed"
+        assert field in data["field_errors"]
+        assert tmp_config.read_text() == original_content
+


### PR DESCRIPTION
### Motivation
- Prevent invalid configuration values from being written to `config.ini` by validating mutation payloads against the typed `hydra_detect.config_schema.SCHEMA` prior to any file updates.
- Surface clear, field-level error messages to API clients and preserve existing redacted-secret behavior (`***`) so masked secrets remain no-ops.

### Description
- Added `validate_config_updates(updates)` to `hydra_detect/web/config_api.py` that checks payload values against `SCHEMA` `FieldSpec`s (supports `bool`, `int`, `float`, `enum` and min/max checks) and returns a map of `section.key` -> error message.
- Validation preserves redacted secrets by skipping fields with the `REDACTED_VALUE` placeholder for redacted keys.
- Wired pre-write validation into `POST /api/config/full` (`api_set_full_config`), `POST /api/config/import` (`api_config_import`), and the setup save flow (`POST /api/setup/save`) in `hydra_detect/web/server.py` so invalid payloads are rejected with HTTP 400 and a JSON body `{"error": "Validation failed", "field_errors": {"section.key": "reason"}}`.
- Added parameterized tests in `tests/test_config_api.py` covering invalid int/float/bool/enum writes for the full-config and import endpoints, asserting the API returns 400, includes the field-level error, and that the config file remains unchanged on validation failure.

### Testing
- Ran `python -m compileall` on the modified modules and test file, which completed successfully.
- Executing `pytest -q tests/test_config_api.py` in this environment failed at collection due to a missing runtime dependency (`httpx`) required by `starlette.testclient`; tests could not be executed here for that reason.
- The new tests were added and committed; when run in a proper test environment with `httpx` installed the added validation tests should exercise the new behavior (expected: validation failures return 400 and do not modify `config.ini`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d194080b448328b60407335cd3daa0)