### PR TITLE
fix: audit findings — chain hash, GPS gate, schema gaps, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Kismet (WiFi/SDR) → RF Hunt Controller → RSSI Gradient Ascent → MAVLink Na
 | `event_logger.py` | Mission event timeline (actions + vehicle track at 1 Hz) |
 | `verify_log.py` | SHA-256 hash chain verification |
 | `review_export.py` | Standalone HTML map report generator |
+| `waypoint_export.py` | QGC WPL 110 waypoint export for detection-driven missions |
 | `rtsp_server.py` | GStreamer RTSP H.264 output |
 | `servo_tracker.py` | Pixel-lock servo controller (pan + strike) |
 | `model_manifest.py` | Model hash verification, manifest, class introspection |
@@ -71,6 +72,8 @@ Kismet (WiFi/SDR) → RF Hunt Controller → RSSI Gradient Ascent → MAVLink Na
 | `rf/navigator.py` | Gradient ascent waypoint navigation |
 | `rf/search.py` | Lawnmower and spiral pattern generators |
 | `rf/signal.py` | RSSI filtering and gradient analysis |
+| `rf/rssi_protocol.py` | Protocol defining the RSSI client interface for RF hunt |
+| `rf/rtl_power_client.py` | RTL-SDR raw power measurement client for FHSS radios |
 | `tak/tak_output.py` | CoT multicast/unicast output thread |
 | `tak/tak_input.py` | CoT command listener (GeoChat + custom types) |
 | `tak/cot_builder.py` | Cursor-on-Target XML builder |

--- a/config.ini.factory
+++ b/config.ini.factory
@@ -159,6 +159,37 @@ advertise_host =                          ; set to your Jetson Tailscale IP
 listen_commands = true
 listen_port = 6969
 
+[approach]
+follow_speed_min = 2.0
+follow_speed_max = 10.0
+follow_distance_m = 15.0
+follow_yaw_rate_max = 30.0
+strike_approach_m = 5.0
+abort_mode = LOITER
+waypoint_interval = 0.5
+
+[drop]
+servo_channel = 0
+pwm_release = 1900
+pwm_hold = 1100
+pulse_duration = 1.0
+drop_distance_m = 3.0
+
+[guidance]
+fwd_gain = 2.0
+lat_gain = 1.5
+vert_gain = 1.0
+yaw_gain = 30.0
+max_fwd_speed = 5.0
+max_lat_speed = 2.0
+max_vert_speed = 1.5
+max_yaw_rate = 45.0
+deadzone = 0.05
+smoothing = 0.4
+target_bbox_ratio = 0.15
+lost_track_timeout_s = 2.0
+min_altitude_m = 5.0
+
 ; ---------------------------------------------------------------------------
 ; Vehicle profiles — override base sections via --vehicle <name> or HYDRA_VEHICLE
 ; Keys use "section.option" format to override the matching base section.
@@ -180,3 +211,7 @@ listen_port = 6969
 ; autonomous.abort_action = cut_throttle
 ; alerts.priority_labels = person,vehicle
 ; tak.callsign = HYDRA-UGV
+
+[vehicle.fw]
+autonomous.post_action_mode = LOITER
+autonomous.min_track_frames = 2

--- a/hydra_detect/autonomous.py
+++ b/hydra_detect/autonomous.py
@@ -197,13 +197,17 @@ class AutonomousController:
             return
 
         # Check GPS freshness BEFORE geofence (Fix 1: stale GPS must be rejected first)
+        # Skip freshness check when last_update is 0.0 — this means GPS data
+        # is operator-provided/static (sim mode, bench config), not stale.
         get_gps = getattr(mavlink, "get_gps", None)
         if get_gps is not None:
             gps_data = get_gps()
-            gps_age = now - gps_data.get("last_update", 0.0)
-            if gps_age > self._gps_max_stale_sec:
-                logger.debug("GPS stale (%.1fs) — skipping autonomous eval", gps_age)
-                return
+            last_update = gps_data.get("last_update", 0.0)
+            if last_update > 0.0:
+                gps_age = now - last_update
+                if gps_age > self._gps_max_stale_sec:
+                    logger.debug("GPS stale (%.1fs) — skipping autonomous eval", gps_age)
+                    return
 
         # Check vehicle inside geofence
         get_lat_lon = getattr(mavlink, "get_lat_lon", None)

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1098,6 +1098,20 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             description="MAVLink video link budget bytes/sec",
         ),
     },
+    "vehicle.fw": {
+        "autonomous.post_action_mode": FieldSpec(
+            FieldType.STRING,
+            default="LOITER",
+            description="Flight mode after autonomous action completes (fixed-wing)",
+        ),
+        "autonomous.min_track_frames": FieldSpec(
+            FieldType.INT,
+            min_val=1,
+            max_val=100,
+            default=2,
+            description="Minimum consecutive track frames before autonomous action (fixed-wing)",
+        ),
+    },
 }
 
 

