### PR TITLE
Move LOW BW click binding from inline HTML to JS

### DIFF
--- a/hydra_detect/web/static/js/app.js
+++ b/hydra_detect/web/static/js/app.js
@@ -710,6 +710,12 @@ const HydraApp = (() => {
         if (overlay) overlay.style.display = 'none';
     }
 
+    function initBandwidthToggle() {
+        const btn = document.getElementById('bandwidth-toggle');
+        if (!btn) return;
+        btn.addEventListener('click', toggleLowBandwidth);
+    }
+
     // ── Logout Button ──
     function initLogoutButton() {
         const btn = document.getElementById('footer-logout');
@@ -737,6 +743,7 @@ const HydraApp = (() => {
         initModalEscape();
         initStreamWatcher();
         initAdaptiveQuality();
+        initBandwidthToggle();
         initLogoutButton();
         updatePollers();
     }

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -52,7 +52,7 @@
             <span class="status-dot" id="dot-gps" title="GPS Fix">GPS</span>
             <span class="topbar-tracks" id="track-count-badge" title="Active tracks">0 TRACKS</span>
             <span class="low-light-badge" id="low-light-badge" aria-label="Low light warning" title="Low light detected — image brightness below threshold">LOW LIGHT</span>
-            <button class="bandwidth-toggle" id="bandwidth-toggle" onclick="HydraApp.toggleLowBandwidth()" aria-label="Toggle low bandwidth mode" title="Toggle low bandwidth mode — reduces JPEG quality to save bandwidth">LOW BW</button>
+            <button class="bandwidth-toggle" id="bandwidth-toggle" aria-label="Toggle low bandwidth mode" title="Toggle low bandwidth mode — reduces JPEG quality to save bandwidth">LOW BW</button>
             <span class="pill pill-live" id="connection-pill" aria-label="Connection status">
                 <span class="pill-dot"></span>
                 <span id="connection-text">LIVE</span>

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -512,12 +512,23 @@ class TestSPAShell:
         assert "/static/css/variables.css" in resp.text
         assert "/static/js/app.js" in resp.text
 
+    def test_bandwidth_toggle_uses_js_listener_for_csp(self, client):
+        resp = client.get("/")
+        assert resp.status_code == 200
+        assert 'id="bandwidth-toggle"' in resp.text
+        assert 'onclick="HydraApp.toggleLowBandwidth()"' not in resp.text
+
 
 class TestStaticFileServing:
     def test_css_variables_served(self, client):
         resp = client.get("/static/css/variables.css")
         assert resp.status_code == 200
         assert "ogt-green" in resp.text
+
+    def test_app_js_binds_bandwidth_click_handler(self, client):
+        resp = client.get("/static/js/app.js")
+        assert resp.status_code == 200
+        assert "btn.addEventListener('click', toggleLowBandwidth);" in resp.text
 
     def test_missing_static_file_404(self, client):
         resp = client.get("/static/nonexistent.css")


### PR DESCRIPTION
### Motivation
- Remove the inline `onclick` handler on the LOW BW toggle to make the dashboard compatible with strict Content Security Policy (avoid `unsafe-inline`).
- Preserve existing behavior while moving event wiring into JavaScript for clearer separation of concerns and CSP safety.

### Description
- Removed `onclick="HydraApp.toggleLowBandwidth()"` from the `#bandwidth-toggle` element in `hydra_detect/web/templates/base.html` so no inline script attribute remains.
- Added `initBandwidthToggle()` to `hydra_detect/web/static/js/app.js` which locates `#bandwidth-toggle` and calls `btn.addEventListener('click', toggleLowBandwidth)`.
- Wired `initBandwidthToggle()` into the app initialization path (`init()`), keeping `toggleLowBandwidth()` unchanged so it still toggles the button's `active` class and posts the quality via `/api/stream/quality`.
- Added/updated UI tests in `tests/test_web_api.py` to assert the inline `onclick` is absent from `/` and that `app.js` contains the `addEventListener('click', toggleLowBandwidth)` binding.

### Testing
- New tests added: `TestSPAShell.test_bandwidth_toggle_uses_js_listener_for_csp` and `TestStaticFileServing.test_app_js_binds_bandwidth_click_handler` to validate CSP-safe behavior.
- Attempted to run the targeted pytest checks, but test collection failed in this environment because `httpx` is not installed (required by `starlette.testclient`), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d197b107988328ab4f2dfb5eda3d16)