### PR TITLE
Harden default web control access

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker run --rm --privileged --runtime nvidia \
   hydra-detect
 ```
 
-Open **http://localhost:8080** in a browser. That's the operator dashboard.
+Open **http://127.0.0.1:8080** in a browser. That's the operator dashboard. By default Hydra now binds the dashboard to localhost and keeps control routes fail-closed unless you configure an API token or explicitly opt into insecure unauthenticated control.
 
 For a full walkthrough starting from a bare Jetson, see the [Jetson flash guide](docs/setup/jetson-flash.mdx) followed by the [Docker install guide](docs/setup/jetson-docker.mdx).
 
@@ -106,6 +106,30 @@ sudo jetson_clocks
 sudo cp scripts/hydra-detect.service /etc/systemd/system/
 sudo systemctl daemon-reload
 sudo systemctl enable --now hydra-detect
+```
+
+## Web Control Safety Defaults
+
+Hydra now ships with a **safe web default**:
+
+- `[web] host = 127.0.0.1` keeps the dashboard local to the Jetson unless you intentionally expose it.
+- Empty `[web] api_token` no longer makes control routes public. Vehicle, strike, RF, config-write, and stop/pause routes fail closed until you set a Bearer token.
+- Read-only routes such as stats, review, and the MJPEG stream can still be served without a token.
+
+To intentionally enable remote control, choose one of these patterns:
+
+1. **Recommended:** set a strong `[web] api_token`, then send `Authorization: Bearer <token>` on control requests.
+2. **Explicitly insecure override:** set `[web] allow_unauthenticated_control = true` only for trusted lab setups where you accept the risk of unauthenticated control.
+3. If you also want remote browser access, change `[web] host` from `127.0.0.1` to a LAN/WAN bind such as `0.0.0.0` only when you intend to expose it.
+
+Example secure remote-control configuration:
+
+```ini
+[web]
+host = 0.0.0.0
+port = 8080
+api_token = replace-with-a-long-random-token
+allow_unauthenticated_control = false
 ```
 
 ## The Dashboard
@@ -279,8 +303,10 @@ Everything lives in `config.ini`. Full reference below.
 | Key | Default | Description |
 |-----|---------|-------------|
 | `enabled` | `true` | Turn the web dashboard on or off |
-| `host` | `0.0.0.0` | Bind address |
+| `host` | `127.0.0.1` | Bind address. Localhost by default so the dashboard is not remotely exposed unless you intentionally change it |
 | `port` | `8080` | HTTP port |
+| `api_token` | *(empty)* | Bearer token for control routes. Blank token now keeps control routes fail-closed |
+| `allow_unauthenticated_control` | `false` | Explicit insecure override for control routes; only enable intentionally |
 | `mjpeg_quality` | `70` | JPEG quality for the video stream (1-100) |
 
 ### [osd]
@@ -410,7 +436,7 @@ Hydra/
 | `POST` | `/api/pipeline/stop` | Gracefully stop the pipeline |
 | `POST` | `/api/pipeline/pause` | Pause or resume detection (`{"paused": true}`) |
 
-Control endpoints (POST routes for target, vehicle, pipeline, and RF) require bearer token authentication.
+Control endpoints (POST routes for target, vehicle, pipeline, RF, and config writes) require bearer token authentication by default. If `api_token` is blank, those control routes now return `401` unless you explicitly set `allow_unauthenticated_control = true`.
 
 ## Vehicle Compatibility
 

--- a/config.ini
+++ b/config.ini
@@ -41,10 +41,11 @@ light_bar_flash_sec = 0.5
 
 [web]
 enabled = true
-host = 0.0.0.0
+host = 127.0.0.1
 port = 8080
 mjpeg_quality = 70
 api_token = 
+allow_unauthenticated_control = false
 
 [osd]
 enabled = true

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -53,11 +53,18 @@ All settings live in `config.ini`. Restart the service after changes. Some setti
 
 ## [web]
 
