### PR TITLE
Add offline and large-log controls to mission review export

### DIFF
--- a/docs/post-mission-review.md
+++ b/docs/post-mission-review.md
@@ -141,7 +141,7 @@ The report includes:
 - OpenStreetMap base layer
 - Detection markers with popups
 - Optional embedded images (base64-encoded)
-- No external dependencies, works offline
+- Optional fully-offline coordinate plot mode (`--offline-mode`)
 
 Options:
 ```
@@ -149,6 +149,9 @@ python -m hydra_detect.review_export <logfile> [OPTIONS]
 
   -o, --output PATH       Output HTML file (default: report.html)
   --images-dir PATH       Directory with saved detection images
+  --max-images N          Max images to embed as base64 (default: 100)
+  --max-records N         Decimate very large logs to N records (0 = no cap)
+  --offline-mode          Disable CDN/Leaflet and render offline coordinate plot
 ```
 
 ## Log File Management

--- a/hydra_detect/review_export.py
+++ b/hydra_detect/review_export.py
@@ -89,6 +89,18 @@ def build_summary(records: list[dict]) -> dict:
     }
 
 
+def decimate_records(records: list[dict], max_records: int) -> list[dict]:
+    """Return at most ``max_records`` records, keeping temporal spread."""
+    if max_records <= 0 or len(records) <= max_records:
+        return records
+    if max_records == 1:
+        return [records[0]]
+    step = (len(records) - 1) / (max_records - 1)
+    indices = {int(round(i * step)) for i in range(max_records)}
+    ordered_indices = sorted(min(len(records) - 1, idx) for idx in indices)
+    return [records[i] for i in ordered_indices]
+
+
 def embed_images(records: list[dict], images_dir: Path, max_images: int = 100) -> list[dict]:
     """Replace image filenames with base64 data URIs for inline viewing.
 
@@ -128,19 +140,85 @@ def embed_images(records: list[dict], images_dir: Path, max_images: int = 100) -
     return records
 
 
-def generate_html(records: list[dict], summary: dict, title: str = "Hydra Mission Report") -> str:
+def _generate_offline_plot(records_json: str) -> str:
+    """Generate a coordinate-only offline plot (no CDN dependencies)."""
+    return f"""
+const D={records_json};
+const plot=document.getElementById('plot');
+const list=document.getElementById('list');
+function esc(s){{const d=document.createElement('div');d.textContent=String(s);return d.innerHTML}}
+function norm(v,a,b){{if(a===b)return 0.5;return (v-a)/(b-a)}}
+function renderOffline(){{
+  const gps=D.filter(d=>d.lat!=null&&d.lon!=null).map(d=>({{...d,lat:parseFloat(d.lat),lon:parseFloat(d.lon)}})).filter(d=>!isNaN(d.lat)&&!isNaN(d.lon));
+  if(!gps.length){{plot.innerHTML='<p>No GPS detections in this log.</p>';list.innerHTML='';return;}}
+  const minLat=Math.min(...gps.map(d=>d.lat)),maxLat=Math.max(...gps.map(d=>d.lat));
+  const minLon=Math.min(...gps.map(d=>d.lon)),maxLon=Math.max(...gps.map(d=>d.lon));
+  const W=840,H=520,P=30;
+  let dots='';
+  for(const d of gps){{
+    const x=P+norm(d.lon,minLon,maxLon)*(W-2*P);
+    const y=H-(P+norm(d.lat,minLat,maxLat)*(H-2*P));
+    dots+=`<circle cx="${{x.toFixed(1)}}" cy="${{y.toFixed(1)}}" r="4" fill="#00ff88"><title>${{esc(d.label||'unknown')}} #${{esc(d.track_id||'?')}} | ${{(d.confidence||0).toFixed(2)}} | ${{esc(d.timestamp||'')}}</title></circle>`;
+  }}
+  plot.innerHTML=`<svg viewBox="0 0 ${{W}} ${{H}}" width="100%" height="520" style="background:#0f0f0f;border:1px solid #333">
+    <rect x="${{P}}" y="${{P}}" width="${{W-2*P}}" height="${{H-2*P}}" fill="none" stroke="#2a2a2a"/>
+    ${{dots}}
+    <text x="${{P}}" y="${{H-8}}" fill="#888" font-size="11">Lon ${{minLon.toFixed(5)}} → ${{maxLon.toFixed(5)}}</text>
+    <text x="8" y="${{P-10}}" fill="#888" font-size="11">Lat ${{maxLat.toFixed(5)}} ↓ ${{minLat.toFixed(5)}}</text>
+  </svg>`;
+  list.innerHTML=gps.slice(0,500).map(d=>`<div class="st"><span>${{esc(d.label||'unknown')}}</span> #${{esc(d.track_id||'?')}} @ ${{d.lat.toFixed(6)}}, ${{d.lon.toFixed(6)}} (${{
+    ((d.confidence||0)*100).toFixed(0)
+  }}%)</div>`).join('');
+}}
+renderOffline();
+"""
+
+
+def generate_html(
+    records: list[dict],
+    summary: dict,
+    title: str = "Hydra Mission Report",
+    *,
+    offline_mode: bool = False,
+) -> str:
     """Generate a self-contained HTML file with Leaflet map."""
     # Escape </script> sequences to prevent script-tag breakout (XSS)
     detections_json = json.dumps(records).replace("</", "<\\/")
     summary_json = json.dumps(summary).replace("</", "<\\/")
     safe_title = html.escape(title)
 
-    return f"""<!DOCTYPE html>
-<html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>{safe_title}</title>
+    mode_badge = "OFFLINE COORDINATE VIEW" if offline_mode else "LEAFLET MAP VIEW"
+    map_style = "" if not offline_mode else "#map{display:none}.off{display:block}.on{display:none}"
+    data_script = (
+        _generate_offline_plot(detections_json)
+        if offline_mode
+        else f"""
+const D={detections_json};
+const S={summary_json};
+function esc(s){{const d=document.createElement('div');d.textContent=String(s);return d.innerHTML}}
+const map=L.map('map').setView([0,0],2);
+L.tileLayer('https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png',{{attribution:'OSM',maxZoom:19}}).addTo(map);
+const mL=L.layerGroup().addTo(map),tL=L.layerGroup().addTo(map);
+const CC=['#ff4444','#44ff44','#4488ff','#ffaa00','#ff44ff','#44ffff','#ff8844','#88ff44','#4444ff','#ffff44'];
+let ccm={{}},ac=new Set();
+function gc(l){{if(!(l in ccm))ccm[l]=CC[Object.keys(ccm).length%CC.length];return ccm[l]}}
+document.getElementById('hdrStats').textContent=`${{S.total}} detections | ${{S.tracks}} tracks | ${{S.with_gps}} geotagged`;
+const sb=document.getElementById('summaryBox');
+sb.innerHTML=`<div class="st">Total: <span>${{esc(S.total)}}</span></div><div class="st">Tracks: <span>${{esc(S.tracks)}}</span></div><div class="st">Geotagged: <span>${{esc(S.with_gps)}}</span></div><div class="st">Time: <span>${{esc((S.time_start||'').slice(11,19))}} \u2192 ${{esc((S.time_end||'').slice(11,19))}}</span></div>`;
+for(const[c,n]of Object.entries(S.classes))sb.innerHTML+=`<div class="st">${{esc(c)}}: <span>${{esc(n)}}</span></div>`;
+const cls=new Set(D.map(d=>d.label).filter(Boolean));ac=new Set(cls);
+const cfEl=document.getElementById('cf');
+for(const c of cls){{const t=document.createElement('span');t.className='tag on';t.textContent=c;t.style.borderColor=gc(c);t.onclick=()=>{{if(ac.has(c)){{ac.delete(c);t.classList.remove('on')}}else{{ac.add(c);t.classList.add('on')}}render()}};cfEl.appendChild(t)}}
+function render(){{mL.clearLayers();tL.clearLayers();const mc=parseFloat(document.getElementById('cs').value);const st=document.getElementById('st').checked;const sm=document.getElementById('sm').checked;const f=D.filter(d=>d.lat!=null&&d.lon!=null&&ac.has(d.label)&&(d.confidence||0)>=mc);if(!f.length)return;const b=[];const tp={{}};for(const d of f){{const la=parseFloat(d.lat),lo=parseFloat(d.lon);if(isNaN(la)||isNaN(lo))continue;b.push([la,lo]);const tid=d.track_id;if(!tp[tid])tp[tid]={{label:d.label,pts:[]}};tp[tid].pts.push([la,lo]);if(sm){{const m=L.circleMarker([la,lo],{{radius:6,fillColor:gc(d.label),color:'#000',weight:1,fillOpacity:.8}});let p=`<b>${{esc(d.label)}}</b> #${{esc(d.track_id)}}<br>Conf: ${{((d.confidence||0)*100).toFixed(0)}}%<br>Time: ${{esc((d.timestamp||'').slice(11,19))}}<br>Pos: ${{la.toFixed(6)}}, ${{lo.toFixed(6)}}`;if(d.image_data)p+=`<br><img class="popup-img" src="${{esc(d.image_data)}}">`;else if(d.image)p+=`<br><small>${{esc(d.image)}}</small>`;m.bindPopup(p,{{maxWidth:300}});mL.addLayer(m)}}}}if(st)for(const tid of Object.keys(tp)){{const t=tp[tid];if(t.pts.length<2)continue;L.polyline(t.pts,{{color:gc(t.label),weight:2,opacity:.5,dashArray:'4 4'}}).addTo(tL)}}if(b.length)map.fitBounds(b,{{padding:[30,30]}})}}
+document.getElementById('cs').oninput=e=>{{document.getElementById('cv').textContent=parseFloat(e.target.value).toFixed(2);render()}};
+document.getElementById('st').onchange=render;document.getElementById('sm').onchange=render;
+render();
+"""
+    )
+    script_libs = (
+        ""
+        if offline_mode
+        else """
 <link rel="stylesheet"
   href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
   integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
@@ -148,7 +226,16 @@ def generate_html(records: list[dict], summary: dict, title: str = "Hydra Missio
 <script
   src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
   integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
-  crossorigin="anonymous"></script>
+  crossorigin="anonymous"></script>"""
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>{safe_title}</title>
+{script_libs}
 <style>
 *{{margin:0;padding:0;box-sizing:border-box}}
 body{{font-family:'Courier New',monospace;background:#0a0a0a;color:#e0e0e0}}
@@ -175,15 +262,17 @@ label{{font-size:11px;color:#888;display:block;margin-bottom:3px}}
 .leaflet-popup-content-wrapper{{background:#1a1a1a;color:#e0e0e0;border-radius:4px}}
 .leaflet-popup-tip{{background:#1a1a1a}}
 .leaflet-popup-content{{font-family:'Courier New',monospace;font-size:12px}}
+{map_style}
 </style>
 </head>
 <body>
 <div class="hdr">
 <h1>HYDRA DETECT — MISSION REPORT</h1>
-<span class="stats" id="hdrStats"></span>
+<span class="stats" id="hdrStats">{mode_badge}</span>
 </div>
 <div class="wrap">
 <div id="map"></div>
+<div class="off" id="plot" style="flex:1;padding:16px"></div>
 <div class="side">
 <div class="sec"><h3>SUMMARY</h3><div id="summaryBox"></div></div>
 <div class="sec"><h3>FILTERS</h3>
@@ -195,29 +284,11 @@ label{{font-size:11px;color:#888;display:block;margin-bottom:3px}}
 <div class="chk"><input type="checkbox" id="st" checked><label for="st">Track trails</label></div>
 <div class="chk"><input type="checkbox" id="sm" checked><label for="sm">Markers</label></div>
 </div>
+<div class="sec"><h3>POINTS</h3><div id="list"></div></div>
 </div>
 </div>
 <script>
-const D={detections_json};
-const S={summary_json};
-function esc(s){{const d=document.createElement('div');d.textContent=String(s);return d.innerHTML}}
-const map=L.map('map').setView([0,0],2);
-L.tileLayer('https://{{s}}.tile.openstreetmap.org/{{z}}/{{x}}/{{y}}.png',{{attribution:'OSM',maxZoom:19}}).addTo(map);
-const mL=L.layerGroup().addTo(map),tL=L.layerGroup().addTo(map);
-const CC=['#ff4444','#44ff44','#4488ff','#ffaa00','#ff44ff','#44ffff','#ff8844','#88ff44','#4444ff','#ffff44'];
-let ccm={{}},ac=new Set();
-function gc(l){{if(!(l in ccm))ccm[l]=CC[Object.keys(ccm).length%CC.length];return ccm[l]}}
-document.getElementById('hdrStats').textContent=`${{S.total}} detections | ${{S.tracks}} tracks | ${{S.with_gps}} geotagged`;
-const sb=document.getElementById('summaryBox');
-sb.innerHTML=`<div class="st">Total: <span>${{esc(S.total)}}</span></div><div class="st">Tracks: <span>${{esc(S.tracks)}}</span></div><div class="st">Geotagged: <span>${{esc(S.with_gps)}}</span></div><div class="st">Time: <span>${{esc((S.time_start||'').slice(11,19))}} \u2192 ${{esc((S.time_end||'').slice(11,19))}}</span></div>`;
-for(const[c,n]of Object.entries(S.classes))sb.innerHTML+=`<div class="st">${{esc(c)}}: <span>${{esc(n)}}</span></div>`;
-const cls=new Set(D.map(d=>d.label).filter(Boolean));ac=new Set(cls);
-const cfEl=document.getElementById('cf');
-for(const c of cls){{const t=document.createElement('span');t.className='tag on';t.textContent=c;t.style.borderColor=gc(c);t.onclick=()=>{{if(ac.has(c)){{ac.delete(c);t.classList.remove('on')}}else{{ac.add(c);t.classList.add('on')}}render()}};cfEl.appendChild(t)}}
-function render(){{mL.clearLayers();tL.clearLayers();const mc=parseFloat(document.getElementById('cs').value);const st=document.getElementById('st').checked;const sm=document.getElementById('sm').checked;const f=D.filter(d=>d.lat!=null&&d.lon!=null&&ac.has(d.label)&&(d.confidence||0)>=mc);if(!f.length)return;const b=[];const tp={{}};for(const d of f){{const la=parseFloat(d.lat),lo=parseFloat(d.lon);if(isNaN(la)||isNaN(lo))continue;b.push([la,lo]);const tid=d.track_id;if(!tp[tid])tp[tid]={{label:d.label,pts:[]}};tp[tid].pts.push([la,lo]);if(sm){{const m=L.circleMarker([la,lo],{{radius:6,fillColor:gc(d.label),color:'#000',weight:1,fillOpacity:.8}});let p=`<b>${{esc(d.label)}}</b> #${{esc(d.track_id)}}<br>Conf: ${{((d.confidence||0)*100).toFixed(0)}}%<br>Time: ${{esc((d.timestamp||'').slice(11,19))}}<br>Pos: ${{la.toFixed(6)}}, ${{lo.toFixed(6)}}`;if(d.image_data)p+=`<br><img class="popup-img" src="${{esc(d.image_data)}}">`;else if(d.image)p+=`<br><small>${{esc(d.image)}}</small>`;m.bindPopup(p,{{maxWidth:300}});mL.addLayer(m)}}}}if(st)for(const tid of Object.keys(tp)){{const t=tp[tid];if(t.pts.length<2)continue;L.polyline(t.pts,{{color:gc(t.label),weight:2,opacity:.5,dashArray:'4 4'}}).addTo(tL)}}if(b.length)map.fitBounds(b,{{padding:[30,30]}})}}
-document.getElementById('cs').oninput=e=>{{document.getElementById('cv').textContent=parseFloat(e.target.value).toFixed(2);render()}};
-document.getElementById('st').onchange=render;document.getElementById('sm').onchange=render;
-render();
+{data_script}
 </script>
 </body>
 </html>"""
@@ -232,6 +303,10 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--images-dir", help="Directory of detection images to embed as base64")
     parser.add_argument("--max-images", type=int, default=100,
                         help="Maximum number of images to embed (default: 100)")
+    parser.add_argument("--max-records", type=int, default=0,
+                        help="Cap rendered detections for very large logs (0 = no cap)")
+    parser.add_argument("--offline-mode", action="store_true",
+                        help="No CDN dependencies; render coordinate-only offline plot")
     parser.add_argument("--title", default="Hydra Mission Report", help="Report title")
     args = parser.parse_args(argv)
 
@@ -251,8 +326,17 @@ def main(argv: list[str] | None = None) -> int:
         else:
             print(f"Warning: images directory not found: {images_path}", file=sys.stderr)
 
+    source_total = len(records)
+    records = decimate_records(records, args.max_records)
     summary = build_summary(records)
-    html_content = generate_html(records, summary, title=args.title)
+    summary["source_total"] = source_total
+    summary["truncated"] = len(records) < source_total
+    html_content = generate_html(
+        records,
+        summary,
+        title=args.title,
+        offline_mode=args.offline_mode,
+    )
 
     output_path = Path(args.output)
     output_path.write_text(html_content)

--- a/tests/test_review_export.py
+++ b/tests/test_review_export.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from hydra_detect.review_export import generate_html
+from hydra_detect.review_export import decimate_records, generate_html
 
 
 def _make_records(labels: list[str]) -> list[dict]:
@@ -115,3 +115,26 @@ class TestHTMLStructure:
         })
         assert '<title>Hydra Mission Report</title>' in html
         assert 'const D=[]' in html
+
+    def test_offline_mode_omits_cdn_leaflet(self):
+        records = _make_records(['person'])
+        summary = _make_summary(['person'])
+        html = generate_html(records, summary, offline_mode=True)
+        assert 'unpkg.com/leaflet' not in html
+        assert 'OFFLINE COORDINATE VIEW' in html
+        assert 'renderOffline' in html
+
+
+class TestDecimation:
+    """Large-log decimation behavior for export size control."""
+
+    def test_decimate_keeps_first_and_last(self):
+        records = [{"track_id": i} for i in range(10)]
+        trimmed = decimate_records(records, 4)
+        assert len(trimmed) == 4
+        assert trimmed[0]["track_id"] == 0
+        assert trimmed[-1]["track_id"] == 9
+
+    def test_decimate_disabled_when_zero(self):
+        records = [{"track_id": i} for i in range(10)]
+        assert decimate_records(records, 0) == records


### PR DESCRIPTION
### Motivation

- Provide a reliable export path for very large detection logs by capping rendered records to avoid huge HTML outputs. 
- Support fully disconnected / air-gapped post-mission review by offering an export mode with zero CDN/Leaflet dependencies.

### Description

- Add `decimate_records(records, max_records)` to deterministically downsample large logs while preserving first/last items and temporal spread, and wire it to a new CLI flag `--max-records`.
- Add `--offline-mode` to `hydra_detect.review_export` and implement `_generate_offline_plot()` to emit a coordinate-only SVG/HTML view so reports can be rendered without external assets, and surface the chosen mode in the generated report header via `generate_html(..., offline_mode=...)`.
- Preserve provenance metadata by adding `source_total` and `truncated` to the summary and keep the original Leaflet-based export as the default path when `--offline-mode` is not set.
- Update tests and docs by adding decimation/offline assertions in `tests/test_review_export.py` and documenting the new CLI options in `docs/post-mission-review.md`.

### Testing

- Ran `pytest -q tests/test_review_export.py tests/test_review.py`, and all tests passed (`31 passed`).
- New unit tests cover offline-mode HTML output (CDN omission and offline renderer presence) and decimation behavior (`decimate_records`) and succeeded as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d29a42f9188328979ffa60335254ad)