--- a/hydra_detect/detection_logger.py
+++ b/hydra_detect/detection_logger.py
@@ -207,6 +207,7 @@ class DetectionLogger:
 
         # Build records (do NOT update _recent yet — only after successful enqueue).
         records: list[Dict[str, Any]] = []
+        chain_hash_before_loop = self._prev_chain_hash
         for track in tracking_result:
             record: Dict[str, Any] = {
                 "timestamp": ts_iso,
@@ -227,12 +228,14 @@ class DetectionLogger:
                 "model_hash": self._model_hash,
             }
             # Rolling SHA-256 chain: hash(record_json + prev_hash)
-            # Chain state is advanced only after successful enqueue (below)
-            # to avoid breaking the chain when records are dropped.
+            # Each record chains against the previous record's hash so
+            # multi-detection frames produce a sequential chain, not a
+            # fan-out from the same prev_hash.
             record_json = json.dumps(record, sort_keys=True)
             chain_input = record_json + self._prev_chain_hash
             chain_hash = hashlib.sha256(chain_input.encode()).hexdigest()
             record["chain_hash"] = chain_hash
+            self._prev_chain_hash = chain_hash
             records.append(record)
 
         # Copy the frame only when we need it for writing (avoids the copy
@@ -252,14 +255,13 @@ class DetectionLogger:
 
         try:
             self._write_queue.put_nowait(work_item)
-            # Advance chain state and update recent buffer only after
-            # successful enqueue so dropped records don't appear in the API
-            # and don't leave a gap in the persisted hash chain.
-            self._prev_chain_hash = records[-1]["chain_hash"]
             with self._recent_lock:
                 for record in records:
                     self._recent.append(record)  # deque evicts oldest when full
         except queue.Full:
+            # Revert chain state so dropped records don't leave a gap
+            # in the persisted hash chain.
+            self._prev_chain_hash = chain_hash_before_loop
             logger.warning(
                 "Detection logger queue full — dropping frame %d "
                 "(storage too slow?)",

--- a/hydra_detect/web/config_api.py
+++ b/hydra_detect/web/config_api.py
@@ -209,7 +209,12 @@ def validate_config_updates(updates: dict[str, dict[str, Any]]) -> dict[str, str
                 continue
 
             # Preserve existing redacted secret behavior.
-            if section in REDACTED_FIELDS and key in REDACTED_FIELDS[section] and value == REDACTED_VALUE:
+            is_redacted = (
+                section in REDACTED_FIELDS
+                and key in REDACTED_FIELDS[section]
+                and value == REDACTED_VALUE
+            )
+            if is_redacted:
                 continue
 
             raw = value if isinstance(value, str) else str(value)

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -209,8 +209,12 @@ def _origin_matches_request(origin: str, request: Request) -> bool:
     if not req_scheme or not req_host:
         return False
 
-    origin_port = parsed.port or (443 if parsed.scheme == "https" else 80 if parsed.scheme == "http" else None)
-    req_port = request.url.port or (443 if req_scheme == "https" else 80 if req_scheme == "http" else None)
+    origin_port = parsed.port or (
+        443 if parsed.scheme == "https" else 80 if parsed.scheme == "http" else None
+    )
+    req_port = request.url.port or (
+        443 if req_scheme == "https" else 80 if req_scheme == "http" else None
+    )
     if origin_port is None or req_port is None:
         return False
 

--- a/tests/test_autonomous.py
+++ b/tests/test_autonomous.py
@@ -285,6 +285,35 @@ class TestEvaluate:
 
         strike_cb.assert_not_called()
 
+    def test_simulated_gps_zero_last_update_proceeds(self):
+        """GPS with last_update=0.0 (sim/static) should not block eval."""
+        ctrl = _make_controller(min_track_frames=1)
+        mav = _make_mavlink()
+        # Simulate static/sim GPS: last_update=0.0
+        mav.get_gps.return_value = {"last_update": 0.0, "fix": 4}
+        strike_cb = MagicMock(return_value=True)
+        tracks = _make_tracks((1, "mine", 0.92))
+
+        ctrl.evaluate(tracks, mav, MagicMock(return_value=True), strike_cb)
+
+        strike_cb.assert_called_once()
+
+    def test_stale_real_gps_blocks_eval(self):
+        """GPS with a real but stale last_update should block eval."""
+        ctrl = _make_controller(min_track_frames=1)
+        mav = _make_mavlink()
+        # Simulate stale GPS: last_update was 5 seconds ago (> default 2.0)
+        mav.get_gps.return_value = {
+            "last_update": time.monotonic() - 5.0,
+            "fix": 4,
+        }
+        strike_cb = MagicMock()
+        tracks = _make_tracks((1, "mine", 0.92))
+
+        ctrl.evaluate(tracks, mav, MagicMock(return_value=True), strike_cb)
+
+        strike_cb.assert_not_called()
+
     def test_unknown_vehicle_mode(self):
         ctrl = _make_controller()
         mav = _make_mavlink(mode=None)

--- a/tests/test_chain_of_custody.py
+++ b/tests/test_chain_of_custody.py
@@ -97,6 +97,54 @@ class TestChainOfCustody:
             assert ok is False
             assert count == 2  # fails on the tampered line
 
+    def test_multi_detection_frame_chains_sequentially(self):
+        """Each record in a multi-detection frame must chain from the previous."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            multi_result = TrackingResult(
+                tracks=[
+                    TrackedObject(track_id=1, x1=10, y1=20, x2=100, y2=200,
+                                  confidence=0.9, class_id=0, label="person"),
+                    TrackedObject(track_id=2, x1=110, y1=20, x2=200, y2=200,
+                                  confidence=0.8, class_id=1, label="car"),
+                    TrackedObject(track_id=3, x1=210, y1=20, x2=300, y2=200,
+                                  confidence=0.7, class_id=2, label="truck"),
+                ],
+                active_ids=3,
+            )
+            dl = DetectionLogger(
+                log_dir=tmpdir, log_format="jsonl",
+                save_images=False, image_dir=tmpdir,
+                model_hash="multi_test",
+            )
+            dl.start()
+            dl.log(multi_result, frame=np.zeros((100, 100, 3), dtype=np.uint8))
+            dl.stop()
+
+            log_file = list(Path(tmpdir).glob("*.jsonl"))[0]
+            lines = log_file.read_text().strip().split("\n")
+            assert len(lines) == 3
+
+            # Verify sequential chaining: each record's hash builds on previous
+            prev_hash = "0" * 64
+            for i, line in enumerate(lines):
+                record = json.loads(line)
+                stored_hash = record.pop("chain_hash")
+                record_json = json.dumps(record, sort_keys=True)
+                import hashlib
+                expected = hashlib.sha256(
+                    (record_json + prev_hash).encode()
+                ).hexdigest()
+                assert stored_hash == expected, (
+                    f"Record {i}: chain broken — expected {expected[:16]}..., "
+                    f"got {stored_hash[:16]}..."
+                )
+                prev_hash = stored_hash
+
+            # Also verify via verify_log
+            ok, count, msg = verify(log_file)
+            assert ok is True
+            assert count == 3
+
     def test_verify_missing_file(self):
         """verify() should fail gracefully for a missing file."""
         ok, count, msg = verify("/nonexistent/file.jsonl")

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -211,4 +211,3 @@ class TestConfigImportValidation:
         assert data["error"] == "Validation failed"
         assert field in data["field_errors"]
         assert tmp_config.read_text() == original_content
-

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -152,7 +152,9 @@ class TestAuthEnforcement:
                 resp = client.post(url, json=body, headers=headers)
             else:
                 resp = client.post(url, headers=headers)
-            assert resp.status_code == 401, f"{url} should require auth despite forged sec-fetch-site"
+            assert resp.status_code == 401, (
+                f"{url} should require auth despite forged sec-fetch-site"
+            )
 
     def test_origin_subdomain_spoof_does_not_bypass_token_checks(self, client):
         configure_auth("secret-token-123")


### PR DESCRIPTION
## Summary

Six fixes from the code review audit, ordered by severity:

1. **CRITICAL — Chain hash bug** (`detection_logger.py`): Multi-detection frames hashed all records against the same `_prev_chain_hash`, then only stored the last record's hash. `verify_log` reported broken chains on valid logs. Fixed by advancing `_prev_chain_hash` inside the loop per-record. Added revert-on-queue-full logic and a 3-detection frame test.

2. **CRITICAL — Stale GPS blocks sim mode** (`autonomous.py`): `gps_data.get("last_update", 0.0)` defaulted to 0.0, making `gps_age` always huge when no real GPS is present. This permanently blocked autonomous eval in sim/bench configs. Fixed by skipping the freshness check when `last_update` is 0.0 (operator-provided/static GPS). Added tests for both sim and stale-real-GPS cases.

3. **Schema gap — `vehicle.fw`** (`config_schema.py`): The `[vehicle.fw]` section existed in `config.ini` but had no schema validation. Added `autonomous.post_action_mode` (string) and `autonomous.min_track_frames` (int, 1-100) field specs.

4. **Factory defaults gap** (`config.ini.factory`): `[approach]`, `[drop]`, `[guidance]`, and `[vehicle.fw]` sections were missing from factory defaults. A factory reset would lose these settings. Copied current sane defaults.

5. **Module index gaps** (`CLAUDE.md`): Three active modules were unlisted: `rf/rssi_protocol.py`, `rf/rtl_power_client.py`, `waypoint_export.py`. Added to Module Index table.

6. **LOC counts** — skipped, CLAUDE.md has no LOC references to update.

## Test plan

- [x] New test: multi-detection frame chains sequentially (`test_chain_of_custody.py`)
- [x] New test: simulated GPS (last_update=0.0) proceeds (`test_autonomous.py`)
- [x] New test: stale real GPS blocks eval (`test_autonomous.py`)
- [x] Full suite: 1011 passed, 1 skipped, 23 deselected

https://claude.ai/code/session_01E63USauY3kMApim8baJr1K