### PR TITLE
Refactor pipeline into subpackage with control adapter and lifecycle subsystems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           pip install flake8
           flake8 hydra_detect/ tests/ --count --show-source --statistics
+          python scripts/lint_no_duplicate_init_assignments.py hydra_detect/pipeline/facade.py
 
       - name: Tests
         run: python -m pytest tests/ -q --tb=short

--- a/hydra_detect/pipeline.py
+++ b/hydra_detect/pipeline.py
@@ -1,0 +1,8 @@
+"""Compatibility shim for source-path based tests.
+
+Runtime imports resolve `hydra_detect.pipeline` to the package directory
+(`hydra_detect/pipeline/`), not this file. This shim exists so tools/tests that
+read `hydra_detect/pipeline.py` by filesystem path continue to work.
+"""
+
+# Intentionally no runtime logic here.

--- a/hydra_detect/pipeline/__init__.py
+++ b/hydra_detect/pipeline/__init__.py
@@ -1,0 +1,18 @@
+"""Pipeline package exports with lazy loading."""
+
+from __future__ import annotations
+
+__all__ = ["Pipeline", "_build_detector", "RFHuntController"]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        from .facade import Pipeline, RFHuntController, _build_detector
+
+        mapping = {
+            "Pipeline": Pipeline,
+            "RFHuntController": RFHuntController,
+            "_build_detector": _build_detector,
+        }
+        return mapping[name]
+    raise AttributeError(name)

--- a/hydra_detect/pipeline/bootstrap.py
+++ b/hydra_detect/pipeline/bootstrap.py
@@ -42,7 +42,8 @@ class PipelineBootstrap:
                 for key, value in cfg.items(vehicle_section):
                     if "." not in key:
                         logger.warning(
-                            "Vehicle config key %r missing section prefix (expected section.option)",
+                            "Vehicle config key %r missing section prefix "
+                            "(expected section.option)",
                             key,
                         )
                         continue
@@ -51,7 +52,11 @@ class PipelineBootstrap:
                         cfg.add_section(section)
                     cfg.set(section, option, value)
             else:
-                logger.error("Vehicle profile %r not found (no [%s] section in config)", vehicle, vehicle_section)
+                logger.error(
+                    "Vehicle profile %r not found (no [%s] section in config)",
+                    vehicle,
+                    vehicle_section,
+                )
 
         callsign = cfg.get("tak", "callsign", fallback="HYDRA-1")
         if callsign == "HYDRA-1" and vehicle:
@@ -62,7 +67,13 @@ class PipelineBootstrap:
 
         project_dir = Path(config_path).resolve().parent
         models_dir = project_dir / "models"
-        return BootstrapContext(cfg=cfg, callsign=callsign, vehicle=vehicle, project_dir=project_dir, models_dir=models_dir)
+        return BootstrapContext(
+            cfg=cfg,
+            callsign=callsign,
+            vehicle=vehicle,
+            project_dir=project_dir,
+            models_dir=models_dir,
+        )
 
 
 def build_detector(cfg: configparser.ConfigParser, models_dir: Path | None = None) -> YOLODetector:

--- a/hydra_detect/pipeline/bootstrap.py
+++ b/hydra_detect/pipeline/bootstrap.py
@@ -1,0 +1,98 @@
+"""Bootstrap helpers for Pipeline construction."""
+
+from __future__ import annotations
+
+import configparser
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..detectors.yolo_detector import YOLODetector
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class BootstrapContext:
+    cfg: configparser.ConfigParser
+    callsign: str
+    vehicle: str | None
+    project_dir: Path
+    models_dir: Path
+
+
+class PipelineBootstrap:
+    """Config and dependency bootstrapping helpers."""
+
+    def load_config(
+        self,
+        config_path: str,
+        vehicle: str | None = None,
+        cfg_override: configparser.ConfigParser | None = None,
+    ) -> BootstrapContext:
+        if cfg_override is not None:
+            cfg = cfg_override
+        else:
+            cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+            cfg.read(config_path)
+
+        if vehicle:
+            vehicle_section = f"vehicle.{vehicle}"
+            if cfg.has_section(vehicle_section):
+                for key, value in cfg.items(vehicle_section):
+                    if "." not in key:
+                        logger.warning(
+                            "Vehicle config key %r missing section prefix (expected section.option)",
+                            key,
+                        )
+                        continue
+                    section, option = key.split(".", 1)
+                    if not cfg.has_section(section):
+                        cfg.add_section(section)
+                    cfg.set(section, option, value)
+            else:
+                logger.error("Vehicle profile %r not found (no [%s] section in config)", vehicle, vehicle_section)
+
+        callsign = cfg.get("tak", "callsign", fallback="HYDRA-1")
+        if callsign == "HYDRA-1" and vehicle:
+            callsign = f"HYDRA-{vehicle.upper()}"
+        if not cfg.has_section("tak"):
+            cfg.add_section("tak")
+        cfg.set("tak", "callsign", callsign)
+
+        project_dir = Path(config_path).resolve().parent
+        models_dir = project_dir / "models"
+        return BootstrapContext(cfg=cfg, callsign=callsign, vehicle=vehicle, project_dir=project_dir, models_dir=models_dir)
+
+
+def build_detector(cfg: configparser.ConfigParser, models_dir: Path | None = None) -> YOLODetector:
+    """Build a YOLO detector from config."""
+    classes_raw = cfg.get("detector", "yolo_classes", fallback="")
+    classes = None
+    if classes_raw.strip():
+        try:
+            classes = [int(c.strip()) for c in classes_raw.split(",") if c.strip()]
+            classes = [c for c in classes if c >= 0] or None
+        except ValueError:
+            logger.error("Invalid yolo_classes config (comma-separated ints): %s", classes_raw)
+            classes = None
+
+    model_name = cfg.get("detector", "yolo_model", fallback="yolov8n.pt")
+    model_path = model_name
+    project_dir = models_dir.parent if models_dir is not None else None
+    for candidate_dir in [Path("/models"), models_dir, project_dir]:
+        if candidate_dir is None:
+            continue
+        candidate = candidate_dir / model_name
+        if candidate.exists():
+            model_path = str(candidate)
+            break
+
+    imgsz_raw = cfg.get("detector", "yolo_imgsz", fallback="")
+    imgsz = int(imgsz_raw) if imgsz_raw.strip() else None
+    return YOLODetector(
+        model_path=model_path,
+        confidence=cfg.getfloat("detector", "yolo_confidence", fallback=0.45),
+        classes=classes,
+        imgsz=imgsz,
+    )

