### PR TITLE
feat(ui): finish 3-page redesign — BEEP / Logout / Open-Vocab Prompts

### DIFF
--- a/hydra_detect/web/static/js/config.js
+++ b/hydra_detect/web/static/js/config.js
@@ -320,6 +320,10 @@ const HydraOperations = (() => {
         });
         addClick('ctrl-alert-apply', () => applyAlertClasses());
 
+        // Open-vocab prompts (YOLO-World / NanoOWL)
+        addClick('ctrl-prompts-apply', () => applyPrompts());
+        loadPrompts();
+
         // RF Hunt
         addChange('ctrl-rf-mode', () => rfModeChanged());
         addClick('ctrl-btn-rf-start', () => rfStart());
@@ -1219,6 +1223,37 @@ const HydraOperations = (() => {
             if (profSel) profSel.value = '';
             const descEl = document.getElementById('ctrl-profile-desc');
             if (descEl) descEl.textContent = '';
+        }
+    }
+
+    async function loadPrompts() {
+        const input = document.getElementById('ctrl-prompts-input');
+        if (!input) return;
+        const cfg = await HydraApp.apiGet('/api/config');
+        if (cfg && Array.isArray(cfg.prompts)) {
+            input.value = cfg.prompts.join(', ');
+        }
+    }
+
+    async function applyPrompts() {
+        const input = document.getElementById('ctrl-prompts-input');
+        if (!input) return;
+        const prompts = input.value
+            .split(',')
+            .map((s) => s.trim())
+            .filter((s) => s.length > 0);
+        if (prompts.length === 0) {
+            HydraApp.showToast('Enter at least one prompt', 'error');
+            return;
+        }
+        if (prompts.length > 20) {
+            HydraApp.showToast('Max 20 prompts allowed', 'error');
+            return;
+        }
+        const result = await HydraApp.apiPost('/api/config/prompts', { prompts: prompts });
+        if (result) {
+            HydraApp.showToast('Prompts updated (' + prompts.length + ')', 'success');
+            input.value = prompts.join(', ');
         }
     }
 

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -1625,6 +1625,16 @@ const HydraOps = (() => {
             });
         }
 
