### PR TITLE
Add explicit bearer auth handling to legacy /control page and regression tests

### DIFF
--- a/docs/features/target-control.md
+++ b/docs/features/target-control.md
@@ -73,3 +73,5 @@ Target control is fully accessible via the REST API:
 | `POST` | `/api/target/unlock` | Release target lock |
 | `POST` | `/api/target/strike` | Send strike command (`{"track_id": 5, "confirm": true}`) |
 | `POST` | `/api/vehicle/loiter` | Command vehicle to hold position |
+
+> Legacy `/control` remains available for now for mobile/operator fallback, but new feature work should target the main SPA dashboard and `/control` should be treated as maintenance-only pending deprecation.

--- a/hydra_detect/web/static/js/control.js
+++ b/hydra_detect/web/static/js/control.js
@@ -1,6 +1,7 @@
 'use strict';
 (function() {
     var lockedTrackId = null;
+    var apiToken = sessionStorage.getItem('hydra_token') || '';
 
     // Stream — use snapshot polling (same as main dashboard)
     var img = document.getElementById('stream');
@@ -25,15 +26,65 @@
     pollFrame();
 
     // API helpers
-    function apiGet(url) {
-        return fetch(url).then(function(r) { return r.ok ? r.json() : null; }).catch(function() { return null; });
+    function authHeaders() {
+        var headers = { 'Content-Type': 'application/json' };
+        if (apiToken) headers.Authorization = 'Bearer ' + apiToken;
+        return headers;
     }
+
+    function setApiToken(token) {
+        apiToken = token || '';
+        sessionStorage.setItem('hydra_token', apiToken);
+    }
+
+    function promptForToken() {
+        var token = prompt('API token required.\nEnter the api_token from config.ini:');
+        if (!token) return false;
+        setApiToken(token.trim());
+        return !!apiToken;
+    }
+
+    function handleActionAuthFailure(resp) {
+        if (resp && resp.status === 401 && resp.headers.get('x-login-required')) {
+            window.location.href = '/login';
+            return 'redirect';
+        }
+        if (resp && (resp.status === 401 || resp.status === 403)) {
+            if (!promptForToken()) {
+                alert('Authentication required for control actions.');
+                return 'stop';
+            }
+            return 'retry';
+        }
+        return 'stop';
+    }
+
+    function apiGet(url) {
+        return fetch(url, { headers: authHeaders() })
+            .then(function(r) { return r.ok ? r.json() : null; })
+            .catch(function() { return null; });
+    }
+
     function apiPost(url, body) {
-        return fetch(url, {
-            method: 'POST',
-            headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify(body),
-        }).then(function(r) { return r.ok ? r.json() : null; }).catch(function() { return null; });
+        function send() {
+            return fetch(url, {
+                method: 'POST',
+                headers: authHeaders(),
+                body: JSON.stringify(body),
+            });
+        }
+
+        return send().then(function(resp) {
+            if (resp.ok) return resp.json();
+
+            var action = handleActionAuthFailure(resp);
+            if (action !== 'retry') return null;
+
+            return send().then(function(retryResp) {
+                if (retryResp.ok) return retryResp.json();
+                return null;
+            }).catch(function() { return null; });
+        }).catch(function() { return null; });
     }
 
     // Build a track card using safe DOM methods (no innerHTML)

--- a/tests/test_require_auth_control.py
+++ b/tests/test_require_auth_control.py
@@ -100,3 +100,36 @@ class TestRequireAuthForControl:
         msg = resp.json()["error"]
         assert "api_token" in msg
         assert "require_auth_for_control" in msg
+
+
+class TestControlPageActionsWithTokenAuth:
+    """Regression coverage for legacy /control actions when token auth is enabled."""
+
+    def test_lock_unlock_strike_require_and_accept_bearer_token(self, client):
+        token = "control-secret-token"
+        configure_auth(token, require_auth_for_control=True)
+
+        stream_state.set_callbacks(
+            on_target_lock=lambda track_id, mode="track": True,
+            on_target_unlock=lambda: True,
+            on_strike_command=lambda track_id: True,
+        )
+
+        # Legacy /control action APIs should deny unauthenticated control posts.
+        lock_unauth = client.post("/api/target/lock", json={"track_id": 7})
+        unlock_unauth = client.post("/api/target/unlock")
+        strike_unauth = client.post("/api/target/strike", json={"track_id": 7, "confirm": True})
+
+        assert lock_unauth.status_code == 401
+        assert unlock_unauth.status_code == 401
+        assert strike_unauth.status_code == 401
+
+        headers = {"Authorization": f"Bearer {token}"}
+
+        lock_auth = client.post("/api/target/lock", json={"track_id": 7}, headers=headers)
+        unlock_auth = client.post("/api/target/unlock", headers=headers)
+        strike_auth = client.post("/api/target/strike", json={"track_id": 7, "confirm": True}, headers=headers)
+
+        assert lock_auth.status_code == 200
+        assert unlock_auth.status_code == 200
+        assert strike_auth.status_code == 200


### PR DESCRIPTION
### Motivation
- Legacy `/control` relied on header-based bypasses and needed explicit client-side bearer authentication to match backend token checks. 
- The mobile/operator control page should reuse the SPA token/session pattern so tokens set in the main UI also apply to the legacy page. 
- UX must surface 401/403 outcomes (redirect to login or prompt for token) instead of silently failing. 
- Add regression coverage to prevent regressions when `require_auth_for_control` is enabled. 

### Description
- Updated `hydra_detect/web/static/js/control.js` to read `hydra_token` from `sessionStorage`, expose `authHeaders()`, `setApiToken()`, `promptForToken()`, and `handleActionAuthFailure()`, and to include `Authorization: Bearer <token>` on `apiPost()`/`apiGet()` requests when a token exists. 
- `apiPost()` now handles backend 401/403 responses by redirecting to `/login` on `x-login-required`, prompting the user for an API token and retrying once, and showing an alert when the user cancels. 
- Added regression test `TestControlPageActionsWithTokenAuth` in `tests/test_require_auth_control.py` that verifies `/api/target/lock`, `/api/target/unlock`, and `/api/target/strike` reject unauthenticated requests and accept a valid `Authorization: Bearer <token>` when `require_auth_for_control=True`. 
- Documented the intended lifecycle for `/control` in `docs/features/target-control.md`, marking the page as maintenance-only fallback and a deprecation candidate while new work targets the SPA. 

### Testing
- Ran `pytest -q tests/test_require_auth_control.py` which failed to collect due to the environment missing the `httpx` package required by `starlette.testclient` (runtime error from TestClient); this is an environment issue, not a functional test failure. 
- The added tests are designed to pass under CI where `httpx` and test dependencies are available. 
- Manual review and static inspection were performed on `control.js` to ensure `Authorization` header is injected and the retry/redirect UX path is implemented.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1e2ae983c8328b4b7010a986a8603)