### PR TITLE
refactor: centralize auth failure rate-limit bookkeeping

### DIFF
--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -139,6 +139,21 @@ _AUTH_FAIL_MAX = 50  # max failures per window before lockout
 _auth_failures: Dict[str, list] = collections.defaultdict(list)
 
 
+def _recent_auth_failures(client_ip: str, now: float) -> list[float]:
+    """Return recent auth failures for an IP and prune expired entries."""
+    failures = [t for t in _auth_failures.get(client_ip, []) if now - t < _AUTH_FAIL_WINDOW]
+    if failures:
+        _auth_failures[client_ip] = failures
+    elif client_ip in _auth_failures:
+        del _auth_failures[client_ip]
+    return failures
+
+
+def _record_auth_failure(client_ip: str, now: float) -> None:
+    """Record one failed auth attempt for an IP."""
+    _auth_failures.setdefault(client_ip, []).append(now)
+
+
 def configure_auth(
     token: Optional[str],
     require_auth_for_control: bool = False,
@@ -184,24 +199,19 @@ def _check_auth(
     # Rate limit check — reject if too many recent failures from this IP
     client_ip = request.client.host if request and request.client else "unknown"
     now = time.monotonic()
-    # Expire old entries outside the window; prune empty IPs to prevent unbounded growth
-    failures = [t for t in _auth_failures.get(client_ip, []) if now - t < _AUTH_FAIL_WINDOW]
-    if failures:
-        _auth_failures[client_ip] = failures
-    elif client_ip in _auth_failures:
-        del _auth_failures[client_ip]
+    failures = _recent_auth_failures(client_ip, now)
     if len(failures) >= _AUTH_FAIL_MAX:
         return JSONResponse({"error": "Too many failed attempts, try again later"}, status_code=429)
 
     if not authorization or not authorization.startswith("Bearer "):
-        _auth_failures[client_ip].append(now)
+        _record_auth_failure(client_ip, now)
         return JSONResponse(
             {"error": "Authorization header with Bearer token required"},
             status_code=401,
         )
     provided = authorization[len("Bearer "):]
     if not hmac.compare_digest(provided, _api_token):
-        _auth_failures[client_ip].append(now)
+        _record_auth_failure(client_ip, now)
         return JSONResponse({"error": "Invalid API token"}, status_code=403)
     return None
 
@@ -629,11 +639,7 @@ async def auth_login(request: Request):
     now = time.monotonic()
 
     # Rate limit check (reuse same tracking as Bearer token auth)
-    failures = [t for t in _auth_failures.get(client_ip, []) if now - t < _AUTH_FAIL_WINDOW]
-    if failures:
-        _auth_failures[client_ip] = failures
-    elif client_ip in _auth_failures:
-        del _auth_failures[client_ip]
+    failures = _recent_auth_failures(client_ip, now)
     if len(failures) >= _AUTH_FAIL_MAX:
         return JSONResponse(
             {"error": "Too many failed attempts, try again later"}, status_code=429,
@@ -645,7 +651,7 @@ async def auth_login(request: Request):
 
     password = str(body["password"])
     if not hmac.compare_digest(password, _web_password):
-        _auth_failures.setdefault(client_ip, []).append(now)
+        _record_auth_failure(client_ip, now)
         return JSONResponse({"error": "Wrong password"}, status_code=401)
 
     cookie_value = _make_session_cookie()

--- a/tests/test_auth_rate_limit_helpers.py
+++ b/tests/test_auth_rate_limit_helpers.py
@@ -1,0 +1,42 @@
+"""Unit tests for auth failure rate-limit helpers."""
+
+from hydra_detect.web import server
+
+
+def test_recent_auth_failures_prunes_expired_entries():
+    """Expired entries are removed and only in-window failures are returned."""
+    server._auth_failures.clear()
+    now = 1000.0
+    server._auth_failures["1.2.3.4"] = [
+        now - server._AUTH_FAIL_WINDOW - 1,
+        now - 1,
+        now - 5,
+    ]
+
+    failures = server._recent_auth_failures("1.2.3.4", now)
+
+    assert failures == [now - 1, now - 5]
+    assert server._auth_failures["1.2.3.4"] == [now - 1, now - 5]
+
+
+def test_recent_auth_failures_removes_empty_ip_bucket():
+    """IP bucket is deleted when all entries are expired."""
+    server._auth_failures.clear()
+    now = 2000.0
+    server._auth_failures["4.3.2.1"] = [now - server._AUTH_FAIL_WINDOW - 1]
+
+    failures = server._recent_auth_failures("4.3.2.1", now)
+
+    assert failures == []
+    assert "4.3.2.1" not in server._auth_failures
+
+
+def test_record_auth_failure_creates_and_appends():
+    """Failure recorder creates buckets and appends timestamps."""
+    server._auth_failures.clear()
+    now = 3000.0
+
+    server._record_auth_failure("5.6.7.8", now)
+    server._record_auth_failure("5.6.7.8", now + 1)
+
+    assert server._auth_failures["5.6.7.8"] == [now, now + 1]

--- a/tests/test_require_auth_control.py
+++ b/tests/test_require_auth_control.py
@@ -128,7 +128,11 @@ class TestControlPageActionsWithTokenAuth:
 
         lock_auth = client.post("/api/target/lock", json={"track_id": 7}, headers=headers)
         unlock_auth = client.post("/api/target/unlock", headers=headers)
-        strike_auth = client.post("/api/target/strike", json={"track_id": 7, "confirm": True}, headers=headers)
+        strike_auth = client.post(
+            "/api/target/strike",
+            json={"track_id": 7, "confirm": True},
+            headers=headers,
+        )
 
         assert lock_auth.status_code == 200
         assert unlock_auth.status_code == 200


### PR DESCRIPTION
### Motivation
- Reduce duplicated sliding-window rate-limit logic for auth failures and make behavior consistent between Bearer-token and password login paths.
- Improve maintainability by centralizing failure pruning and recording into small helpers.

### Description
- Add `_recent_auth_failures(client_ip, now)` to prune expired entries and return active failure timestamps for an IP.
- Add `_record_auth_failure(client_ip, now)` to append a failure timestamp and lazily create the IP bucket.
- Replace duplicated pruning/append logic in `_check_auth` (Bearer token validation) and `/auth/login` with the new helpers so both paths share the same bookkeeping.
- Add `tests/test_auth_rate_limit_helpers.py` with unit tests covering pruning behavior, removal of empty IP buckets, and append semantics for the new helpers.

### Testing
- Ran `python -m py_compile hydra_detect/web/server.py tests/test_auth_rate_limit_helpers.py`, which succeeded.
- Ran `pytest -q tests/test_auth_rate_limit_helpers.py`, which failed during import because `hydra_detect.web.server` imports OpenCV and the container is missing the system library `libGL.so.1` (ImportError); tests did not execute due to that environment issue.
- Earlier attempt to run `pytest -q tests/test_require_auth_control.py` also errored during collection due to missing `httpx` (ModuleNotFoundError) in the test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2982f1af083288c219bc2200a721d)