+        // Quick action: Beep — apiPost handles error toasts itself
+        var beepBtn = document.getElementById('ops-btn-beep');
+        if (beepBtn) {
+            beepBtn.addEventListener('click', function () {
+                HydraApp.apiPost('/api/vehicle/beep', { tune: 'alert' }).then(function (r) {
+                    if (r) HydraApp.showToast('Beep sent', 'success');
+                });
+            });
+        }
+
         // Approach: Abort
         var approachAbortBtn = document.getElementById('ops-btn-approach-abort');
         if (approachAbortBtn) {

--- a/hydra_detect/web/static/js/settings.js
+++ b/hydra_detect/web/static/js/settings.js
@@ -212,6 +212,41 @@ const HydraSettings = (() => {
             if (importFile) importFile.click();
         });
         if (importFile) importFile.addEventListener('change', handleImportFile);
+
+        const logoutBtn = document.getElementById('settings-logout');
+        if (logoutBtn) logoutBtn.addEventListener('click', handleLogout);
+        initSessionBlock();
+    }
+
+    async function initSessionBlock() {
+        const block = document.getElementById('settings-session-block');
+        if (!block) return;
+        try {
+            const resp = await fetch('/auth/status', { credentials: 'same-origin' });
+            if (!resp.ok) return;
+            const data = await resp.json();
+            if (data && data.password_enabled) {
+                block.style.display = '';
+            }
+        } catch (err) {
+            // Silent — auth status is optional UX gate
+        }
+    }
+
+    async function handleLogout() {
+        try {
+            const resp = await fetch('/auth/logout', {
+                method: 'POST',
+                credentials: 'same-origin',
+            });
+            if (resp.ok) {
+                window.location.href = '/';
+                return;
+            }
+            HydraApp.showToast('Logout failed (' + resp.status + ')', 'error');
+        } catch (err) {
+            HydraApp.showToast('Logout failed — network error', 'error');
+        }
     }
 
     async function handleRestart() {

--- a/hydra_detect/web/templates/config.html
+++ b/hydra_detect/web/templates/config.html
@@ -228,6 +228,13 @@
                 </div>
                 <div class="panel-alert-class-list" id="ctrl-alert-class-list"></div>
             </div>
+            <div class="panel-field">
+                <label class="panel-field-label" for="ctrl-prompts-input">Open-Vocab Prompts <span class="panel-field-note">(comma-separated; YOLO-World / NanoOWL only, max 20)</span></label>
+                <textarea id="ctrl-prompts-input" rows="2" placeholder="person, truck, weapon"></textarea>
+                <div class="panel-alert-btns">
+                    <button class="btn btn-green btn-sm" id="ctrl-prompts-apply">Apply Prompts</button>
+                </div>
+            </div>
         </div>
     </div>
 

--- a/hydra_detect/web/templates/ops.html
+++ b/hydra_detect/web/templates/ops.html
@@ -134,6 +134,7 @@
                 <button class="btn btn-danger ops-action-btn" id="ops-btn-abort" title="Emergency abort">ABORT</button>
                 <button class="btn ops-action-btn" id="ops-btn-loiter" title="Hold position">LOITER</button>
                 <button class="btn ops-action-btn" id="ops-btn-rtl" title="Return to launch">RTL</button>
+                <button class="btn ops-action-btn" id="ops-btn-beep" title="Play buzzer alert on Pixhawk">BEEP</button>
             </div>
         </div>
 

--- a/hydra_detect/web/templates/settings.html
+++ b/hydra_detect/web/templates/settings.html
@@ -99,6 +99,15 @@
         </div>
     </div>
 
+    <!-- Session — only shown when web password auth is enabled -->
+    <div class="settings-recovery" id="settings-session-block" style="display:none;">
+        <div class="settings-recovery-label mock-section-label">Session</div>
+        <div class="settings-recovery-actions">
+            <button class="btn btn-recovery btn-danger-outline" id="settings-logout"
+                    title="Sign out of this dashboard session">Log Out</button>
+        </div>
+    </div>
+
     <div class="settings-footer" id="settings-power-footer" style="display:none;">
         <span class="settings-footer-link" id="settings-power-user">Power User Options</span>
     </div>


### PR DESCRIPTION
## Summary

Closes the last 3 of 15 features listed in `docs/superpowers/specs/2026-04-02-ui-redesign-3-page.md` ("Unimplemented Features to Surface"). All endpoints already existed; only UI wiring was missing.

| # | Feature | Endpoint | Where |
|---|---------|----------|-------|
| 5 | Buzzer/beep | `POST /api/vehicle/beep` | Ops quick-action bar |
| 8 | Logout | `POST /auth/logout` | Settings (auth-gated via `/auth/status`) |
| 11 | Open-vocab prompts | `POST /api/config/prompts` | Config Detection panel |

Diff: 6 files, +97 lines, no new CSS or dependencies. Reuses existing `.btn`/`.btn-recovery`/`.panel-field` patterns.

## Notes

- Logout block hidden when web password auth is disabled (no dead button on open instances).
- Prompts cap at 20 (matches server `MAX_PROMPTS`); pre-fills from `GET /api/config` runtime config.
- Beep endpoint is un-auth; logout/prompts use same-origin cookie/Bearer per `_check_auth` bypass.
- `placeholder` text uses "person, truck, weapon" — avoids the SORCC vocabulary linter (`vehicle` → `platform`).

## Test plan

- [x] `pytest tests/` — 1542 pass (baseline 1542, same 3 pre-existing failures unrelated)
- [x] `flake8 hydra_detect/ tests/` — no new warnings
- [x] JS unit tests — same 4/13 pass as baseline
- [ ] Live dashboard smoke (Jetson):
  - [ ] Ops → BEEP plays Pixhawk tune (or 503 toast if MAVLink down)
  - [ ] Settings → Log Out only appears when password set; click returns to `/login`
  - [ ] Config → Detection → enter `person, truck, dog` → Apply → success toast; >20 entries → error
