### PR TITLE
Harden confirmation modal accessibility behavior

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -188,3 +188,12 @@ All pages include defense-in-depth headers:
 - Content Security Policy restricting scripts, styles, and connections
 
 The instructor page has a relaxed CSP (`connect-src *`) to allow cross-origin fetches to other Jetsons.
+
+## Keyboard Accessibility Test Checklist (Confirmation Modals)
+
+Use this quick checklist for strike/drop/continuous strike confirmation modals:
+
+- [ ] **Tab cycle:** Open modal, press `Tab` through controls, verify focus stays trapped in modal and loops back to first control.
+- [ ] **Reverse Tab cycle:** Press `Shift+Tab`, verify focus loops from first control back to last control.
+- [ ] **Escape close:** Press `Escape`, verify modal closes and focus returns to the original trigger button.
+- [ ] **Screen reader label:** Confirm modal is announced as a dialog with the correct title (from `aria-labelledby`).

--- a/hydra_detect/web/static/js/app.js
+++ b/hydra_detect/web/static/js/app.js
@@ -17,6 +17,7 @@ const HydraApp = (() => {
     const MAX_TOASTS = 3;
     const TOAST_DEDUP_MS = 5000;
     let apiToken = sessionStorage.getItem('hydra_token') || '';
+    let activeModal = null;
 
     // ── Shared Data (updated by pollers, read by views) ──
     const state = {
@@ -337,13 +338,87 @@ const HydraApp = (() => {
         }
     }
 
-    // ── Modal: Escape to close ──
+    function getModalDialog(modal) {
+        return modal ? (modal.querySelector('[role="dialog"]') || modal) : null;
+    }
+
+    function getFocusableElements(container) {
+        if (!container) return [];
+        return Array.from(container.querySelectorAll(
+            'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        )).filter(el => el.offsetParent !== null);
+    }
+
+    function openModal(modal, triggerElement) {
+        if (!modal) return;
+        if (activeModal && activeModal !== modal) closeModal(activeModal);
+
+        modal.__triggerElement = triggerElement || document.activeElement;
+        modal.classList.add('active');
+        activeModal = modal;
+
+        const dialog = getModalDialog(modal);
+        const focusables = getFocusableElements(dialog);
+        if (focusables.length > 0) {
+            focusables[0].focus();
+        } else if (dialog) {
+            dialog.focus();
+        }
+    }
+
+    function closeModal(modal) {
+        if (!modal) return;
+        modal.classList.remove('active');
+        if (activeModal === modal) activeModal = null;
+
+        const trigger = modal.__triggerElement;
+        if (trigger && document.contains(trigger) && typeof trigger.focus === 'function') {
+            trigger.focus();
+        }
+        modal.__triggerElement = null;
+    }
+
+    function closeActiveModal() {
+        if (activeModal) {
+            closeModal(activeModal);
+            return;
+        }
+        const openModalEl = document.querySelector('.modal-overlay.active');
+        if (openModalEl) closeModal(openModalEl);
+    }
+
+    // ── Modal: Escape to close + Tab focus trap ──
     function initModalEscape() {
         document.addEventListener('keydown', e => {
+            const modal = activeModal || document.querySelector('.modal-overlay.active');
+            if (!modal) return;
+
             if (e.key === 'Escape') {
-                document.querySelectorAll('.modal-overlay.active').forEach(m => {
-                    m.classList.remove('active');
-                });
+                e.preventDefault();
+                closeModal(modal);
+                return;
+            }
+
+            if (e.key === 'Tab') {
+                const dialog = getModalDialog(modal);
+                const focusables = getFocusableElements(dialog);
+                if (focusables.length === 0) {
+                    e.preventDefault();
+                    if (dialog) dialog.focus();
+                    return;
+                }
+
+                const first = focusables[0];
+                const last = focusables[focusables.length - 1];
+                const current = document.activeElement;
+
+                if (e.shiftKey && current === first) {
+                    e.preventDefault();
+                    last.focus();
+                } else if (!e.shiftKey && current === last) {
+                    e.preventDefault();
+                    first.focus();
+                }
             }
         });
     }
@@ -760,5 +835,8 @@ const HydraApp = (() => {
         toggleFullscreen,
         runPreflight,
         dismissPreflight,
+        openModal,
+        closeModal,
+        closeActiveModal,
     };
 })();

--- a/hydra_detect/web/static/js/config.js
+++ b/hydra_detect/web/static/js/config.js
@@ -1158,7 +1158,7 @@ const HydraOperations = (() => {
         const label = document.getElementById('strike-target-label');
         if (label) label.textContent = '#' + selectedTrackId + ' (' + selectedTrackLabel + ')';
         const modal = document.getElementById('strike-modal');
-        if (modal) modal.classList.add('active');
+        if (modal) HydraApp.openModal(modal);
 
         // Wire confirm/cancel (idempotent via replaceWith clone)
         wireStrikeModal();
@@ -1173,7 +1173,7 @@ const HydraOperations = (() => {
             confirmBtn.parentNode.replaceChild(clone, confirmBtn);
             clone.addEventListener('click', async () => {
                 const modal = document.getElementById('strike-modal');
-                if (modal) modal.classList.remove('active');
+                if (modal) HydraApp.closeModal(modal);
                 if (selectedTrackId === null) return;
                 const result = await HydraApp.apiPost('/api/target/strike', {
                     track_id: selectedTrackId,
@@ -1191,7 +1191,7 @@ const HydraOperations = (() => {
             cancelBtn.parentNode.replaceChild(clone, cancelBtn);
             clone.addEventListener('click', () => {
                 const modal = document.getElementById('strike-modal');
-                if (modal) modal.classList.remove('active');
+                if (modal) HydraApp.closeModal(modal);
             });
         }
     }
@@ -1576,7 +1576,7 @@ const HydraOperations = (() => {
         const label = document.getElementById('drop-target-label');
         if (label) label.textContent = '#' + selectedTrackId + ' (' + selectedTrackLabel + ')';
         const modal = document.getElementById('drop-modal');
-        if (modal) modal.classList.add('active');
+        if (modal) HydraApp.openModal(modal);
         wireDropModal();
     }
 
@@ -1588,7 +1588,7 @@ const HydraOperations = (() => {
             confirmBtn.parentNode.replaceChild(clone, confirmBtn);
             clone.addEventListener('click', async () => {
                 const modal = document.getElementById('drop-modal');
-                if (modal) modal.classList.remove('active');
+                if (modal) HydraApp.closeModal(modal);
                 if (selectedTrackId === null) return;
                 await HydraApp.apiPost('/api/approach/drop/' + selectedTrackId, { confirm: true });
             });
@@ -1598,7 +1598,7 @@ const HydraOperations = (() => {
             cancelBtn.parentNode.replaceChild(clone, cancelBtn);
             clone.addEventListener('click', () => {
                 const modal = document.getElementById('drop-modal');
-                if (modal) modal.classList.remove('active');
+                if (modal) HydraApp.closeModal(modal);
             });
         }
     }
@@ -1609,7 +1609,7 @@ const HydraOperations = (() => {
         const label = document.getElementById('approach-strike-target-label');
         if (label) label.textContent = '#' + selectedTrackId + ' (' + selectedTrackLabel + ')';
         const modal = document.getElementById('approach-strike-modal');
-        if (modal) modal.classList.add('active');
+        if (modal) HydraApp.openModal(modal);
         wireApproachStrikeModal();
     }
 
@@ -1621,7 +1621,7 @@ const HydraOperations = (() => {
             confirmBtn.parentNode.replaceChild(clone, confirmBtn);
             clone.addEventListener('click', async () => {
                 const modal = document.getElementById('approach-strike-modal');
-                if (modal) modal.classList.remove('active');
+                if (modal) HydraApp.closeModal(modal);
                 if (selectedTrackId === null) return;
                 await HydraApp.apiPost('/api/approach/strike/' + selectedTrackId, { confirm: true });
             });
@@ -1631,7 +1631,7 @@ const HydraOperations = (() => {
             cancelBtn.parentNode.replaceChild(clone, cancelBtn);
             clone.addEventListener('click', () => {
                 const modal = document.getElementById('approach-strike-modal');
-                if (modal) modal.classList.remove('active');
+                if (modal) HydraApp.closeModal(modal);
             });
         }
     }

--- a/hydra_detect/web/static/js/control.js
+++ b/hydra_detect/web/static/js/control.js
@@ -137,22 +137,75 @@
         apiPost('/api/target/unlock', {}).then(poll);
     }
 
+    function getConfirmFocusable() {
+        var modal = document.querySelector('#confirm-overlay [role=\"dialog\"]');
+        if (!modal) return [];
+        return Array.prototype.slice.call(modal.querySelectorAll('button:not([disabled]), [tabindex]:not([tabindex=\"-1\"])'));
+    }
+
+    function openConfirmModal(triggerEl) {
+        var overlay = document.getElementById('confirm-overlay');
+        if (!overlay) return;
+        overlay.__triggerElement = triggerEl || document.activeElement;
+        overlay.classList.add('active');
+        var modal = overlay.querySelector('[role=\"dialog\"]');
+        var focusables = getConfirmFocusable();
+        if (focusables.length) focusables[0].focus();
+        else if (modal) modal.focus();
+    }
+
+    function closeConfirmModal() {
+        var overlay = document.getElementById('confirm-overlay');
+        if (!overlay) return;
+        overlay.classList.remove('active');
+        var trigger = overlay.__triggerElement;
+        if (trigger && document.contains(trigger) && typeof trigger.focus === 'function') {
+            trigger.focus();
+        }
+        overlay.__triggerElement = null;
+    }
+
+    document.addEventListener('keydown', function (e) {
+        var overlay = document.getElementById('confirm-overlay');
+        if (!overlay || !overlay.classList.contains('active')) return;
+
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            closeConfirmModal();
+            pendingStrikeId = null;
+            return;
+        }
+
+        if (e.key !== 'Tab') return;
+        var focusables = getConfirmFocusable();
+        if (!focusables.length) return;
+        var first = focusables[0];
+        var last = focusables[focusables.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+        }
+    });
+
     // Strike confirmation
     var pendingStrikeId = null;
     function confirmStrike(trackId) {
         pendingStrikeId = trackId;
         document.getElementById('confirm-tid').textContent = '#' + trackId;
-        document.getElementById('confirm-overlay').classList.add('active');
+        openConfirmModal(document.activeElement);
     }
     document.getElementById('confirm-yes').addEventListener('click', function() {
-        document.getElementById('confirm-overlay').classList.remove('active');
+        closeConfirmModal();
         if (pendingStrikeId != null) {
             apiPost('/api/target/strike', { track_id: pendingStrikeId, confirm: true }).then(poll);
             pendingStrikeId = null;
         }
     });
     document.getElementById('confirm-no').addEventListener('click', function() {
-        document.getElementById('confirm-overlay').classList.remove('active');
+        closeConfirmModal();
         pendingStrikeId = null;
     });
 

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -441,6 +441,9 @@ const HydraOps = (() => {
 
         var card = document.createElement('div');
         card.className = 'ops-confirm-card';
+        card.setAttribute('role', 'dialog');
+        card.setAttribute('aria-modal', 'true');
+        card.setAttribute('tabindex', '-1');
 
         var title = document.createElement('div');
         title.className = 'ops-confirm-title';
@@ -451,6 +454,9 @@ const HydraOps = (() => {
             title.className += ' warning';
             title.textContent = 'Confirm Drop';
         }
+        var titleId = 'ops-confirm-title-' + action + '-' + trackId;
+        title.id = titleId;
+        card.setAttribute('aria-labelledby', titleId);
         card.appendChild(title);
 
         var desc = document.createElement('div');
@@ -487,12 +493,12 @@ const HydraOps = (() => {
 
         card.appendChild(actionsDiv);
         overlay.appendChild(card);
-        overlay.classList.add('active');
+        HydraApp.openModal(overlay);
     }
 
     function hideConfirmOverlay() {
         var overlay = document.getElementById('ops-confirm-overlay');
-        if (overlay) overlay.classList.remove('active');
+        if (overlay) HydraApp.closeModal(overlay);
         confirmAction = null;
     }
 

--- a/hydra_detect/web/static/js/settings.js
+++ b/hydra_detect/web/static/js/settings.js
@@ -590,11 +590,11 @@ const HydraSettings = (() => {
     document.addEventListener('click', e => {
         if (e.target.id === 'settings-power-user') {
             const modal = document.getElementById('power-user-modal');
-            if (modal) modal.classList.add('active');
+            if (modal) HydraApp.openModal(modal, e.target);
         }
         if (e.target.id === 'power-user-cancel') {
             const modal = document.getElementById('power-user-modal');
-            if (modal) modal.classList.remove('active');
+            if (modal) HydraApp.closeModal(modal);
         }
         if (e.target.id === 'power-user-enable') {
             // Rickroll — commitment to the bit
@@ -615,7 +615,7 @@ const HydraSettings = (() => {
             }
             // Close the modal
             const modal = document.getElementById('power-user-modal');
-            if (modal) modal.classList.remove('active');
+            if (modal) HydraApp.closeModal(modal);
         }
     });
 

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -81,8 +81,8 @@
 
     <!-- ── Strike Confirmation Modal ── -->
     <div class="modal-overlay" id="strike-modal">
-        <div class="modal">
-            <h3 style="color: var(--danger); margin-bottom: var(--gap-md);">Confirm Strike</h3>
+        <div class="modal" role="dialog" aria-modal="true" aria-labelledby="strike-modal-title" tabindex="-1">
+            <h3 id="strike-modal-title" style="color: var(--danger); margin-bottom: var(--gap-md);">Confirm Strike</h3>
             <p style="margin-bottom: var(--gap-sm);">Target: <strong id="strike-target-label">--</strong></p>
             <p style="font-size: var(--font-sm); color: var(--text-secondary); margin-bottom: var(--gap-lg);">
                 Vehicle will navigate toward the target. Manual GCS override is always available.
@@ -96,8 +96,8 @@
 
     <!-- ── Drop Confirmation Modal ── -->
     <div class="modal-overlay" id="drop-modal">
-        <div class="modal">
-            <h3 style="color: var(--warning); margin-bottom: var(--gap-md);">Confirm Drop</h3>
+        <div class="modal" role="dialog" aria-modal="true" aria-labelledby="drop-modal-title" tabindex="-1">
+            <h3 id="drop-modal-title" style="color: var(--warning); margin-bottom: var(--gap-md);">Confirm Drop</h3>
             <p style="margin-bottom: var(--gap-sm);">Target: <strong id="drop-target-label">--</strong></p>
             <p style="font-size: var(--font-sm); color: var(--text-secondary); margin-bottom: var(--gap-lg);">
                 Vehicle will approach target and release drop servo on arrival. Manual GCS override is always available.
@@ -111,8 +111,8 @@
 
     <!-- ── Approach Strike Confirmation Modal ── -->
     <div class="modal-overlay" id="approach-strike-modal">
-        <div class="modal">
-            <h3 style="color: var(--danger); margin-bottom: var(--gap-md);">Confirm Continuous Strike</h3>
+        <div class="modal" role="dialog" aria-modal="true" aria-labelledby="approach-strike-modal-title" tabindex="-1">
+            <h3 id="approach-strike-modal-title" style="color: var(--danger); margin-bottom: var(--gap-md);">Confirm Continuous Strike</h3>
             <p style="margin-bottom: var(--gap-sm);">Target: <strong id="approach-strike-target-label">--</strong></p>
             <p style="font-size: var(--font-sm); color: var(--text-secondary); margin-bottom: var(--gap-lg);">
                 Vehicle will continuously approach target at maximum speed with arm engaged. Manual GCS override is always available.
@@ -132,8 +132,8 @@
 
     <!-- ── Power User Easter Egg Modal ── -->
     <div class="modal-overlay" id="power-user-modal">
-        <div class="modal">
-            <h3 style="color: var(--text-primary); margin-bottom: var(--gap-md);">Advanced Configuration</h3>
+        <div class="modal" role="dialog" aria-modal="true" aria-labelledby="power-user-modal-title" tabindex="-1">
+            <h3 id="power-user-modal-title" style="color: var(--text-primary); margin-bottom: var(--gap-md);">Advanced Configuration</h3>
             <p style="margin-bottom: var(--gap-lg); font-size: var(--font-sm); color: var(--text-secondary);">
                 Enable advanced configuration mode? This exposes low-level system parameters.
             </p>

--- a/hydra_detect/web/templates/control.html
+++ b/hydra_detect/web/templates/control.html
@@ -101,8 +101,8 @@
     </div>
 
     <div class="confirm-overlay" id="confirm-overlay">
-        <div class="confirm-box">
-            <h2>CONFIRM STRIKE</h2>
+        <div class="confirm-box" role="dialog" aria-modal="true" aria-labelledby="confirm-overlay-title" tabindex="-1">
+            <h2 id="confirm-overlay-title">CONFIRM STRIKE</h2>
             <p>Navigate vehicle toward target <span id="confirm-tid"></span>?</p>
             <div class="confirm-btns">
                 <button class="btn btn-strike" id="confirm-yes">STRIKE</button>


### PR DESCRIPTION
### Motivation

- Improve accessibility and robustness of all confirmation modals by adding proper ARIA semantics, predictable focus behavior, and keyboard handling.
- Ensure operators using keyboard or screen readers can open dialogs, have focus moved into the dialog, be trapped while it is active, and have focus restored when the dialog closes.

### Description

- Add dialog semantics to static modals in `base.html` and the control page by adding `role="dialog"`, `aria-modal="true"`, `aria-labelledby` titles, and `tabindex="-1"` on modal containers. (files: `hydra_detect/web/templates/base.html`, `hydra_detect/web/templates/control.html`).
- Implement shared modal accessibility helpers in `HydraApp` (`getModalDialog`, `getFocusableElements`, `openModal`, `closeModal`, `closeActiveModal`) and enhance the centralized keyboard handler to support `Escape` close and Tab/Shift+Tab focus trapping. (file: `hydra_detect/web/static/js/app.js`).
- Migrate existing confirmation flows to use the shared helpers so open/close and focus restoration are consistent across the app, including Config and Settings flows and the dynamically created Ops overlay. (files: `hydra_detect/web/static/js/config.js`, `hydra_detect/web/static/js/settings.js`, `hydra_detect/web/static/js/ops.js`).
- Harden the legacy `/control` confirmation overlay with ARIA attributes and add local open/close/focus-trap logic in `control.js` to preserve behavior when that page is used standalone. (files: `hydra_detect/web/static/js/control.js`, `hydra_detect/web/templates/control.html`).
- Add a brief keyboard accessibility test checklist for confirmation modals to `docs/dashboard.md` covering Tab cycle, reverse Tab cycle, Escape close, and screen reader label checks.

### Testing

- Ran a targeted pytest invocation for web template checks, but collection failed due to a missing test dependency (`httpx`) in the environment so automated tests could not be executed here (error indicates `httpx` must be installed to run Starlette/FastAPI tests).
- No other automated tests were run in this environment after the changes due to the test dependency issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d197b97f3c83288cf2a97553c57c41)