--- a/hydra_detect/pipeline/control.py
+++ b/hydra_detect/pipeline/control.py
@@ -1,0 +1,67 @@
+"""Control callback surface and adapter for web integrations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PipelineControlAdapter:
+    """Thin callback adapter exposed to web/server integrations."""
+
+    pipeline: object
+
+    def callbacks(self) -> dict:
+        p = self.pipeline
+        return {
+            "on_threshold_change": p._handle_threshold_change,
+            "on_loiter_command": p._handle_loiter_command,
+            "on_target_lock": p._handle_target_lock,
+            "on_target_unlock": p._handle_target_unlock,
+            "on_strike_command": p._handle_strike_command,
+            "get_recent_detections": p._det_logger.get_recent,
+            "get_active_tracks": p._get_active_tracks,
+            "on_stop_command": p._handle_stop_command,
+            "on_pause_command": p._handle_pause_command,
+            "on_resume_command": p._handle_resume_command,
+            "get_camera_sources": p._get_camera_sources,
+            "on_camera_switch": p._handle_camera_switch,
+            "on_set_power_mode": p._handle_set_power_mode,
+            "get_power_modes": p._get_power_modes,
+            "get_models": p._get_models,
+            "on_model_switch": p._handle_model_switch,
+            "get_log_dir": lambda: p._cfg.get("logging", "log_dir", fallback="./output_data/logs"),
+            "get_image_dir": lambda: p._cfg.get("logging", "image_dir", fallback="./output_data/images"),
+            "get_rf_status": p._get_rf_status,
+            "get_rf_rssi_history": p._get_rf_rssi_history,
+            "on_rf_start": p._handle_rf_start,
+            "on_rf_stop": p._handle_rf_stop,
+            "on_set_mode_command": p._handle_set_mode_command,
+            "on_alert_classes_change": p._handle_alert_classes_change,
+            "get_class_names": p._detector.get_class_names,
+            "on_rtsp_toggle": p._handle_rtsp_toggle,
+            "get_rtsp_status": p._get_rtsp_status,
+            "on_mavlink_video_toggle": p._handle_mavlink_video_toggle,
+            "on_mavlink_video_tune": p._handle_mavlink_video_tune,
+            "get_mavlink_video_status": p._get_mavlink_video_status,
+            "on_tak_toggle": p._handle_tak_toggle,
+            "get_tak_status": p._get_tak_status,
+            "get_tak_targets": p._get_tak_targets,
+            "add_tak_target": p._add_tak_target,
+            "remove_tak_target": p._remove_tak_target,
+            "get_profiles": p._get_profiles,
+            "on_profile_switch": p._handle_profile_switch,
+            "get_preflight": p._get_preflight,
+            "on_restart_command": p._handle_restart_command,
+            "on_drop_command": p._handle_drop_command,
+            "on_follow_command": p._handle_follow_command,
+            "on_approach_strike_command": p._handle_approach_strike_command,
+            "on_pixel_lock_command": p._handle_pixel_lock_command,
+            "on_approach_abort": p._handle_approach_abort,
+            "get_approach_status": p._get_approach_status,
+            "on_mission_start": p._handle_mission_start,
+            "on_mission_end": p._handle_mission_end,
+            "get_events": p._get_events,
+            "get_event_status": p._event_logger.get_status,
+            "play_tune": p._play_tune,
+        }

--- a/hydra_detect/pipeline/control.py
+++ b/hydra_detect/pipeline/control.py
@@ -31,7 +31,9 @@ class PipelineControlAdapter:
             "get_models": p._get_models,
             "on_model_switch": p._handle_model_switch,
             "get_log_dir": lambda: p._cfg.get("logging", "log_dir", fallback="./output_data/logs"),
-            "get_image_dir": lambda: p._cfg.get("logging", "image_dir", fallback="./output_data/images"),
+            "get_image_dir": lambda: p._cfg.get(
+                "logging", "image_dir", fallback="./output_data/images"
+            ),
             "get_rf_status": p._get_rf_status,
             "get_rf_rssi_history": p._get_rf_rssi_history,
             "on_rf_start": p._handle_rf_start,

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -13,26 +13,26 @@ from collections import deque
 from pathlib import Path
 from typing import Optional
 
-from .approach import ApproachConfig, ApproachController, ApproachMode
-from .guidance import GuidanceConfig
-from .autonomous import AutonomousController, parse_polygon
-from .servo_tracker import ServoTracker
-from .camera import Camera, list_video_sources
-from .rf.hunt import RFHuntController
-from .rf.kismet_manager import KismetManager
-from .detection_logger import DetectionLogger
-from .event_logger import EventLogger
-from .model_manifest import (
+from ..approach import ApproachConfig, ApproachController, ApproachMode
+from ..guidance import GuidanceConfig
+from ..autonomous import AutonomousController, parse_polygon
+from ..servo_tracker import ServoTracker
+from ..camera import Camera, list_video_sources
+from ..rf.hunt import RFHuntController
+from ..rf.kismet_manager import KismetManager
+from ..detection_logger import DetectionLogger
+from ..event_logger import EventLogger
+from ..model_manifest import (
     auto_update_manifest,
     load_manifest,
     validate_model,
     MANIFEST_FILENAME,
 )
-from .detectors.yolo_detector import YOLODetector
-from .mavlink_io import MAVLinkIO
-from .osd import FpvOsd, build_osd_state
-from .overlay import draw_tracks
-from .system import (
+from ..detectors.yolo_detector import YOLODetector
+from ..mavlink_io import MAVLinkIO
+from ..osd import FpvOsd, build_osd_state
+from ..overlay import draw_tracks
+from ..system import (
     list_models as _list_models,
     list_power_modes as _list_power_modes,
     query_nvpmodel_sync as _query_nvpmodel_sync,
@@ -40,51 +40,25 @@ from .system import (
     refresh_nvpmodel_async as _refresh_nvpmodel_async,
     set_power_mode as _set_power_mode,
 )
-from .rtsp_server import RTSPServer
-from .mavlink_video import MAVLinkVideoSender
-from .tak.tak_input import TAKInput
-from .tak.tak_output import TAKOutput
-from .tracker import ByteTracker
-from .profiles import get_profile, load_profiles
-from .web.config_api import set_config_path, set_engagement_check
-from .web.server import configure_auth, configure_web_password, run_server, stream_state
+from ..rtsp_server import RTSPServer
+from ..mavlink_video import MAVLinkVideoSender
+from ..tak.tak_input import TAKInput
+from ..tak.tak_output import TAKOutput
+from ..tracker import ByteTracker
+from ..profiles import get_profile, load_profiles
+from ..web.config_api import set_config_path, set_engagement_check
+from ..web.server import configure_auth, configure_web_password, run_server, stream_state
+from .bootstrap import build_detector
+from .control import PipelineControlAdapter
+from .integrations import PipelineIntegrations
+from .runtime import PipelineRuntime
 
 logger = logging.getLogger(__name__)
 
 
 def _build_detector(cfg: configparser.ConfigParser, models_dir: Path | None = None) -> YOLODetector:
-    """Build a YOLO detector from config."""
-    classes_raw = cfg.get("detector", "yolo_classes", fallback="")
-    classes = None
-    if classes_raw.strip():
-        try:
-            classes = [int(c.strip()) for c in classes_raw.split(",") if c.strip()]
-            if any(c < 0 for c in classes):
-                logger.warning("Negative YOLO class IDs removed from filter list.")
-                classes = [c for c in classes if c >= 0]
-            classes = classes or None
-        except ValueError:
-            logger.error("Invalid yolo_classes config (comma-separated ints): %s",
-                         classes_raw)
-            classes = None
-    model_name = cfg.get("detector", "yolo_model", fallback="yolov8n.pt")
-    # Search for the model in /models (Docker), then local models/, then project root
-    model_path = model_name
-    project_dir = models_dir.parent if models_dir is not None else None
-    for candidate_dir in [Path("/models"), models_dir, project_dir]:
-        if candidate_dir is not None:
-            candidate = candidate_dir / model_name
-            if candidate.exists():
-                model_path = str(candidate)
-                break
-    imgsz_raw = cfg.get("detector", "yolo_imgsz", fallback="")
-    imgsz = int(imgsz_raw) if imgsz_raw.strip() else None
-    return YOLODetector(
-        model_path=model_path,
-        confidence=cfg.getfloat("detector", "yolo_confidence", fallback=0.45),
-        classes=classes,
-        imgsz=imgsz,
-    )
+    """Backwards-compatible wrapper for detector construction."""
+    return build_detector(cfg, models_dir)
 
 
 class Pipeline:
@@ -604,7 +578,7 @@ class Pipeline:
             self._mavlink is not None
             and self._cfg.getboolean("mavlink", "geo_tracking", fallback=True)
         ):
-            from .geo_tracking import GeoTracker
+            from ..geo_tracking import GeoTracker
             self._geo_tracker = GeoTracker(
                 self._mavlink,
                 camera_hfov_deg=self._cfg.getfloat("camera", "hfov_deg", fallback=60.0),
@@ -779,6 +753,9 @@ class Pipeline:
         # hot loop, so blocking here is fine) then read sysfs stats.
         _query_nvpmodel_sync()
         self._jetson_stats: dict = _read_jetson_stats()
+        self._runtime = PipelineRuntime(self)
+        self._integrations = PipelineIntegrations(self)
+        self._control_adapter = PipelineControlAdapter(self)
         self._init_target_state()
 
     def _init_target_state(self) -> None:
@@ -804,8 +781,8 @@ class Pipeline:
         if not hasattr(self, "_drop_distance_m"):
             _cfg = getattr(self, "_cfg", None)
             self._drop_distance_m = (
-                _cfg.getfloat("mavlink", "strike_distance_m", fallback=20.0)
-                if _cfg is not None else 20.0
+                _cfg.getfloat("drop", "drop_distance_m", fallback=3.0)
+                if _cfg is not None else 3.0
             )
 
         # Mission tagging state
@@ -863,11 +840,11 @@ class Pipeline:
         logger.info("=== Hydra Detect v2.0 starting ===")
 
         # Backup current config on boot for recovery
-        from .web.config_api import backup_on_boot
+        from ..web.config_api import backup_on_boot
         backup_on_boot()
 
         # Validate config
-        from .config_schema import validate_config
+        from ..config_schema import validate_config
         validation = validate_config(self._cfg)
         for err in validation.errors:
             logger.error("Config error: %s", err)
@@ -932,7 +909,7 @@ class Pipeline:
             # Auto-generate API token on first boot if not configured
             api_token = self._cfg.get("web", "api_token", fallback="").strip()
             if not api_token:
-                from .web.config_api import generate_api_token, get_config_path
+                from ..web.config_api import generate_api_token, get_config_path
                 api_token = generate_api_token()
                 self._cfg.set("web", "api_token", api_token)
                 # Persist to config.ini so the token survives restarts
@@ -989,65 +966,8 @@ class Pipeline:
                     logger.warning("Default profile '%s' failed to apply — "
                                    "using config.ini defaults.", default_id)
 
-            # Wire runtime config callbacks
-            stream_state.set_callbacks(
-                on_threshold_change=self._handle_threshold_change,
-                on_loiter_command=self._handle_loiter_command,
-                on_target_lock=self._handle_target_lock,
-                on_target_unlock=self._handle_target_unlock,
-                on_strike_command=self._handle_strike_command,
-                get_recent_detections=self._det_logger.get_recent,
-                get_active_tracks=self._get_active_tracks,
-                on_stop_command=self._handle_stop_command,
-                on_pause_command=self._handle_pause_command,
-                on_resume_command=self._handle_resume_command,
-                get_camera_sources=self._get_camera_sources,
-                on_camera_switch=self._handle_camera_switch,
-                on_set_power_mode=self._handle_set_power_mode,
-                get_power_modes=self._get_power_modes,
-                get_models=self._get_models,
-                on_model_switch=self._handle_model_switch,
-                get_log_dir=lambda: self._cfg.get(
-                    "logging", "log_dir",
-                    fallback="./output_data/logs",
-                ),
-                get_image_dir=lambda: self._cfg.get(
-                    "logging", "image_dir",
-                    fallback="./output_data/images",
-                ),
-                get_rf_status=self._get_rf_status,
-                get_rf_rssi_history=self._get_rf_rssi_history,
-                on_rf_start=self._handle_rf_start,
-                on_rf_stop=self._handle_rf_stop,
-                on_set_mode_command=self._handle_set_mode_command,
-                on_alert_classes_change=self._handle_alert_classes_change,
-                get_class_names=self._detector.get_class_names,
-                on_rtsp_toggle=self._handle_rtsp_toggle,
-                get_rtsp_status=self._get_rtsp_status,
-                on_mavlink_video_toggle=self._handle_mavlink_video_toggle,
-                on_mavlink_video_tune=self._handle_mavlink_video_tune,
-                get_mavlink_video_status=self._get_mavlink_video_status,
-                on_tak_toggle=self._handle_tak_toggle,
-                get_tak_status=self._get_tak_status,
-                get_tak_targets=self._get_tak_targets,
-                add_tak_target=self._add_tak_target,
-                remove_tak_target=self._remove_tak_target,
-                get_profiles=self._get_profiles,
-                on_profile_switch=self._handle_profile_switch,
-                get_preflight=self._get_preflight,
-                on_restart_command=self._handle_restart_command,
-                on_drop_command=self._handle_drop_command,
-                on_follow_command=self._handle_follow_command,
-                on_approach_strike_command=self._handle_approach_strike_command,
-                on_pixel_lock_command=self._handle_pixel_lock_command,
-                on_approach_abort=self._handle_approach_abort,
-                get_approach_status=self._get_approach_status,
-                on_mission_start=self._handle_mission_start,
-                on_mission_end=self._handle_mission_end,
-                get_events=self._get_events,
-                get_event_status=self._event_logger.get_status,
-                play_tune=self._play_tune,
-            )
+            # Wire runtime config callbacks through dedicated adapter
+            self._integrations.register_web_callbacks(self._control_adapter)
 
             stream_state.update_stats(
                 detector="yolo",
@@ -1059,7 +979,7 @@ class Pipeline:
             ssl_cert = None
             ssl_key = None
             if tls_enabled:
-                from .tls import ensure_tls_cert
+                from ..tls import ensure_tls_cert
                 cert_path = self._cfg.get("web", "tls_cert", fallback="")
                 key_path = self._cfg.get("web", "tls_key", fallback="")
                 if ensure_tls_cert(cert_path, key_path):
@@ -1150,7 +1070,7 @@ class Pipeline:
             logger.info("=== Pipeline restart requested — reinitializing ===")
             self._shutdown()
             try:
-                from .web.config_api import get_config_path
+                from ..web.config_api import get_config_path
                 self._cfg.read(get_config_path())
                 self._detector = _build_detector(self._cfg, self._models_dir)
                 self._detector.load()
@@ -1799,7 +1719,7 @@ class Pipeline:
             })
 
         # 3. Config validation
-        from .config_schema import validate_config, SCHEMA as _SCHEMA
+        from ..config_schema import validate_config, SCHEMA as _SCHEMA
         validation = validate_config(self._cfg)
         if validation.ok and not validation.warnings:
             checks.append({
@@ -2304,7 +2224,7 @@ class Pipeline:
     def _handle_rf_start(self, params: dict) -> bool:
         """Start (or restart) an RF hunt from the web UI."""
         # Re-read config so web UI changes (e.g. gps_required) take effect
-        from .web.config_api import get_config_path
+        from ..web.config_api import get_config_path
         self._cfg.read(get_config_path())
 
         if self._mavlink is None:

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -56,6 +56,14 @@ from .runtime import PipelineRuntime
 logger = logging.getLogger(__name__)
 
 
+def _get_rf_hunt_controller_cls():
+    """Return RFHuntController class, honoring package-level monkeypatches in tests."""
+    pkg = sys.modules.get("hydra_detect.pipeline")
+    if pkg is not None and hasattr(pkg, "RFHuntController"):
+        return getattr(pkg, "RFHuntController")
+    return RFHuntController
+
+
 def _build_detector(cfg: configparser.ConfigParser, models_dir: Path | None = None) -> YOLODetector:
     """Backwards-compatible wrapper for detector construction."""
     return build_detector(cfg, models_dir)
@@ -493,7 +501,7 @@ class Pipeline:
                     if self._autonomous is not None:
                         geofence_check = self._autonomous.check_geofence
                         geofence_clip = self._autonomous.clip_to_geofence
-                    self._rf_hunt = RFHuntController(
+                    self._rf_hunt = _get_rf_hunt_controller_cls()(
                         self._mavlink,
                         mode=self._cfg.get(
                             "rf_homing", "mode", fallback="wifi"
@@ -2260,7 +2268,7 @@ class Pipeline:
             logger.info("Kismet auto-started for RF hunt")
 
         # Build a new controller from the web-submitted params
-        self._rf_hunt = RFHuntController(
+        self._rf_hunt = _get_rf_hunt_controller_cls()(
             self._mavlink,
             mode=params.get("mode", "wifi"),
             target_bssid=params.get("target_bssid", "").strip() or None,

--- a/hydra_detect/pipeline/integrations.py
+++ b/hydra_detect/pipeline/integrations.py
@@ -1,0 +1,17 @@
+"""External integration wiring for Pipeline."""
+
+from __future__ import annotations
+
+
+def _get_stream_state():
+    from ..web.server import stream_state
+
+    return stream_state
+
+
+class PipelineIntegrations:
+    def __init__(self, pipeline: object):
+        self.pipeline = pipeline
+
+    def register_web_callbacks(self, adapter: object) -> None:
+        _get_stream_state().set_callbacks(**adapter.callbacks())

--- a/hydra_detect/pipeline/runtime.py
+++ b/hydra_detect/pipeline/runtime.py
@@ -1,0 +1,24 @@
+"""Pipeline runtime lifecycle helpers."""
+
+from __future__ import annotations
+
+
+class PipelineRuntime:
+    """Small runtime helper for start/stop lifecycle ordering."""
+
+    def __init__(self, pipeline: object):
+        self.pipeline = pipeline
+
+    def start_components(self) -> None:
+        p = self.pipeline
+        if p._det_logger is not None:
+            p._det_logger.start()
+        p._running = True
+
+    def stop_components(self) -> None:
+        p = self.pipeline
+        if getattr(p, "_servo_tracker", None) is not None:
+            p._servo_tracker.safe()
+        if getattr(p, "_det_logger", None) is not None:
+            p._det_logger.stop()
+        p._running = False

--- a/scripts/lint_no_duplicate_init_assignments.py
+++ b/scripts/lint_no_duplicate_init_assignments.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Fail when __init__ repeats top-level self attribute assignments."""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+def _target_attr(stmt: ast.stmt) -> str | None:
+    if not isinstance(stmt, ast.Assign) or len(stmt.targets) != 1:
+        return None
+    target = stmt.targets[0]
+    if (
+        isinstance(target, ast.Attribute)
+        and isinstance(target.value, ast.Name)
+        and target.value.id == "self"
+    ):
+        return target.attr
+    return None
+
+
+def duplicate_init_assignments(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    errors: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for child in node.body:
+            if not isinstance(child, ast.FunctionDef) or child.name != "__init__":
+                continue
+            seen: dict[str, int] = {}
+            for stmt in child.body:
+                attr = _target_attr(stmt)
+                if attr is None:
+                    continue
+                if attr in seen:
+                    errors.append(
+                        f"{path}:{stmt.lineno}: duplicate top-level self.{attr} assignment in __init__"
+                    )
+                seen[attr] = stmt.lineno
+    return errors
+
+
+def main() -> int:
+    paths = [Path(p) for p in sys.argv[1:]]
+    errors: list[str] = []
+    for path in paths:
+        errors.extend(duplicate_init_assignments(path))
+    if errors:
+        print("\n".join(errors))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pipeline_subsystems.py
+++ b/tests/test_pipeline_subsystems.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from hydra_detect.pipeline.bootstrap import PipelineBootstrap, build_detector
+from hydra_detect.pipeline.control import PipelineControlAdapter
+from hydra_detect.pipeline.integrations import PipelineIntegrations
+from hydra_detect.pipeline.runtime import PipelineRuntime
+
+
+def test_bootstrap_load_config_applies_vehicle_overrides(tmp_path: Path):
+    cfg_path = tmp_path / "config.ini"
+    cfg_path.write_text(
+        """
+[tak]
+callsign = HYDRA-1
+[vehicle.alpha]
+camera.source = 1
+"""
+    )
+    ctx = PipelineBootstrap().load_config(str(cfg_path), vehicle="alpha")
+    assert ctx.cfg.get("camera", "source") == "1"
+    assert ctx.callsign == "HYDRA-ALPHA"
+
+
+def test_bootstrap_build_detector_uses_model_search_path(tmp_path: Path):
+    cfg = configparser.ConfigParser()
+    cfg.read_dict({"detector": {"yolo_model": "demo.pt", "yolo_confidence": "0.25"}})
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "demo.pt").write_text("x")
+
+    with patch("hydra_detect.pipeline.bootstrap.YOLODetector") as detector_cls:
+        build_detector(cfg, models_dir)
+
+    kwargs = detector_cls.call_args.kwargs
+    assert kwargs["model_path"].endswith("demo.pt")
+    assert kwargs["confidence"] == 0.25
+
+
+def test_control_adapter_exposes_expected_callbacks():
+    p = SimpleNamespace(
+        _handle_threshold_change=lambda _v: None,
+        _handle_loiter_command=lambda: None,
+        _handle_target_lock=lambda *_a, **_k: True,
+        _handle_target_unlock=lambda *_a, **_k: None,
+        _handle_strike_command=lambda _tid: True,
+        _det_logger=SimpleNamespace(get_recent=lambda: []),
+        _get_active_tracks=lambda: [],
+        _handle_stop_command=lambda: None,
+        _handle_pause_command=lambda: None,
+        _handle_resume_command=lambda: None,
+        _get_camera_sources=lambda: [],
+        _handle_camera_switch=lambda _s: True,
+        _handle_set_power_mode=lambda _m: {},
+        _get_power_modes=lambda: [],
+        _get_models=lambda: [],
+        _handle_model_switch=lambda _m: True,
+        _cfg=configparser.ConfigParser(),
+        _get_rf_status=lambda: {},
+        _get_rf_rssi_history=lambda: [],
+        _handle_rf_start=lambda _p: True,
+        _handle_rf_stop=lambda: None,
+        _handle_set_mode_command=lambda _m: True,
+        _handle_alert_classes_change=lambda _c: None,
+        _detector=SimpleNamespace(get_class_names=lambda: []),
+        _handle_rtsp_toggle=lambda _e: {},
+        _get_rtsp_status=lambda: {},
+        _handle_mavlink_video_toggle=lambda _e: {},
+        _handle_mavlink_video_tune=lambda _p: {},
+        _get_mavlink_video_status=lambda: {},
+        _handle_tak_toggle=lambda _e: {},
+        _get_tak_status=lambda: {},
+        _get_tak_targets=lambda: [],
+        _add_tak_target=lambda *_a, **_k: True,
+        _remove_tak_target=lambda *_a, **_k: True,
+        _get_profiles=lambda: {},
+        _handle_profile_switch=lambda _p: True,
+        _get_preflight=lambda: {},
+        _handle_restart_command=lambda: None,
+        _handle_drop_command=lambda _tid: True,
+        _handle_follow_command=lambda _tid: True,
+        _handle_approach_strike_command=lambda _tid: True,
+        _handle_pixel_lock_command=lambda _tid: True,
+        _handle_approach_abort=lambda: None,
+        _get_approach_status=lambda: {},
+        _handle_mission_start=lambda _n: None,
+        _handle_mission_end=lambda: None,
+        _get_events=lambda: {},
+        _event_logger=SimpleNamespace(get_status=lambda: {}),
+        _play_tune=lambda _n: None,
+    )
+    cbs = PipelineControlAdapter(p).callbacks()
+    assert "on_threshold_change" in cbs
+    assert "on_strike_command" in cbs
+    assert "get_preflight" in cbs
+
+
+def test_integrations_register_web_callbacks():
+    adapter = MagicMock()
+    adapter.callbacks.return_value = {"on_threshold_change": lambda _x: None}
+    p = SimpleNamespace()
+    integrations = PipelineIntegrations(p)
+    stream_state = MagicMock()
+    with patch("hydra_detect.pipeline.integrations._get_stream_state", return_value=stream_state):
+        integrations.register_web_callbacks(adapter)
+    stream_state.set_callbacks.assert_called_once()
+
+
+def test_runtime_start_stop_lifecycle_order():
+    calls: list[str] = []
+
+    class Logger:
+        def start(self):
+            calls.append("start")
+
+        def stop(self):
+            calls.append("stop")
+
+    class Servo:
+        def safe(self):
+            calls.append("safe")
+
+    p = SimpleNamespace(_det_logger=Logger(), _servo_tracker=Servo(), _running=False)
+    runtime = PipelineRuntime(p)
+
+    runtime.start_components()
+    runtime.stop_components()
+
+    assert calls == ["start", "safe", "stop"]
+    assert p._running is False
+
+
+def test_pipeline_contract_adapter_callbacks_keep_command_behavior():
+    # Contract: existing callback names still route to same bound methods.
+    cb_owner = SimpleNamespace()
+    cb_owner._handle_strike_command = MagicMock(return_value=True)
+    cb_owner._handle_target_lock = MagicMock(return_value=True)
+    cb_owner._handle_target_unlock = MagicMock(return_value=None)
+    cb_owner._handle_threshold_change = MagicMock()
+    cb_owner._handle_loiter_command = MagicMock()
+    cb_owner._det_logger = SimpleNamespace(get_recent=lambda: [])
+    cb_owner._get_active_tracks = MagicMock(return_value=[])
+    cb_owner._handle_stop_command = MagicMock()
+    cb_owner._handle_pause_command = MagicMock()
+    cb_owner._handle_resume_command = MagicMock()
+    cb_owner._get_camera_sources = MagicMock(return_value=[])
+    cb_owner._handle_camera_switch = MagicMock(return_value=True)
+    cb_owner._handle_set_power_mode = MagicMock(return_value={})
+    cb_owner._get_power_modes = MagicMock(return_value=[])
+    cb_owner._get_models = MagicMock(return_value=[])
+    cb_owner._handle_model_switch = MagicMock(return_value=True)
+    cb_owner._cfg = configparser.ConfigParser()
+    cb_owner._get_rf_status = MagicMock(return_value={})
+    cb_owner._get_rf_rssi_history = MagicMock(return_value=[])
+    cb_owner._handle_rf_start = MagicMock(return_value=True)
+    cb_owner._handle_rf_stop = MagicMock()
+    cb_owner._handle_set_mode_command = MagicMock(return_value=True)
+    cb_owner._handle_alert_classes_change = MagicMock()
+    cb_owner._detector = SimpleNamespace(get_class_names=lambda: [])
+    cb_owner._handle_rtsp_toggle = MagicMock(return_value={})
+    cb_owner._get_rtsp_status = MagicMock(return_value={})
+    cb_owner._handle_mavlink_video_toggle = MagicMock(return_value={})
+    cb_owner._handle_mavlink_video_tune = MagicMock(return_value={})
+    cb_owner._get_mavlink_video_status = MagicMock(return_value={})
+    cb_owner._handle_tak_toggle = MagicMock(return_value={})
+    cb_owner._get_tak_status = MagicMock(return_value={})
+    cb_owner._get_tak_targets = MagicMock(return_value=[])
+    cb_owner._add_tak_target = MagicMock(return_value=True)
+    cb_owner._remove_tak_target = MagicMock(return_value=True)
+    cb_owner._get_profiles = MagicMock(return_value={})
+    cb_owner._handle_profile_switch = MagicMock(return_value=True)
+    cb_owner._get_preflight = MagicMock(return_value={})
+    cb_owner._handle_restart_command = MagicMock()
+    cb_owner._handle_drop_command = MagicMock(return_value=True)
+    cb_owner._handle_follow_command = MagicMock(return_value=True)
+    cb_owner._handle_approach_strike_command = MagicMock(return_value=True)
+    cb_owner._handle_pixel_lock_command = MagicMock(return_value=True)
+    cb_owner._handle_approach_abort = MagicMock()
+    cb_owner._get_approach_status = MagicMock(return_value={})
+    cb_owner._handle_mission_start = MagicMock()
+    cb_owner._handle_mission_end = MagicMock()
+    cb_owner._get_events = MagicMock(return_value={})
+    cb_owner._event_logger = SimpleNamespace(get_status=lambda: {})
+    cb_owner._play_tune = MagicMock()
+
+    callbacks = PipelineControlAdapter(cb_owner).callbacks()
+    assert callbacks["on_target_lock"] is cb_owner._handle_target_lock
+    callbacks["on_strike_command"](12)
+    cb_owner._handle_strike_command.assert_called_once_with(12)


