### PR TITLE
Add 'Keep Frame' action to bounding-box radial menu

### DIFF
--- a/hydra_detect/web/static/css/ops.css
+++ b/hydra_detect/web/static/css/ops.css
@@ -398,8 +398,11 @@
     display: flex;
     align-items: center;
     justify-content: center;
+    text-align: center;
     cursor: pointer;
     font-size: 0.6rem;
+    line-height: 1.1;
+    padding: 4px;
     font-family: var(--font-mono);
     color: var(--text-primary);
     text-transform: uppercase;

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -332,7 +332,7 @@ const HydraOps = (() => {
         var actions = [
             { label: 'Follow', action: 'follow', angle: 0 },
             { label: 'Lock', action: 'lock', angle: 60 },
-            { label: 'P-Lock', action: 'pixel_lock', angle: 120 },
+            { label: 'Keep Frame', action: 'keep_in_frame', angle: 120 },
             { label: 'Loiter', action: 'loiter', angle: 180 },
             { label: 'Drop', action: 'drop', cls: 'warning', angle: 240 },
             { label: 'Strike', action: 'strike', cls: 'danger', angle: 300 },
@@ -392,9 +392,9 @@ const HydraOps = (() => {
             HydraApp.apiPost('/api/approach/follow/' + trackId, {}).then(function (r) {
                 if (r) HydraApp.showToast('Follow engaged on #' + trackId, 'success');
             });
-        } else if (action === 'pixel_lock') {
+        } else if (action === 'pixel_lock' || action === 'keep_in_frame') {
             HydraApp.apiPost('/api/approach/pixel_lock/' + trackId, {}).then(function (r) {
-                if (r) HydraApp.showToast('Pixel-lock on #' + trackId, 'success');
+                if (r) HydraApp.showToast('Keep-in-frame engaged on #' + trackId, 'success');
             });
         } else if (action === 'lock') {
             HydraApp.apiPost('/api/target/lock', { track_id: trackId }).then(function (r) {


### PR DESCRIPTION
### Motivation
- Operators need a quick way to command frame-retention (keep target centered) from the Ops HUD radial menu when clicking a detection, alongside existing actions like Loiter and Strike.

### Description
- Added a `Keep Frame` item to the bounding-box radial context menu in `hydra_detect/web/static/js/ops.js` that uses the `keep_in_frame` action identifier. 
- Mapped `keep_in_frame` to the existing pixel-lock path by treating it as an alias for the `/api/approach/pixel_lock/:trackId` endpoint so the UI selection issues the same approach/pixel-lock command. 
- Adjusted radial menu button CSS in `hydra_detect/web/static/css/ops.css` to better support multi-word labels and centered text in the circular menu items.

### Testing
- Ran `pytest -q tests/test_preflight_ui.py` and collection failed in this environment because `httpx` is not installed (Starlette/FastAPI `TestClient` requires `httpx`), so the test did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1eb21cca08328bf2e432d1c6fdac8)