+
+<Warning>
+Safe default: Hydra now binds the web UI to `127.0.0.1` and denies unauthenticated control requests when `[web] api_token` is empty. To intentionally enable remote control, set a non-empty `api_token` and, if needed, change `host` to `0.0.0.0` or another non-local bind address. Only set `allow_unauthenticated_control = true` for deliberately insecure test environments.
+</Warning>
+
 | Key | Default | Description |
 |-----|---------|-------------|
 | `enabled` | `true` | Turn the web dashboard on or off |
-| `host` | `0.0.0.0` | Bind address |
+| `host` | `127.0.0.1` | Bind address. Localhost by default so the dashboard is not LAN/WAN-exposed unless you intentionally change it |
 | `port` | `8080` | HTTP port |
+| `api_token` | *(empty)* | Bearer token for control routes. If blank, control routes fail closed unless you explicitly enable the insecure override |
+| `allow_unauthenticated_control` | `false` | Explicit insecure override for control routes. Set to `true` only if you intentionally accept unauthenticated remote control risk |
 | `mjpeg_quality` | `70` | JPEG quality for the video stream (1-100) |
 
 ## [osd]

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -292,7 +292,7 @@ class Pipeline:
 
         # Web UI
         self._web_enabled = self._cfg.getboolean("web", "enabled", fallback=True)
-        self._web_host = self._cfg.get("web", "host", fallback="0.0.0.0")
+        self._web_host = self._cfg.get("web", "host", fallback="127.0.0.1")
         self._web_port = self._cfg.getint("web", "port", fallback=8080)
 
         self._running = False
@@ -361,12 +361,22 @@ class Pipeline:
         if self._web_enabled:
             # Configure API auth
             api_token = self._cfg.get("web", "api_token", fallback="").strip()
-            if not api_token:
+            allow_insecure_control = self._cfg.getboolean(
+                "web", "allow_unauthenticated_control", fallback=False
+            )
+            if not api_token and not allow_insecure_control:
                 logger.warning(
-                    "WARNING: No API token configured — web control endpoints are "
-                    "unauthenticated. Set [web] api_token in config.ini for production use."
+                    "No API token configured — control routes fail closed until [web] api_token "
+                    "is set or allow_unauthenticated_control=true is explicitly enabled."
                 )
