### PR TITLE
fix(tests): realign stale tests + drop unused imports

### DIFF
--- a/tests/test_detection_logger_writer_resilience.py
+++ b/tests/test_detection_logger_writer_resilience.py
@@ -7,8 +7,6 @@ daemon thread silently and the hot path would fill the queue to capacity.
 
 from __future__ import annotations
 
-import queue
-import threading
 import time
 from unittest.mock import patch
 

--- a/tests/test_event_logger_ring_buffer.py
+++ b/tests/test_event_logger_ring_buffer.py
@@ -9,8 +9,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from hydra_detect.event_logger import EventLogger
 
 

--- a/tests/test_ops_layout.py
+++ b/tests/test_ops_layout.py
@@ -69,12 +69,14 @@ class TestNewZoneElements:
 
     def test_cockpit_strip_three_cells(self):
         html = OPS_HTML.read_text()
+        # Cell 2 (TAK) migrated from SVG radar to Leaflet map in 2a8f48f —
+        # `ops-cockpit-tak-map` div is now the render target.
         for needle in (
             'id="ops-cockpit-servo"',
             'id="ops-cockpit-tak"',
             'id="ops-cockpit-sdr"',
             'id="ops-cockpit-servo-svg"',
-            'id="ops-cockpit-tak-svg"',
+            'id="ops-cockpit-tak-map"',
             'id="ops-cockpit-sdr-spectrum"',
             'id="ops-cockpit-sdr-list"',
         ):
@@ -82,9 +84,10 @@ class TestNewZoneElements:
 
     def test_outer_grid_uses_mock_template(self):
         css = OPS_CSS.read_text()
-        # Mock spec verbatim: `auto 1fr 360px` / `1fr 220px`
-        assert "grid-template-columns: auto 1fr 360px" in css
-        assert "grid-template-rows: 1fr 220px" in css
+        # Mock spec after a4effd8 widened bounds with minmax() to stop
+        # the grid blowing out on narrower viewports.
+        assert "grid-template-columns: auto minmax(0, 1fr) minmax(280px, 360px)" in css
+        assert "grid-template-rows: minmax(0, 1fr) 220px" in css
 
 
 # ── (b) ops.js exports updateFlightHud + updateCockpitStrip ──

--- a/tests/test_tak_view.py
+++ b/tests/test_tak_view.py
@@ -48,14 +48,6 @@ class TestTakTabNavigation:
         assert "/static/js/tak.js" in resp.text
         assert "/static/css/tak.css" in resp.text
 
-    def test_tak_placeholder_copy_present(self, client):
-        """M2 stub columns — copy must be visible so Kyle sees B2/B3/B9 state."""
-        resp = client.get("/")
-        assert resp.status_code == 200
-        assert "B2 — not yet built" in resp.text
-        assert "B3 — not yet built" in resp.text
-        assert "B9 — not yet built" in resp.text
-
 
 class TestTakStaticAssets:
     def test_tak_js_served(self, client):


### PR DESCRIPTION
## Summary

Three tests on `main` were out of sync with recent UI work; flake8 was also flagging three unused imports. Clean sweep so the next PR doesn't inherit a red baseline.

### Test realignment
- **`tests/test_tak_view.py::test_tak_placeholder_copy_present`** — dropped. The "B2/B3/B9 — not yet built" placeholder copy was the M2 stub marker; those columns are live now (Type Counts / Peers / Audit) so the stub text is gone from `tak.html`.
- **`tests/test_ops_layout.py::test_cockpit_strip_three_cells`** — commit `2a8f48f` replaced the SVG radar in the Ops cockpit TAK cell with a Leaflet map (`ops-cockpit-tak-svg` → `ops-cockpit-tak-map`). Needle updated.
- **`tests/test_ops_layout.py::test_outer_grid_uses_mock_template`** — commit `a4effd8` widened the grid template with `minmax()` bounds per the Hydrahandoff2 mock update to prevent blowout on narrow viewports. Test still expected the pre-minmax literal. Updated to the responsive values.

### Unused-import cleanup (flake8 F401)
- `tests/test_detection_logger_writer_resilience.py`: `queue`, `threading`
- `tests/test_event_logger_ring_buffer.py`: `pytest`

## Test plan
- [x] `python -m pytest tests/` → 1561 passed, 1 skipped
- [x] `flake8 hydra_detect/ tests/` → clean
- [ ] CI green on this branch

https://claude.ai/code/session_012jpiRFTjubDn5Vd7LuSQmT