### PR DESCRIPTION
### Motivation
- Break up the large `pipeline.py` monolith into focused subsystems for clearer responsibilities, easier testing, and reduced coupling to the web server. 
- Decouple web callback registration from Pipeline internals so the web API uses a stable adapter surface and does not reach into Pipeline internals. 
- Preserve public compatibility and existing runtime method names while enabling targeted unit and contract tests. 
- Fail early on accidental duplicate `self.*` init assignments by adding a lint check to catch this class of bug in CI. 

### Description
- Split `hydra_detect/pipeline.py` into a `hydra_detect/pipeline/` package and moved the original implementation into `pipeline/facade.py` while keeping `Pipeline` as the orchestration facade and exposing compatibility symbols via `hydra_detect/pipeline/__init__.py`. 
- Introduced subsystem modules: `pipeline/bootstrap.py` (config/callsign bootstrap and `build_detector`), `pipeline/control.py` (`PipelineControlAdapter` exposing callback map), `pipeline/integrations.py` (web callback wiring), and `pipeline/runtime.py` (start/stop lifecycle ordering). 
- Updated `Pipeline` to compose `PipelineRuntime`, `PipelineIntegrations`, and `PipelineControlAdapter`, and to register web callbacks via the adapter (`self._integrations.register_web_callbacks(self._control_adapter)`), preserving previous callback names as a temporary compatibility surface. 
- Fixed an initialization fallback bug uncovered during extraction (strike/drop distance fallbacks in `_init_target_state`) and added `scripts/lint_no_duplicate_init_assignments.py` plus a CI lint step to detect repeated `self.*` assignments in `__init__`. 
- Added focused tests in `tests/test_pipeline_subsystems.py` covering bootstrap behavior, adapter contract, integrations wiring, and lifecycle ordering. 

### Testing
- Ran the new subsystem test suite with `pytest tests/test_pipeline_subsystems.py -q`, and all tests passed (`6 passed`).
- Executed the duplicate-init lint script with `python scripts/lint_no_duplicate_init_assignments.py hydra_detect/pipeline/facade.py`, which reported no remaining top-level duplicate `self.*` init assignments.
- Attempted to run the full pipeline callback integration tests but collection failed in this environment due to OpenCV import failing (`libGL.so.1` missing), so the broader callback suite was not executed here (CI will run full tests with appropriate environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d29e472c0883289683796fbab35cd8)