-            configure_auth(api_token or None)
+            elif not api_token and allow_insecure_control:
+                logger.warning(
+                    "WARNING: allow_unauthenticated_control=true enables unauthenticated control routes."
+                )
+            configure_auth(
+                api_token or None,
+                allow_insecure_control=allow_insecure_control,
+            )
 
             # Set initial runtime config for web UI
             stream_state.update_runtime_config({

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -49,22 +49,31 @@ templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 
 # API token for control endpoints — set via configure_auth()
 _api_token: Optional[str] = None
+_allow_insecure_control = False
 
 
-def configure_auth(token: Optional[str]) -> None:
-    """Set the API token for control endpoints. None or empty disables auth."""
-    global _api_token
+def configure_auth(token: Optional[str], *, allow_insecure_control: bool = False) -> None:
+    """Configure control-route auth.
+
+    Control routes require Bearer auth unless an explicit insecure override is on.
+    """
+    global _api_token, _allow_insecure_control
     _api_token = token if token else None
+    _allow_insecure_control = allow_insecure_control
     if _api_token:
         logger.info("API token auth enabled for control endpoints.")
+    elif _allow_insecure_control:
+        logger.warning("Insecure override enabled: control endpoints accept unauthenticated requests.")
     else:
-        logger.info("API token auth disabled (no token configured).")
+        logger.info("API token missing: control endpoints remain disabled until authenticated access is configured.")
 
 
 def _check_auth(authorization: Optional[str]) -> Optional[JSONResponse]:
     """Validate Bearer token. Returns an error response if auth fails, None if OK."""
     if _api_token is None:
-        return None  # Auth disabled
+        if _allow_insecure_control:
+            return None
+        return JSONResponse({"error": "Control endpoints require a configured API token or explicit insecure override"}, status_code=401)
     if not authorization or not authorization.startswith("Bearer "):
         return JSONResponse({"error": "Authorization header with Bearer token required"}, status_code=401)
     provided = authorization[len("Bearer "):]
@@ -898,7 +907,7 @@ async def api_restore_config_backup(request: Request, authorization: str | None 
 
 # ── Server launcher ──────────────────────────────────────────────────
 
-def run_server(host: str = "0.0.0.0", port: int = 8080) -> threading.Thread:
+def run_server(host: str = "127.0.0.1", port: int = 8080) -> threading.Thread:
     """Start uvicorn in a daemon thread and return the thread handle."""
     import uvicorn
 

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -33,7 +33,7 @@ def tmp_config(tmp_path):
     config = configparser.ConfigParser()
     config["camera"] = {"source": "auto", "width": "640", "height": "480", "fps": "30"}
     config["detector"] = {"yolo_model": "yolov8s.pt", "yolo_confidence": "0.45"}
-    config["web"] = {"host": "0.0.0.0", "port": "8080", "api_token": "secret-test-token"}
+    config["web"] = {"host": "127.0.0.1", "port": "8080", "api_token": "secret-test-token", "allow_unauthenticated_control": "false"}
     config["tracker"] = {"track_thresh": "0.5", "track_buffer": "30"}
     path = tmp_path / "config.ini"
     with open(path, "w") as f:
@@ -57,9 +57,9 @@ class TestConfigGetEndpoint:
         assert resp.status_code == 200
         assert resp.json()["web"]["api_token"] == "***"
 
-    def test_get_config_requires_auth_when_enabled(self, client, tmp_config):
-        configure_auth("my-token")
-        resp = client.get("/api/config/full")
+    def test_get_config_requires_auth_with_secure_default(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.get("/api/config/full")
         assert resp.status_code == 401
 
 
@@ -93,10 +93,17 @@ class TestConfigPostEndpoint:
         assert resp.status_code == 200
         assert (tmp_config.parent / "config.ini.bak").exists()
 
-    def test_post_config_requires_auth_when_enabled(self, client, tmp_config):
-        configure_auth("my-token")
-        resp = client.post("/api/config/full", json={"camera": {"fps": "15"}})
+    def test_post_config_requires_auth_with_secure_default(self, client, tmp_config):
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/full", json={"camera": {"fps": "15"}})
         assert resp.status_code == 401
+
+
+    def test_post_config_allows_explicit_insecure_override(self, client, tmp_config):
+        configure_auth(None, allow_insecure_control=True)
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/config/full", json={"camera": {"fps": "15"}})
+        assert resp.status_code == 200
 
     def test_post_config_rejects_oversized_body(self, client, tmp_config):
         huge = {"camera": {"source": "x" * 70000}}

--- a/tests/test_rf_web_api.py
+++ b/tests/test_rf_web_api.py
@@ -5,13 +5,19 @@ from __future__ import annotations
 import pytest
 from starlette.testclient import TestClient
 
-from hydra_detect.web.server import app, stream_state
+from hydra_detect.web.server import app, configure_auth, stream_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    configure_auth(None)
+    stream_state._callbacks = {}
+    yield
 
 
 @pytest.fixture
 def client():
     """Create a test client and reset stream_state callbacks."""
-    stream_state._callbacks = {}
     return TestClient(app)
 
 
@@ -42,29 +48,54 @@ class TestRFStatusEndpoint:
 
 
 class TestRFStartEndpoint:
+    def test_start_requires_auth_by_default_when_token_empty(self, client):
+        resp = client.post("/api/rf/start", json={"mode": "wifi", "target_bssid": "AA:BB:CC:DD:EE:FF"})
+        assert resp.status_code == 401
+
+    def test_start_missing_bearer_rejected_when_token_configured(self, client):
+        configure_auth("secret-token")
+        resp = client.post("/api/rf/start", json={"mode": "wifi", "target_bssid": "AA:BB:CC:DD:EE:FF"})
+        assert resp.status_code == 401
+
+    def test_start_accepts_valid_bearer_token(self, client):
+        configure_auth("secret-token")
+        stream_state.set_callbacks(on_rf_start=lambda params: True)
+        resp = client.post(
+            "/api/rf/start",
+            json={"mode": "sdr", "target_freq_mhz": 915.0},
+            headers={"Authorization": "Bearer secret-token"},
+        )
+        assert resp.status_code == 200
+
     def test_start_without_callback(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/rf/start", json={"mode": "wifi", "target_bssid": "AA:BB:CC:DD:EE:FF"})
         assert resp.status_code == 503
 
     def test_start_invalid_mode(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/rf/start", json={"mode": "bluetooth"})
         assert resp.status_code == 400
         assert "mode" in resp.json()["error"]
 
     def test_start_wifi_no_bssid(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/rf/start", json={"mode": "wifi"})
         assert resp.status_code == 400
         assert "bssid" in resp.json()["error"].lower()
 
     def test_start_invalid_bssid_format(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/rf/start", json={"mode": "wifi", "target_bssid": "invalid"})
         assert resp.status_code == 400
 
     def test_start_invalid_freq(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/rf/start", json={"mode": "sdr", "target_freq_mhz": 99999})
         assert resp.status_code == 400
 
     def test_start_invalid_search_pattern(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/rf/start", json={
             "mode": "sdr", "target_freq_mhz": 915.0,
             "search_pattern": "zigzag"
@@ -72,13 +103,15 @@ class TestRFStartEndpoint:
         assert resp.status_code == 400
 
     def test_start_invalid_numeric_field(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/rf/start", json={
             "mode": "sdr", "target_freq_mhz": 915.0,
-            "search_area_m": 5000.0  # over max
+            "search_area_m": 5000.0
         })
         assert resp.status_code == 400
 
     def test_start_success(self, client):
+        configure_auth(None, allow_insecure_control=True)
         stream_state.set_callbacks(on_rf_start=lambda params: True)
         resp = client.post("/api/rf/start", json={
             "mode": "sdr",
@@ -90,6 +123,7 @@ class TestRFStartEndpoint:
         assert resp.json()["status"] == "ok"
 
     def test_start_callback_returns_false(self, client):
+        configure_auth(None, allow_insecure_control=True)
         stream_state.set_callbacks(on_rf_start=lambda params: False)
         resp = client.post("/api/rf/start", json={
             "mode": "sdr",
@@ -98,11 +132,13 @@ class TestRFStartEndpoint:
         assert resp.status_code == 503
 
     def test_start_sdr_valid(self, client):
+        configure_auth(None, allow_insecure_control=True)
         received = {}
 
         def on_start(params):
             received.update(params)
             return True
+
         stream_state.set_callbacks(on_rf_start=on_start)
         resp = client.post("/api/rf/start", json={
             "mode": "sdr",
@@ -119,11 +155,17 @@ class TestRFStartEndpoint:
 
 
 class TestRFStopEndpoint:
+    def test_stop_requires_auth_by_default_when_token_empty(self, client):
+        resp = client.post("/api/rf/stop")
+        assert resp.status_code == 401
+
     def test_stop_without_callback(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/rf/stop")
         assert resp.status_code == 503
 
     def test_stop_success(self, client):
+        configure_auth(None, allow_insecure_control=True)
         stopped = []
         stream_state.set_callbacks(on_rf_stop=lambda: stopped.append(True))
         resp = client.post("/api/rf/stop")

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -16,7 +16,6 @@ def _reset_state():
     configure_auth(None)
     stream_state.target_lock = {"locked": False, "track_id": None, "mode": None, "label": None}
     stream_state.runtime_config = {"prompts": ["person"], "threshold": 0.25, "auto_loiter": False}
-    # Clear callbacks
     stream_state._callbacks.clear()
     yield
 
@@ -26,9 +25,32 @@ def client():
     return TestClient(app)
 
 
-# ---------------------------------------------------------------------------
-# Read-only endpoints (no auth required)
-# ---------------------------------------------------------------------------
+CONTROL_ENDPOINTS = [
+    ("POST", "/api/config/prompts", {"prompts": ["car"]}),
+    ("POST", "/api/config/threshold", {"threshold": 0.5}),
+    ("POST", "/api/vehicle/loiter", None),
+    ("POST", "/api/target/lock", {"track_id": 1}),
+    ("POST", "/api/target/unlock", None),
+    ("POST", "/api/target/strike", {"track_id": 1, "confirm": True}),
+    ("POST", "/api/config/alert-classes", {"classes": ["person"]}),
+    ("POST", "/api/vehicle/mode", {"mode": "AUTO"}),
+]
+
+READ_ONLY_ENDPOINTS = [
+    ("GET", "/api/stats"),
+    ("GET", "/api/config"),
+    ("GET", "/api/tracks"),
+    ("GET", "/api/target"),
+    ("GET", "/api/detections"),
+    ("GET", "/api/config/alert-classes"),
+]
+
+
+def _request(client: TestClient, method: str, url: str, body=None, headers=None):
+    if method == "POST":
+        return client.post(url, json=body, headers=headers or {})
+    return client.get(url, headers=headers or {})
+
 
 class TestReadOnlyEndpoints:
     def test_stats(self, client):
@@ -57,78 +79,59 @@ class TestReadOnlyEndpoints:
         assert resp.json() == []
 
 
-# ---------------------------------------------------------------------------
-# Auth enforcement on control endpoints
-# ---------------------------------------------------------------------------
-
 class TestAuthEnforcement:
-    CONTROL_ENDPOINTS = [
-        ("POST", "/api/config/prompts", {"prompts": ["car"]}),
-        ("POST", "/api/config/threshold", {"threshold": 0.5}),
-        ("POST", "/api/vehicle/loiter", None),
-        ("POST", "/api/target/lock", {"track_id": 1}),
-        ("POST", "/api/target/unlock", None),
-        ("POST", "/api/target/strike", {"track_id": 1, "confirm": True}),
-        ("POST", "/api/config/alert-classes", {"classes": ["person"]}),
-        ("POST", "/api/vehicle/mode", {"mode": "AUTO"}),
-    ]
-
-    def test_no_auth_when_disabled(self, client):
-        """When no token is configured, control endpoints should work without auth."""
+    def test_empty_token_fails_closed_for_control_routes(self, client):
         configure_auth(None)
-        # Just check we don't get 401/403 (may get 400/503 from missing callbacks — that's fine)
-        for method, url, body in self.CONTROL_ENDPOINTS:
-            if body:
-                resp = client.post(url, json=body)
-            else:
-                resp = client.post(url)
-            assert resp.status_code not in (401, 403), f"{url} returned {resp.status_code}"
+        for method, url, body in CONTROL_ENDPOINTS:
+            resp = _request(client, method, url, body=body)
+            assert resp.status_code == 401, f"{url} should fail closed without auth"
 
-    def test_missing_token_rejected(self, client):
+    def test_read_only_routes_stay_available_without_token(self, client):
+        configure_auth(None)
+        for method, url in READ_ONLY_ENDPOINTS:
+            resp = _request(client, method, url)
+            assert resp.status_code == 200, f"{url} should remain readable"
+
+    def test_missing_token_rejected_when_token_configured(self, client):
         configure_auth("secret-token-123")
-        for method, url, body in self.CONTROL_ENDPOINTS:
-            if body:
-                resp = client.post(url, json=body)
-            else:
-                resp = client.post(url)
+        for method, url, body in CONTROL_ENDPOINTS:
+            resp = _request(client, method, url, body=body)
             assert resp.status_code == 401, f"{url} should require auth"
 
     def test_wrong_token_rejected(self, client):
         configure_auth("secret-token-123")
         headers = {"Authorization": "Bearer wrong-token"}
-        for method, url, body in self.CONTROL_ENDPOINTS:
-            if body:
-                resp = client.post(url, json=body, headers=headers)
-            else:
-                resp = client.post(url, headers=headers)
+        for method, url, body in CONTROL_ENDPOINTS:
+            resp = _request(client, method, url, body=body, headers=headers)
             assert resp.status_code == 403, f"{url} should reject wrong token"
 
-    def test_correct_token_accepted(self, client):
+    def test_valid_bearer_token_allows_control_routes(self, client):
         configure_auth("secret-token-123")
         headers = {"Authorization": "Bearer secret-token-123"}
-        for method, url, body in self.CONTROL_ENDPOINTS:
-            if body:
-                resp = client.post(url, json=body, headers=headers)
-            else:
-                resp = client.post(url, headers=headers)
-            # Should NOT be 401 or 403 (may be 400/503 from missing callbacks)
+        for method, url, body in CONTROL_ENDPOINTS:
+            resp = _request(client, method, url, body=body, headers=headers)
+            assert resp.status_code not in (401, 403), f"{url} returned {resp.status_code}"
+
+    def test_explicit_insecure_override_re_enables_unauthenticated_control(self, client):
+        configure_auth(None, allow_insecure_control=True)
+        for method, url, body in CONTROL_ENDPOINTS:
+            resp = _request(client, method, url, body=body)
             assert resp.status_code not in (401, 403), f"{url} returned {resp.status_code}"
 
 
-# ---------------------------------------------------------------------------
-# Control endpoint behaviour
-# ---------------------------------------------------------------------------
-
 class TestControlEndpoints:
     def test_set_prompts_validates_input(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/config/prompts", json={"prompts": []})
         assert resp.status_code == 400
 
     def test_set_threshold_validates_range(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/config/threshold", json={"threshold": 2.0})
         assert resp.status_code == 400
 
     def test_set_threshold_success(self, client):
+        configure_auth(None, allow_insecure_control=True)
         called_with = {}
 
         def on_threshold(t):
@@ -140,42 +143,46 @@ class TestControlEndpoints:
         assert called_with["t"] == 0.6
 
     def test_lock_requires_track_id(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/target/lock", json={})
         assert resp.status_code == 400
 
     def test_strike_requires_confirm(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/target/strike", json={"track_id": 1})
         assert resp.status_code == 400
 
     def test_strike_requires_track_id(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/target/strike", json={"confirm": True})
         assert resp.status_code == 400
 
     def test_loiter_no_mavlink(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/vehicle/loiter")
         assert resp.status_code == 503
 
 
-# ---------------------------------------------------------------------------
-# Prompt input validation
-# ---------------------------------------------------------------------------
-
 class TestPromptValidation:
     def test_too_many_prompts(self, client):
+        configure_auth(None, allow_insecure_control=True)
         prompts = [f"item{i}" for i in range(MAX_PROMPTS + 1)]
         resp = client.post("/api/config/prompts", json={"prompts": prompts})
         assert resp.status_code == 400
         assert "max" in resp.json()["error"]
 
     def test_non_string_prompt(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/config/prompts", json={"prompts": [123]})
         assert resp.status_code == 400
 
     def test_empty_string_prompt(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/config/prompts", json={"prompts": ["valid", "  "]})
         assert resp.status_code == 400
 
     def test_long_prompt_truncated(self, client):
+        configure_auth(None, allow_insecure_control=True)
         received = {}
 
         def on_prompts(p):
@@ -188,6 +195,7 @@ class TestPromptValidation:
         assert len(received["p"][0]) == MAX_PROMPT_LENGTH
 
     def test_prompts_stripped(self, client):
+        configure_auth(None, allow_insecure_control=True)
         received = {}
 
         def on_prompts(p):
@@ -199,12 +207,9 @@ class TestPromptValidation:
         assert received["p"] == ["person", "car"]
 
 
-# ---------------------------------------------------------------------------
-# Audit logging
-# ---------------------------------------------------------------------------
-
 class TestAuditLogging:
     def test_strike_logs_audit(self, client, caplog):
+        configure_auth(None, allow_insecure_control=True)
         stream_state.set_callbacks(on_strike_command=lambda tid: True)
         with caplog.at_level(logging.INFO, logger="hydra.audit"):
             resp = client.post("/api/target/strike", json={"track_id": 7, "confirm": True})
@@ -212,6 +217,7 @@ class TestAuditLogging:
         assert any("action=strike" in r.message and "target=7" in r.message for r in caplog.records)
 
     def test_loiter_logs_audit(self, client, caplog):
+        configure_auth(None, allow_insecure_control=True)
         stream_state.set_callbacks(on_loiter_command=lambda: None)
         with caplog.at_level(logging.INFO, logger="hydra.audit"):
             resp = client.post("/api/vehicle/loiter")
@@ -219,6 +225,7 @@ class TestAuditLogging:
         assert any("action=loiter" in r.message and "outcome=ok" in r.message for r in caplog.records)
 
     def test_failed_action_logs_outcome(self, client, caplog):
+        configure_auth(None, allow_insecure_control=True)
         stream_state.set_callbacks(on_strike_command=lambda tid: False)
         with caplog.at_level(logging.INFO, logger="hydra.audit"):
             resp = client.post("/api/target/strike", json={"track_id": 3, "confirm": True})
@@ -226,15 +233,9 @@ class TestAuditLogging:
         assert any("action=strike" in r.message and "outcome=failed" in r.message for r in caplog.records)
 
 
-# ---------------------------------------------------------------------------
-# Alert classes endpoints
-# ---------------------------------------------------------------------------
-
 class TestAlertClassesEndpoints:
     def test_get_alert_classes(self, client):
-        stream_state.set_callbacks(
-            get_class_names=lambda: ["person", "car", "dog"],
-        )
+        stream_state.set_callbacks(get_class_names=lambda: ["person", "car", "dog"])
         stream_state.runtime_config["alert_classes"] = ["person"]
         resp = client.get("/api/config/alert-classes")
         assert resp.status_code == 200
@@ -246,9 +247,12 @@ class TestAlertClassesEndpoints:
         assert data["alert_classes"] == ["person"]
 
     def test_post_alert_classes(self, client):
+        configure_auth(None, allow_insecure_control=True)
         called = {}
+
         def on_change(classes):
             called["classes"] = classes
+
         stream_state.set_callbacks(
             on_alert_classes_change=on_change,
             get_class_names=lambda: ["person", "car", "dog"],
@@ -258,9 +262,12 @@ class TestAlertClassesEndpoints:
         assert called["classes"] == ["person", "car"]
 
     def test_post_empty_means_all(self, client):
+        configure_auth(None, allow_insecure_control=True)
         called = {}
+
         def on_change(classes):
             called["classes"] = classes
+
         stream_state.set_callbacks(
             on_alert_classes_change=on_change,
             get_class_names=lambda: ["person", "car"],
@@ -270,45 +277,42 @@ class TestAlertClassesEndpoints:
         assert called["classes"] == []
 
     def test_post_invalid_class_rejected(self, client):
-        stream_state.set_callbacks(
-            get_class_names=lambda: ["person", "car"],
-        )
+        configure_auth(None, allow_insecure_control=True)
+        stream_state.set_callbacks(get_class_names=lambda: ["person", "car"])
         resp = client.post("/api/config/alert-classes", json={"classes": ["person", "INVALID"]})
         assert resp.status_code == 400
 
 
-# ---------------------------------------------------------------------------
-# Vehicle mode endpoint
-# ---------------------------------------------------------------------------
-
 class TestVehicleModeEndpoint:
     def test_set_mode_success(self, client):
+        configure_auth(None, allow_insecure_control=True)
         called = {}
+
         def on_mode(mode):
             called["mode"] = mode
             return True
+
         stream_state.set_callbacks(on_set_mode_command=on_mode)
         resp = client.post("/api/vehicle/mode", json={"mode": "AUTO"})
         assert resp.status_code == 200
         assert called["mode"] == "AUTO"
 
     def test_set_mode_missing_mode(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/vehicle/mode", json={})
         assert resp.status_code == 400
 
     def test_set_mode_no_callback(self, client):
+        configure_auth(None, allow_insecure_control=True)
         resp = client.post("/api/vehicle/mode", json={"mode": "AUTO"})
         assert resp.status_code == 503
 
     def test_set_mode_failed(self, client):
+        configure_auth(None, allow_insecure_control=True)
         stream_state.set_callbacks(on_set_mode_command=lambda m: False)
         resp = client.post("/api/vehicle/mode", json={"mode": "AUTO"})
         assert resp.status_code == 503
 
-
-# ---------------------------------------------------------------------------
-# Static file serving
-# ---------------------------------------------------------------------------
 
 class TestSPAShell:
     def test_index_serves_base_html(self, client):


### PR DESCRIPTION
### Motivation
- Prevent freshly-deployed instances from exposing remote vehicle control by shipping a network- and auth-safe default for the web UI. 
- Make control routes fail closed when no API token is configured unless the operator intentionally opts into an insecure override. 

### Description
- Change the default web bind address in `config.ini` from `0.0.0.0` to `127.0.0.1` and add a new `[web] allow_unauthenticated_control = false` flag to make the secure behavior explicit. 
- Update `hydra_detect/pipeline.py` to read the new `allow_unauthenticated_control` flag and call `configure_auth(api_token or None, allow_insecure_control=...)`, warning and failing closed when `api_token` is empty and the insecure override is not enabled. 
- Modify `hydra_detect/web/server.py` to accept an `allow_insecure_control` parameter in `configure_auth`, track `_allow_insecure_control`, and make `_check_auth` return `401` for unauthenticated control requests when no token is set unless the explicit insecure override is active; read-only routes remain accessible. 
- Separate tests and test expectations to cover the secure default and the explicit override by updating `tests/test_web_api.py`, `tests/test_rf_web_api.py`, and `tests/test_config_api.py` to assert empty-token denial for control routes, valid Bearer acceptance, read-only route availability, and the explicit insecure override path. 
- Update operator docs in `README.md` and `docs/reference/configuration.mdx` to document the safe defaults and the two supported ways to enable remote control (set `api_token` or explicitly enable `allow_unauthenticated_control`). 

### Testing
- Updated/added tests in `tests/test_web_api.py`, `tests/test_rf_web_api.py`, and `tests/test_config_api.py` to validate: empty token + secure default denies control routes, valid Bearer token grants control routes, read-only endpoints remain available, and the explicit `allow_unauthenticated_control` override re-enables unauthenticated control when requested. 
- `python -m compileall hydra_detect` succeeded and `python -m compileall tests` succeeded. 
- Attempted to run `pytest tests/test_web_api.py tests/test_rf_web_api.py tests/test_config_api.py`, but test collection was blocked because the test environment lacks the `httpx` package required by `starlette.testclient`, and installation via `pip` failed in this environment (package index/proxy access error), so full pytest runs could not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb903788c4832884897c99a3de185f)