### PR TITLE
feat: require_auth_for_control flag + code review tracker

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -57,6 +57,7 @@ session_timeout_min = 480
 tls_enabled = false
 tls_cert = certs/hydra.crt
 tls_key = certs/hydra.key
+require_auth_for_control = false
 
 [osd]
 enabled = true

--- a/config.ini.factory
+++ b/config.ini.factory
@@ -51,6 +51,7 @@ host = 0.0.0.0
 port = 8080
 mjpeg_quality = 70
 api_token =
+require_auth_for_control = false
 
 [osd]
 enabled = true

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -321,6 +321,9 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
         "session_timeout_min": FieldSpec(
             FieldType.INT, min_val=5, max_val=1440, default=480,
             description="Login session timeout in minutes"),
+        "require_auth_for_control": FieldSpec(
+            FieldType.BOOL, default=False,
+            description="Require api_token for control POST endpoints"),
     },
     "autonomous": {
         "enabled": FieldSpec(

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -961,7 +961,10 @@ class Pipeline:
                     )
                     self._cfg.set("web", "api_token", "")
                     api_token = ""
-            configure_auth(api_token or None)
+            require_auth = self._cfg.getboolean(
+                "web", "require_auth_for_control", fallback=False,
+            )
+            configure_auth(api_token or None, require_auth_for_control=require_auth)
 
             # Web password login (empty = disabled, current behavior preserved)
             web_password = self._cfg.get("web", "web_password", fallback="").strip()
@@ -1872,6 +1875,20 @@ class Pipeline:
                 "name": "callsign",
                 "status": "warn",
                 "message": "Duplicate callsign detected on TAK network — change in config",
+            })
+
+        # 7. Auth hardening check
+        require_auth = self._cfg.getboolean(
+            "web", "require_auth_for_control", fallback=False,
+        )
+        if not require_auth:
+            checks.append({
+                "name": "auth",
+                "status": "warn",
+                "message": (
+                    "Control endpoints are unauthenticated."
+                    " Set api_token in config.ini for production use."
+                ),
             })
 
         # Compute overall status (worst of all checks)

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -1877,11 +1877,13 @@ class Pipeline:
                 "message": "Duplicate callsign detected on TAK network — change in config",
             })
 
