### PR TITLE
Use server auth status for logout button visibility

### DIFF
--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -656,6 +656,17 @@ async def auth_logout():
     )
 
 
+@app.get("/auth/status")
+async def auth_status(request: Request):
+    """Return whether web password auth is enabled and this request is authenticated."""
+    if _web_password is None:
+        return {"password_enabled": False, "authenticated": True}
+
+    cookie = request.cookies.get("hydra_session", "")
+    authenticated = bool(cookie and _validate_session_cookie(cookie))
+    return {"password_enabled": True, "authenticated": authenticated}
+
+
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
     """Serve the operator dashboard SPA."""

--- a/hydra_detect/web/static/js/app.js
+++ b/hydra_detect/web/static/js/app.js
@@ -711,16 +711,25 @@ const HydraApp = (() => {
     }
 
     // ── Logout Button ──
-    function initLogoutButton() {
+    async function initLogoutButton() {
         const btn = document.getElementById('footer-logout');
         if (!btn) return;
-        // Show logout button only when a session cookie exists
-        if (document.cookie.split(';').some(c => c.trim().startsWith('hydra_session='))) {
-            btn.style.display = '';
+
+        try {
+            const resp = await fetch('/auth/status', { credentials: 'same-origin' });
+            if (resp.ok) {
+                const data = await resp.json();
+                if (data && data.password_enabled && data.authenticated) {
+                    btn.style.display = '';
+                }
+            }
+        } catch (e) {
+            // Ignore auth-status lookup failures and keep button hidden.
         }
+
         btn.addEventListener('click', async () => {
             try {
-                await fetch('/auth/logout', { method: 'POST' });
+                await fetch('/auth/logout', { method: 'POST', credentials: 'same-origin' });
             } catch (e) {
                 // Ignore network errors on logout
             }

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -190,6 +190,29 @@ class TestAuthEnforcement:
             assert resp.status_code not in (401, 403), f"{url} returned {resp.status_code}"
 
 
+class TestAuthStatusEndpoint:
+    def test_auth_status_when_password_disabled(self, client):
+        configure_web_password(None)
+        resp = client.get("/auth/status")
+        assert resp.status_code == 200
+        assert resp.json() == {"password_enabled": False, "authenticated": True}
+
+    def test_auth_status_when_password_enabled_without_session(self, client):
+        configure_web_password("ui-password-1")
+        resp = client.get("/auth/status")
+        assert resp.status_code == 200
+        assert resp.json() == {"password_enabled": True, "authenticated": False}
+
+    def test_auth_status_when_password_enabled_with_session(self, client):
+        configure_web_password("ui-password-1")
+        login_resp = client.post("/auth/login", json={"password": "ui-password-1"})
+        assert login_resp.status_code == 200
+
+        resp = client.get("/auth/status")
+        assert resp.status_code == 200
+        assert resp.json() == {"password_enabled": True, "authenticated": True}
+
+
 class TestWaypointExportAuth:
     def test_waypoint_export_requires_auth_when_token_enabled(self, client):
         stream_state.set_callbacks(


### PR DESCRIPTION
### Motivation
- Avoid frontend parsing of `document.cookie` to decide logout visibility and instead use server-provided auth state.
- Provide a small, explicit endpoint the SPA can query to determine both whether web-password auth is enabled and whether the current request is authenticated.
- Ensure correct behavior in both password-enabled and password-disabled modes and keep logout idempotent.

### Description
- Added `GET /auth/status` in `hydra_detect/web/server.py` which returns `{"password_enabled": bool, "authenticated": bool}` for the current request. 
- Reworked SPA logout initialization in `hydra_detect/web/static/js/app.js` to call `/auth/status` (with `credentials: 'same-origin'`) and only show the footer logout button when `password_enabled` is true and `authenticated` is true, and to call `/auth/logout` with same-origin credentials on click. 
- Included tests in `tests/test_web_api.py` that assert `/auth/status` behavior for password-disabled, password-enabled without a session, and password-enabled with a valid session. 
- Preserved existing session validation logic (`_validate_session_cookie`) and kept logout semantics idempotent by always posting to `/auth/logout` then redirecting to `/login`.

### Testing
- Ran `python -m py_compile hydra_detect/web/server.py`, which succeeded. 
- Attempted to run `pytest -q tests/test_web_api.py -k "auth_status or valid_session_cookie_bypasses_bearer_token"`, which could not complete in this environment because the test harness requires the `httpx` package for `fastapi.testclient` and it is not installed. 
- The new tests were added but could not be executed here due to the missing `httpx` dependency.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d197b442a883288aaa445304fe8d74)