### PR TITLE
docs: add QSPI firmware update guide for new Jetsons

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -68,7 +68,7 @@ sudo systemctl restart hydra-detect
 Key volume mounts:
 
 | Host Path | Container Path | Purpose |
-|-----------|---------------|---------|
+|-----------|---------------|--------|
 | `config.ini` | `/app/config.ini` | Configuration |
 | `models/` | `/models` | YOLO model files |
 | `output_data/` | `/data` | Logs, images, crops |
@@ -197,13 +197,16 @@ This script syncs the codebase to configured Jetson targets. Each Jetson must re
 
 After configuring a Jetson to a known-good state:
 
-1. Flash and configure JetPack
-2. Run `hydra-setup.sh`
-3. Build the Docker image
-4. Test all subsystems
-5. Clone the microSD card or NVMe with `dd` or Etcher
+1. Update QSPI firmware if needed (see [QSPI Update](setup/jetson-flash.md#step-0-qspi-firmware-update-new-jetsons-only))
+2. Flash and configure JetPack 6.x
+3. Run `hydra-setup.sh`
+4. Build the Docker image
+5. Test all subsystems
+6. Clone the microSD card or NVMe with `dd` or Etcher
 
 Distribute the cloned image to new Jetsons. Only `config.ini` needs per-vehicle customization (callsign, camera source, serial port).
+
+**Important:** New out-of-box Jetsons must have their QSPI firmware updated before they can boot a JetPack 6.x golden image. See the [QSPI update procedure](setup/jetson-flash.md#step-0-qspi-firmware-update-new-jetsons-only) for the one-card pipeline that handles multiple devices efficiently.
 
 ### Factory Reset
 

--- a/docs/setup/jetson-flash.md
+++ b/docs/setup/jetson-flash.md
@@ -17,6 +17,54 @@ Written for students reproducing the Hydra Detect build from scratch.
 - Monitor, keyboard, mouse (for initial setup only)
 - Wi-Fi network (or Ethernet)
 
+## Step 0: QSPI Firmware Update (New Jetsons Only)
+
+New out-of-box Jetson Orin Nanos ship with old QSPI firmware that cannot boot JetPack 6.x. If your Jetson has never been updated, you must update the QSPI first. Jetsons that have already run JetPack 6.x can skip this step.
+
+**How to tell if you need this:** Insert a JetPack 6.x SD card and power on. If the Jetson fails to boot (no NVIDIA logo, no Ubuntu setup), the QSPI needs updating.
+
+### QSPI Update Procedure
+
+1. Download the **JetPack 5.1.3** SD card image from [NVIDIA Jetson Downloads](https://developer.nvidia.com/embedded/downloads). This is the last JetPack version compatible with old QSPI firmware.
+
+2. Flash JetPack 5.1.3 to a microSD card using [Balena Etcher](https://etcher.balena.io/).
+
+3. Insert the JP 5.1.3 card into the Jetson and power on. Walk through the Ubuntu first-boot wizard (language, keyboard, Wi-Fi, user account). Use `sorcc`/`sorcc` for credentials.
+
+4. Open a terminal and install the QSPI updater:
+
+```bash
+sudo apt-get update
+sudo apt-get install nvidia-l4t-jetson-orin-nano-qspi-updater
+```
+
+<Warning>
+The package name uses a lowercase L (`l4t`), not the number one (`14t`). This is a common typo that causes `Unable to locate package` errors.
+</Warning>
+
+5. Reboot:
+
+```bash
+sudo reboot
+```
+
+6. The Jetson flashes the QSPI firmware during boot. When complete, the board **halts** (screen goes blank or shows UEFI). This is expected. Disconnect power.
+
+7. Remove the JP 5.1.3 card. Insert your JetPack 6.x card (or the golden image card). Power on. JetPack 6.x boots normally.
+
+### Reusing One JP 5.1.3 Card for Multiple Jetsons
+
+You can reuse the same JP 5.1.3 SD card across multiple Jetsons. After the first Jetson completes the Ubuntu OOBE wizard, subsequent Jetsons boot directly to the desktop with the same user account. The QSPI updater package is cached in `/var/cache/apt/archives/`, so the `apt install` step is near-instant on devices 2+.
+
+Workflow for multiple devices:
+
+1. Flash one JP 5.1.3 SD card.
+2. Boot Jetson #1, complete OOBE, install QSPI updater, reboot, wait for halt.
+3. Power off. Move the same card to Jetson #2. Boot, open terminal, `apt install` the updater, reboot, halt.
+4. Repeat for remaining Jetsons.
+
+The QSPI update does not modify the SD card. Each new Jetson still has old factory QSPI, so JP 5.1.3 boots on all of them.
+
 <Steps>
 
 <Step title="Flash JetPack to the SD card">

--- a/docs/setup/qspi-update.md
+++ b/docs/setup/qspi-update.md
@@ -1,0 +1,87 @@
+---
+title: "QSPI Firmware Update"
+description: "Update QSPI firmware on new Jetson Orin Nano devices so they can boot JetPack 6.x."
+sidebarTitle: "QSPI update"
+icon: "bolt"
+---
+
+# QSPI Firmware Update — Jetson Orin Nano
+
+New out-of-box Jetson Orin Nanos ship with old QSPI firmware incompatible with JetPack 6.x (L4T R36.x). The QSPI must be updated before the Jetson can boot a JetPack 6 SD card or golden image.
+
+No host PC required. The update runs from a JetPack 5.1.3 SD card booted on the Jetson itself.
+
+## What You Need
+
+- JetPack 5.1.3 SD card image ([download from NVIDIA](https://developer.nvidia.com/embedded/downloads))
+- One microSD card (used temporarily for the update, then reused)
+- Monitor, keyboard for first device only (subsequent devices boot to desktop automatically)
+- Wi-Fi or Ethernet (for the `apt install` on the first device)
+
+## Single Device Procedure
+
+1. Flash JetPack 5.1.3 to a microSD card using Etcher or `dd`.
+2. Insert the card into the Jetson. Connect monitor, keyboard, power.
+3. Complete the Ubuntu first-boot wizard. Use `sorcc`/`sorcc` for credentials.
+4. Open a terminal (`Ctrl+Alt+T`):
+
+```bash
+sudo apt-get update
+sudo apt-get install nvidia-l4t-jetson-orin-nano-qspi-updater
+sudo reboot
+```
+
+<Warning>
+The package name uses lowercase L: `l4t`, not `14t`. Common typo.
+</Warning>
+
+5. The Jetson flashes the QSPI during boot, then **halts** (blank screen or UEFI prompt). This is expected.
+6. Disconnect power. Remove the JP 5.1.3 card. Insert the JetPack 6.x or golden image card. Power on.
+
+## Multi-Device Pipeline (Reuse One Card)
+
+One JP 5.1.3 SD card handles all devices. After the first Jetson completes the Ubuntu OOBE, the card boots directly to the desktop on subsequent Jetsons (same user account, no re-setup). The QSPI updater package is cached after the first download.
+
+### Assembly Line
+
+| Device | Steps | Time |
+|--------|-------|------|
+| Jetson #1 | Boot JP 5.1.3 → OOBE wizard → `apt install` updater → reboot → halt | ~10 min |
+| Jetson #2 | Boot JP 5.1.3 (skips OOBE) → `apt install` updater (cached) → reboot → halt | ~5 min |
+| Jetson #3+ | Same as #2 | ~5 min each |
+
+After QSPI update, swap in the golden image card and boot. Per-device customization: set callsign via the setup wizard at `/setup` or edit `config.ini` directly.
+
+## Verification
+
+After booting JetPack 6.x, confirm the update:
+
+```bash
+cat /etc/nv_tegra_release
+# Expected: R36 (release), REVISION: 4.x
+```
+
+If this shows R36.4.x, the QSPI is current and JetPack 6.x is running.
+
+## Troubleshooting
+
+### `Unable to locate package nvidia-l4t-jetson-orin-nano-qspi-updater`
+
+Check the package name for typos (lowercase L, not number 1). Run `sudo apt-get update` first. Ensure the Jetson has internet access.
+
+### Board does not halt after reboot
+
+If the board reboots back to JP 5.1.3 desktop instead of halting, the QSPI update may not have triggered. Re-run:
+
+```bash
+sudo apt-get install --reinstall nvidia-l4t-jetson-orin-nano-qspi-updater
+sudo reboot
+```
+
+### JetPack 6.x still fails to boot after QSPI update
+
+Re-flash the JetPack 6.x SD card. A corrupted flash is more common than a failed QSPI update. Use Etcher with verify enabled.
+
+---
+
+*Procedure verified for Jetson Orin Nano 8 GB, JetPack 5.1.3 → JetPack 6.2.1, April 2026*


### PR DESCRIPTION
## Summary
- Add QSPI firmware update prerequisite to `docs/setup/jetson-flash.md`
- Update golden image section in `docs/deployment.md` to reference QSPI step
- Add standalone `docs/setup/qspi-update.md` with multi-device pipeline procedure

New out-of-box Jetson Orin Nanos ship with old QSPI firmware that won't boot JetPack 6.x. These docs cover the one-card pipeline for updating multiple devices efficiently.