-        # 7. Auth hardening check
-        require_auth = self._cfg.getboolean(
-            "web", "require_auth_for_control", fallback=False,
+        # 7. Auth hardening check — only warn when web is enabled and
+        #    control endpoints are actually exposed without authentication.
+        web_enabled = self._cfg.getboolean("web", "enabled", fallback=True)
+        has_token = bool(
+            self._cfg.get("web", "api_token", fallback="").strip()
         )
-        if not require_auth:
+        if web_enabled and not has_token:
             checks.append({
                 "name": "auth",
                 "status": "warn",

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -131,6 +131,7 @@ templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 
 # API token for control endpoints — set via configure_auth()
 _api_token: Optional[str] = None
+_require_auth_for_control: bool = False
 
 # Rate limiting for auth failures — per-IP, sliding window
 _AUTH_FAIL_WINDOW = 60  # seconds
@@ -138,10 +139,14 @@ _AUTH_FAIL_MAX = 50  # max failures per window before lockout
 _auth_failures: Dict[str, list] = collections.defaultdict(list)
 
 
-def configure_auth(token: Optional[str]) -> None:
+def configure_auth(
+    token: Optional[str],
+    require_auth_for_control: bool = False,
+) -> None:
     """Set the API token for control endpoints. None or empty disables auth."""
-    global _api_token
+    global _api_token, _require_auth_for_control
     _api_token = token if token else None
+    _require_auth_for_control = require_auth_for_control
     if _api_token:
         logger.info("API token auth enabled for control endpoints.")
     else:
@@ -154,6 +159,14 @@ def _check_auth(
 ) -> Optional[JSONResponse]:
     """Validate Bearer token. Returns an error response if auth fails, None if OK."""
     if _api_token is None:
+        if _require_auth_for_control:
+            return JSONResponse(
+                {"error": (
+                    "Control endpoint requires api_token. Set it in"
+                    " config.ini or set require_auth_for_control = false."
+                )},
+                status_code=401,
+            )
         return None  # Auth disabled
 
     if request is not None:

--- a/tests/test_require_auth_control.py
+++ b/tests/test_require_auth_control.py
@@ -1,0 +1,102 @@
+"""Tests for require_auth_for_control config flag."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hydra_detect.web.server import (
+    _auth_failures,
+    app,
+    configure_auth,
+    configure_web_password,
+    stream_state,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset auth state between tests."""
+    configure_auth(None)
+    configure_web_password(None)
+    _auth_failures.clear()
+    stream_state._callbacks.clear()
+    yield
+    # Restore defaults
+    configure_auth(None)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+# A control POST endpoint to test against
+_CONTROL_ENDPOINT = "/api/config/prompts"
+_CONTROL_BODY = {"prompts": ["person"]}
+
+
+class TestRequireAuthForControl:
+    """require_auth_for_control = true with no api_token denies control."""
+
+    def test_control_denied_when_flag_true_no_token(self, client):
+        """POST control endpoint returns 401 when flag is true and no token."""
+        configure_auth(None, require_auth_for_control=True)
+        resp = client.post(_CONTROL_ENDPOINT, json=_CONTROL_BODY)
+        assert resp.status_code == 401
+        data = resp.json()
+        assert "require" in data["error"].lower() or "api_token" in data["error"]
+
+    def test_control_allowed_when_flag_false(self, client):
+        """POST control endpoint succeeds when flag is false (default)."""
+        configure_auth(None, require_auth_for_control=False)
+        resp = client.post(_CONTROL_ENDPOINT, json=_CONTROL_BODY)
+        # Should succeed (200) — no auth required
+        assert resp.status_code == 200
+
+    def test_bearer_token_works_regardless_of_flag(self, client):
+        """Bearer token auth works whether flag is true or false."""
+        token = "test-secret-token"
+        configure_auth(token, require_auth_for_control=True)
+        resp = client.post(
+            _CONTROL_ENDPOINT,
+            json=_CONTROL_BODY,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+
+    def test_read_endpoints_always_accessible(self, client):
+        """GET read-only endpoints work regardless of flag setting."""
+        configure_auth(None, require_auth_for_control=True)
+        # Health is always accessible
+        resp = client.get("/api/health")
+        assert resp.status_code in (200, 503)  # depends on camera state
+        # Stats is always accessible
+        resp = client.get("/api/stats")
+        assert resp.status_code == 200
+        # Tracks is always accessible
+        resp = client.get("/api/tracks")
+        assert resp.status_code == 200
+
+    def test_flag_true_with_token_allows_authenticated_control(self, client):
+        """When flag=true and token is set, authenticated requests succeed."""
+        token = "my-token"
+        configure_auth(token, require_auth_for_control=True)
+        # Without token — denied
+        resp = client.post(_CONTROL_ENDPOINT, json=_CONTROL_BODY)
+        assert resp.status_code == 401
+        # With token — allowed
+        resp = client.post(
+            _CONTROL_ENDPOINT,
+            json=_CONTROL_BODY,
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert resp.status_code == 200
+
+    def test_error_message_content(self, client):
+        """Error message guides user to set api_token or disable the flag."""
+        configure_auth(None, require_auth_for_control=True)
+        resp = client.post(_CONTROL_ENDPOINT, json=_CONTROL_BODY)
+        msg = resp.json()["error"]
+        assert "api_token" in msg
+        assert "require_auth_for_control" in msg


### PR DESCRIPTION
## Summary

- Added `require_auth_for_control` flag to `[web]` config (default `false`)
- Control POST endpoints return 401 when flag=true and no `api_token` set
- Read-only GET endpoints always accessible
- Preflight warning when control is unauthenticated
- 6 new tests, all passing (1022 total)
- `CODE_REVIEW_TRACKER.md` populated with 10 review chunks
- Pre-existing flake8 violations fixed

## Test plan

- [x] All 1022 tests pass
- [x] flake8 clean
- [ ] Verify control POST denied when `require_auth_for_control = true` and no token
- [ ] Verify control POST allowed when flag is `false` (default behavior preserved)
- [ ] Verify Bearer token works regardless of flag setting
- [ ] Verify read-only GET endpoints always accessible

https://claude.ai/code/session_01E63USauY3kMApim8baJr1K