### PR TITLE
test: expand coverage on safety-critical paths + wire CI coverage metric

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,28 @@ jobs:
           pip install --no-deps ultralytics supervision
           grep -v "opencv-python\|ultralytics\|supervision" requirements.txt > /tmp/reqs.txt
           pip install -r /tmp/reqs.txt
-          pip install opencv-python-headless httpx pytest flake8 pyyaml
+          pip install opencv-python-headless
+          pip install -r requirements-dev.txt
 
       - name: Lint
         run: |
           make lint
           python scripts/lint_no_duplicate_init_assignments.py hydra_detect/pipeline/facade.py
 
-      - name: Test
-        run: make test
+      - name: Test (with coverage)
+        run: |
+          python -m pytest tests/ -q --tb=short \
+            --ignore=tests/test_integration_wiring.py \
+            -k "not integration and not slow" \
+            --cov=hydra_detect --cov-report=term --cov-report=xml
+
+      - name: Upload coverage XML
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: warn
 
       - name: Comment on PR
         if: always() && github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel in-progress runs on the same ref — claude/** branches fire both
+# `push` AND `pull_request` events which otherwise duplicate (and race)
+# the same job.  Keep the newer run; cancel the older.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,10 @@ certs/
 
 # Local environment (secrets, IPs)
 .env.local
+
+# pytest-cov + hypothesis artifacts
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+.hypothesis/

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,9 @@ SERVICE    ?= hydra-detect
 CONTAINER  ?= hydra-detect
 SMOKE_HOST ?= http://127.0.0.1:8080
 
-# Quick subset: skip the slow integration wiring + explicit "integration" names.
+# Quick subset: skip the slow integration wiring + explicit "integration"/"slow" names.
 FAST_IGNORES := --ignore=tests/test_integration_wiring.py
-FAST_KEXPR   := -k "not integration"
+FAST_KEXPR   := -k "not integration and not slow"
 
 # Endpoints probed by `make smoke`. Format: <path>:<json-key-to-grep>.
 # Only object-returning GET routes (array responses like /api/tracks have no
@@ -34,12 +34,13 @@ SMOKE_PROBES := \
   /api/config/full:camera \
   /api/stream/quality:quality
 
-.PHONY: help test test-all lint build up logs shell clean smoke dev dev-down
+.PHONY: help test test-all test-cov lint build up logs shell clean smoke dev dev-down
 
 help:
 	@echo "Hydra Detect — make targets"
-	@echo "  test      Fast pytest subset (skips integration-wiring)"
+	@echo "  test      Fast pytest subset (skips integration-wiring + slow)"
 	@echo "  test-all  Full pytest suite (verbose)"
+	@echo "  test-cov  Fast subset with coverage report on hydra_detect/"
 	@echo "  lint      flake8 on hydra_detect/ + tests/ (+ mypy if installed)"
 	@echo "  build     docker build -t $(IMAGE) ."
 	@echo "  up        sudo systemctl restart $(SERVICE)"
@@ -55,6 +56,10 @@ test:
 
 test-all:
 	$(PYTEST) tests/ -v
+
+test-cov:
+	$(PYTEST) tests/ -q --tb=short $(FAST_IGNORES) $(FAST_KEXPR) \
+	  --cov=hydra_detect --cov-report=term-missing --cov-report=xml
 
 lint:
 	$(FLAKE8) hydra_detect/ tests/ --count --show-source --statistics

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
 markers =
     hardware: tests requiring Jetson/Pixhawk/camera hardware (deselected by default)
+    slow: long-running tests (concurrency stress, fuzz tables) — deselected by default fast suite
+    regression: tests pinning a specific past defect (use test name/docstring to reference the bug)
 addopts = -m "not hardware"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+pytest>=7.4,<9.0
+pytest-cov>=4.1,<7.0
+hypothesis>=6.90,<7.0
+flake8>=6.0,<8.0
+httpx>=0.24,<1.0
+pyyaml>=6.0,<7.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,57 @@
+# Hydra Detect — Test Conventions
+
+## Running
+
+```bash
+make test           # fast subset (CI default — skips hardware, integration, slow)
+make test-all       # full suite including hardware-marked tests
+make test-cov       # fast subset with coverage report on hydra_detect/
+python -m pytest tests/test_approach.py -v   # single file
+```
+
+## Markers
+
+| Marker | Purpose | Default |
+|---|---|---|
+| `@pytest.mark.hardware` | Requires Jetson/Pixhawk/camera | Deselected |
+| `@pytest.mark.slow` | Long-running (concurrency stress, full fuzz table) | Deselected in `make test` |
+| `@pytest.mark.regression` | Pins a specific past defect | Run with the suite; searchable |
+
+## House style (don't invent new conventions)
+
+- **Mocking:** `unittest.mock.MagicMock` only — no `pytest-mock`.
+- **No root `conftest.py`:** fixtures live in-module as `_make_*()` helpers or autouse state resets.
+- **MAVLink:** see `tests/test_mavlink_commands.py::_make_mavlink_io()`.
+- **ApproachController:** see `tests/test_drop_strike.py::_make_controller()`.
+- **FastAPI:** `TestClient(app)` with `_reset_state` autouse — see `tests/test_web_api.py` top.
+- **Real config objects:** pass actual dataclasses (`ApproachConfig`, `GuidanceConfig`); mock only hardware boundaries.
+
+## Regression discipline
+
+When a bug is fixed, add a test. Two options, pick whichever fits:
+
+1. **Inline**: add a `test_regression_<short_name>` method in the relevant test class with `@pytest.mark.regression`. Include the commit SHA or issue number in the docstring.
+2. **Standalone**: `tests/test_regression_<bug_slug>.py` for cross-cutting bugs that don't map cleanly to one module.
+
+Example:
+
+```python
+@pytest.mark.regression
+def test_regression_abort_restores_pre_approach_mode(self):
+    """Fixed: abort used to hardcode LOITER instead of restoring captured mode.
+    See commit a1b2c3d."""
+    ...
+```
+
+## Coverage
+
+CI runs `pytest --cov=hydra_detect --cov-report=xml` and uploads `coverage.xml`
+as an artifact. No `--cov-fail-under` floor is enforced yet — we're in
+baseline-collection mode. To inspect local coverage:
+
+```bash
+make test-cov
+```
+
+Raise failing module coverage by adding targeted tests rather than fighting the
+threshold.

--- a/tests/test_approach.py
+++ b/tests/test_approach.py
@@ -1,0 +1,313 @@
+"""Tests for Follow and Pixel-Lock approach modes.
+
+Sister file to ``test_drop_strike.py`` which covers Drop and Strike.  Shares
+the same ``_make_controller`` / ``_make_track`` helper pattern.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from hydra_detect.approach import ApproachConfig, ApproachController, ApproachMode
+from hydra_detect.guidance import GuidanceConfig
+
+
+# ---------------------------------------------------------------------------
+# Helpers (copied from test_drop_strike.py — house style, no shared conftest)
+# ---------------------------------------------------------------------------
+
+def _make_mavlink():
+    mav = MagicMock()
+    mav.get_vehicle_mode.return_value = "AUTO"
+    mav.get_lat_lon.return_value = (34.05, -118.25, 50.0)
+    mav.estimate_target_position.return_value = (34.051, -118.251)
+    mav.command_guided_to.return_value = True
+    mav.command_do_change_speed.return_value = True
+    mav.send_velocity_ned.return_value = True
+    mav.get_rc_channels.return_value = [1500] * 16
+    mav.set_mode.return_value = True
+    return mav
+
+
+def _make_track(x1=100, y1=100, x2=200, y2=200, track_id=1):
+    t = MagicMock()
+    t.x1, t.y1, t.x2, t.y2 = x1, y1, x2, y2
+    t.track_id = track_id
+    return t
+
+
+def _make_controller(mavlink=None, guidance_cfg=None, **kw):
+    mav = mavlink or _make_mavlink()
+    defaults = dict(
+        follow_speed_min=2.0,
+        follow_speed_max=10.0,
+        follow_distance_m=15.0,
+        camera_hfov_deg=60.0,
+        waypoint_interval=0.0,  # disable rate limit by default
+        guidance_cfg=guidance_cfg or GuidanceConfig(min_altitude_m=5.0),
+    )
+    defaults.update(kw)
+    cfg = ApproachConfig(**defaults)
+    return ApproachController(mav, cfg), mav
+
+
+# ---------------------------------------------------------------------------
+# Follow — start
+# ---------------------------------------------------------------------------
+
+class TestFollowStart:
+    def test_start_follow_sets_mode(self):
+        ctrl, mav = _make_controller()
+        assert ctrl.start_follow(42) is True
+        assert ctrl.mode == ApproachMode.FOLLOW
+        assert ctrl.target_track_id == 42
+
+    def test_start_follow_captures_pre_approach_mode(self):
+        ctrl, mav = _make_controller()
+        mav.get_vehicle_mode.return_value = "GUIDED"
+        ctrl.start_follow(1)
+        ctrl.abort()
+        # Abort should restore the captured mode, not the generic abort fallback
+        mav.set_mode.assert_called_with("GUIDED")
+
+    def test_start_follow_rejects_when_active(self):
+        ctrl, _ = _make_controller()
+        ctrl.start_follow(1)
+        assert ctrl.start_follow(2) is False
+        assert ctrl.target_track_id == 1
+
+    def test_start_follow_initializes_counters(self):
+        ctrl, _ = _make_controller()
+        ctrl.start_follow(1)
+        assert ctrl.get_status()["waypoints_sent"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Follow — update
+# ---------------------------------------------------------------------------
+
+class TestFollowUpdate:
+    def test_update_sends_waypoint_and_speed(self):
+        ctrl, mav = _make_controller()
+        ctrl.start_follow(1)
+        mav.command_guided_to.reset_mock()
+        mav.command_do_change_speed.reset_mock()
+
+        track = _make_track(x1=310, y1=200, x2=330, y2=280)  # near centre
+        ctrl.update(track, 640, 480)
+
+        mav.estimate_target_position.assert_called_once()
+        mav.command_guided_to.assert_called_once_with(34.051, -118.251)
+        mav.command_do_change_speed.assert_called_once()
+
+    def test_update_none_track_holds_position(self):
+        ctrl, mav = _make_controller()
+        ctrl.start_follow(1)
+        mav.command_guided_to.reset_mock()
+        ctrl.update(None, 640, 480)
+        mav.command_guided_to.assert_not_called()
+
+    def test_waypoint_interval_rate_limit(self):
+        """Two rapid calls within the interval should send only one waypoint."""
+        ctrl, mav = _make_controller(waypoint_interval=1.0)
+        ctrl.start_follow(1)
+        track = _make_track()
+        ctrl.update(track, 640, 480)
+        call_count_1 = mav.command_guided_to.call_count
+        # Immediate second call — inside the 1s window
+        ctrl.update(track, 640, 480)
+        assert mav.command_guided_to.call_count == call_count_1
+
+    def test_speed_scales_with_centering(self):
+        """A centred target commands higher speed than an off-centre one."""
+        ctrl, mav = _make_controller(
+            follow_speed_min=2.0, follow_speed_max=10.0,
+        )
+        ctrl.start_follow(1)
+
+        # Centred: speed should approach max
+        centred = _make_track(x1=315, y1=200, x2=325, y2=280)
+        ctrl.update(centred, 640, 480)
+        centred_speed = mav.command_do_change_speed.call_args[0][0]
+
+        # Reset rate-limit (waypoint_interval=0 already, but _last_wp_time=now;
+        # force it to 0 so the next update passes the check)
+        ctrl._last_wp_time = 0.0
+        mav.command_do_change_speed.reset_mock()
+
+        # Off-centre: speed should drop toward min
+        off_centre = _make_track(x1=10, y1=200, x2=30, y2=280)
+        ctrl.update(off_centre, 640, 480)
+        off_centre_speed = mav.command_do_change_speed.call_args[0][0]
+
+        assert centred_speed > off_centre_speed
+        assert 2.0 <= off_centre_speed < 10.0
+        assert 2.0 < centred_speed <= 10.0
+
+    def test_estimate_target_returns_none_skips_waypoint(self):
+        ctrl, mav = _make_controller()
+        ctrl.start_follow(1)
+        mav.estimate_target_position.return_value = None
+        mav.command_guided_to.reset_mock()
+
+        ctrl.update(_make_track(), 640, 480)
+        mav.command_guided_to.assert_not_called()
+
+    def test_guided_to_exception_swallowed(self):
+        """Follow must not crash the hot loop if MAVLink raises."""
+        ctrl, mav = _make_controller()
+        ctrl.start_follow(1)
+        mav.command_guided_to.side_effect = RuntimeError("link down")
+        # Should not raise
+        ctrl.update(_make_track(), 640, 480)
+        assert ctrl.mode == ApproachMode.FOLLOW  # still active
+
+
+# ---------------------------------------------------------------------------
+# Pixel-Lock — start
+# ---------------------------------------------------------------------------
+
+class TestPixelLockStart:
+    def test_start_pixel_lock_switches_to_guided(self):
+        ctrl, mav = _make_controller()
+        assert ctrl.start_pixel_lock(1) is True
+        mav.set_mode.assert_any_call("GUIDED")
+        assert ctrl.mode == ApproachMode.PIXEL_LOCK
+
+    def test_guided_mode_failure_aborts_start(self):
+        """Safety invariant: must not enter PIXEL_LOCK if GUIDED switch fails."""
+        ctrl, mav = _make_controller()
+        mav.set_mode.return_value = False
+        assert ctrl.start_pixel_lock(1) is False
+        assert ctrl.mode == ApproachMode.IDLE
+
+    def test_guided_mode_exception_aborts_start(self):
+        ctrl, mav = _make_controller()
+        mav.set_mode.side_effect = RuntimeError("mavlink down")
+        assert ctrl.start_pixel_lock(1) is False
+        assert ctrl.mode == ApproachMode.IDLE
+
+    def test_start_pixel_lock_rejects_when_active(self):
+        ctrl, _ = _make_controller()
+        ctrl.start_follow(1)
+        assert ctrl.start_pixel_lock(2) is False
+
+
+# ---------------------------------------------------------------------------
+# Pixel-Lock — update
+# ---------------------------------------------------------------------------
+
+class TestPixelLockUpdate:
+    def test_update_sends_velocity_ned(self):
+        ctrl, mav = _make_controller()
+        ctrl.start_pixel_lock(1)
+        mav.send_velocity_ned.reset_mock()
+
+        track = _make_track(x1=200, y1=150, x2=400, y2=300)
+        ctrl.update(track, 640, 480)
+
+        mav.send_velocity_ned.assert_called_once()
+        args = mav.send_velocity_ned.call_args[0]
+        assert len(args) == 4  # vx, vy, vz, yaw_rate
+
+    def test_min_altitude_clamps_descent(self):
+        """Regression: descending velocity must be zeroed when at/below min altitude."""
+        guidance_cfg = GuidanceConfig(
+            min_altitude_m=10.0,
+            max_vert_speed=2.0,
+            vert_gain=5.0,
+        )
+        ctrl, mav = _make_controller(guidance_cfg=guidance_cfg)
+        # Vehicle at the minimum altitude
+        mav.get_lat_lon.return_value = (34.05, -118.25, 10.0)
+        ctrl.start_pixel_lock(1)
+        mav.send_velocity_ned.reset_mock()
+
+        # Target BELOW centre → ey > 0 → vz > 0 (descend in NED)
+        below = _make_track(x1=300, y1=400, x2=340, y2=470)
+        ctrl.update(below, 640, 480)
+
+        vx, vy, vz, yaw = mav.send_velocity_ned.call_args[0]
+        assert vz == 0.0, "Descent must be clamped at min altitude"
+
+    def test_min_altitude_allows_climb(self):
+        guidance_cfg = GuidanceConfig(
+            min_altitude_m=10.0,
+            max_vert_speed=2.0,
+            vert_gain=5.0,
+        )
+        ctrl, mav = _make_controller(guidance_cfg=guidance_cfg)
+        mav.get_lat_lon.return_value = (34.05, -118.25, 10.0)
+        ctrl.start_pixel_lock(1)
+        mav.send_velocity_ned.reset_mock()
+
+        # Target ABOVE centre → ey < 0 → vz < 0 (climb) — should NOT be clamped
+        above = _make_track(x1=300, y1=20, x2=340, y2=100)
+        ctrl.update(above, 640, 480)
+        vx, vy, vz, yaw = mav.send_velocity_ned.call_args[0]
+        assert vz <= 0.0, "Climb should be preserved even near min altitude"
+
+    def test_track_lost_beyond_timeout_aborts(self):
+        guidance_cfg = GuidanceConfig(lost_track_timeout_s=0.01)
+        ctrl, mav = _make_controller(guidance_cfg=guidance_cfg)
+        ctrl.start_pixel_lock(1)
+        # Simulate lost track past the timeout
+        time.sleep(0.05)
+        ctrl.update(None, 640, 480)
+        assert ctrl.mode == ApproachMode.IDLE
+
+    def test_update_none_track_within_timeout_sends_zero_vel(self):
+        guidance_cfg = GuidanceConfig(lost_track_timeout_s=10.0)
+        ctrl, mav = _make_controller(guidance_cfg=guidance_cfg)
+        ctrl.start_pixel_lock(1)
+        mav.send_velocity_ned.reset_mock()
+
+        ctrl.update(None, 640, 480)
+        # Still active, zero-velocity brake
+        assert ctrl.mode == ApproachMode.PIXEL_LOCK
+        mav.send_velocity_ned.assert_called_once_with(0.0, 0.0, 0.0, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# Abort from Follow / Pixel-Lock
+# ---------------------------------------------------------------------------
+
+class TestAbort:
+    @pytest.mark.regression
+    def test_regression_abort_restores_pre_approach_mode(self):
+        """Abort must restore the captured pre-approach mode, not LOITER.
+
+        Prior bug: ``abort()`` hard-coded ``set_mode("LOITER")`` instead of the
+        vehicle's pre-approach mode. A student aborting mid-AUTO mission would
+        land in LOITER unexpectedly.
+        """
+        ctrl, mav = _make_controller()
+        mav.get_vehicle_mode.return_value = "AUTO"
+        ctrl.start_follow(1)
+        ctrl.abort()
+        mav.set_mode.assert_called_with("AUTO")
+
+    def test_abort_from_pixel_lock_brakes_and_restores(self):
+        ctrl, mav = _make_controller()
+        ctrl.start_pixel_lock(1)
+        mav.send_velocity_ned.reset_mock()
+        mav.set_mode.reset_mock()
+
+        ctrl.abort()
+
+        # Zero velocity brake
+        mav.send_velocity_ned.assert_called_with(0, 0, 0, 0)
+        # Mode restored
+        mav.set_mode.assert_called()
+        assert ctrl.mode == ApproachMode.IDLE
+
+    def test_abort_from_pixel_lock_tolerates_brake_failure(self):
+        ctrl, mav = _make_controller()
+        ctrl.start_pixel_lock(1)
+        mav.send_velocity_ned.side_effect = RuntimeError("link down")
+        # Must not raise — abort is a safety path
+        ctrl.abort()
+        assert ctrl.mode == ApproachMode.IDLE

--- a/tests/test_concurrency_stress.py
+++ b/tests/test_concurrency_stress.py
@@ -1,0 +1,197 @@
+"""Concurrency stress tests for shared-state components.
+
+Marked ``@pytest.mark.slow`` so they're deselected by default (``make test``).
+Run explicitly with ``pytest tests/test_concurrency_stress.py``.
+
+These tests exercise thread-safety invariants rather than specific interleavings.
+Contention patterns differ between dev laptops and CI's 2-core GitHub runners;
+we assert what MUST hold (consistency, bounded wall-clock) rather than precise
+ordering.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from hydra_detect.approach import ApproachConfig, ApproachController, ApproachMode
+from hydra_detect.mavlink_io import MAVLinkIO
+
+
+pytestmark = pytest.mark.slow
+
+
+def _make_mavlink():
+    mav = MagicMock()
+    mav.get_vehicle_mode.return_value = "AUTO"
+    mav.get_lat_lon.return_value = (34.05, -118.25, 50.0)
+    mav.estimate_target_position.return_value = (34.051, -118.251)
+    mav.command_guided_to.return_value = True
+    mav.send_velocity_ned.return_value = True
+    mav.command_do_change_speed.return_value = True
+    mav.set_mode.return_value = True
+    mav.get_rc_channels.return_value = [1500] * 16
+    return mav
+
+
+def _make_controller():
+    cfg = ApproachConfig(waypoint_interval=0.0)
+    return ApproachController(_make_mavlink(), cfg)
+
+
+class TestApproachControllerStress:
+    def test_concurrent_start_abort_leaves_consistent_state(self):
+        """8 threads × N iterations of start_follow + abort — controller must
+        never end in a mode other than IDLE after a final abort, and the
+        final target_track_id must agree with the final mode."""
+        ctrl = _make_controller()
+
+        errors: list[Exception] = []
+        stop = threading.Event()
+
+        def hammer_start_abort():
+            try:
+                while not stop.is_set():
+                    ctrl.start_follow(1)
+                    ctrl.abort()
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=hammer_start_abort) for _ in range(8)]
+        for t in threads:
+            t.start()
+        time.sleep(0.2)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5.0)
+            assert not t.is_alive(), "thread failed to join — possible deadlock"
+
+        # Final explicit abort
+        ctrl.abort()
+        assert ctrl.mode == ApproachMode.IDLE
+        assert ctrl.target_track_id is None
+        assert not errors, f"unhandled exceptions: {errors}"
+
+    def test_competing_mode_starts_only_one_wins(self):
+        """Two threads racing to start different modes — exactly one must succeed
+        (since the controller serializes via ``_lock`` inside start_*)."""
+        ctrl = _make_controller()
+        results: list[bool] = []
+        barrier = threading.Barrier(2)
+
+        def try_follow():
+            barrier.wait()
+            results.append(ctrl.start_follow(1))
+
+        def try_drop():
+            barrier.wait()
+            results.append(ctrl.start_drop(2, 34.0, -118.0))
+
+        t1 = threading.Thread(target=try_follow)
+        t2 = threading.Thread(target=try_drop)
+        t1.start()
+        t2.start()
+        t1.join(timeout=2.0)
+        t2.join(timeout=2.0)
+
+        # Exactly one True, one False
+        assert results.count(True) == 1
+        assert results.count(False) == 1
+        assert ctrl.mode in (ApproachMode.FOLLOW, ApproachMode.DROP)
+
+
+class TestMavlinkSendLockStress:
+    def test_concurrent_send_raw_message_serializes(self):
+        """4 threads sending raw messages in a tight loop.  The send lock in
+        ``send_raw_message`` must serialize calls to the underlying transport
+        so we never get concurrent send() invocations (which would corrupt
+        pymavlink's encoder state)."""
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        mav._mav = MagicMock()
+        mav._mav.mav = MagicMock()
+
+        # Instrument send() to detect overlapping calls
+        in_flight = [0]
+        max_in_flight = [0]
+        instrumentation_lock = threading.Lock()
+
+        def instrumented_send(*args, **kw):
+            with instrumentation_lock:
+                in_flight[0] += 1
+                max_in_flight[0] = max(max_in_flight[0], in_flight[0])
+            time.sleep(0.0005)  # force overlap window
+            with instrumentation_lock:
+                in_flight[0] -= 1
+
+        mav._mav.mav.send.side_effect = instrumented_send
+
+        errors: list[Exception] = []
+        stop = threading.Event()
+
+        def hammer():
+            try:
+                while not stop.is_set():
+                    mav.send_raw_message(MagicMock())
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=hammer) for _ in range(4)]
+        for t in threads:
+            t.start()
+        time.sleep(0.2)
+        stop.set()
+        for t in threads:
+            t.join(timeout=5.0)
+
+        assert max_in_flight[0] == 1, (
+            f"send() was called concurrently (max_in_flight={max_in_flight[0]}); "
+            "send lock is not serializing"
+        )
+        assert not errors
+
+
+class TestApproachAbortRaceRegression:
+    @pytest.mark.regression
+    def test_abort_while_update_in_flight_does_not_deadlock(self):
+        """update() acquires the lock briefly to read mode, releases it, then
+        dispatches. abort() running in parallel must not deadlock against update()."""
+        ctrl = _make_controller()
+        ctrl.start_follow(1)
+
+        errors: list[Exception] = []
+        stop = threading.Event()
+
+        def hammer_update():
+            track = MagicMock()
+            track.x1, track.y1, track.x2, track.y2 = 100, 100, 200, 200
+            track.track_id = 1
+            try:
+                while not stop.is_set():
+                    ctrl.update(track, 640, 480)
+            except Exception as e:
+                errors.append(e)
+
+        def hammer_abort():
+            try:
+                while not stop.is_set():
+                    ctrl.abort()
+                    ctrl.start_follow(1)
+            except Exception as e:
+                errors.append(e)
+
+        t_update = threading.Thread(target=hammer_update)
+        t_abort = threading.Thread(target=hammer_abort)
+        t_update.start()
+        t_abort.start()
+        time.sleep(0.2)
+        stop.set()
+
+        # Both threads must exit within the join window — otherwise deadlock
+        t_update.join(timeout=5.0)
+        t_abort.join(timeout=5.0)
+        assert not t_update.is_alive()
+        assert not t_abort.is_alive()
+        assert not errors

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -477,3 +477,102 @@ class TestFallbackAlignment:
             "Pipeline fallback / schema default mismatches:\n"
             + "\n".join(mismatches)
         )
+
+
+# ---------------------------------------------------------------------------
+# Property-based tests via hypothesis
+# ---------------------------------------------------------------------------
+
+from hypothesis import HealthCheck, given, settings, strategies as st  # noqa: E402
+
+
+# Deterministic + fast settings so CI doesn't flake / slow.  30 examples is
+# plenty for these simple coercion properties; each case is <1ms.
+_hyp = settings(
+    max_examples=30,
+    deadline=1000,
+    derandomize=True,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+
+
+class TestPropertyBased:
+    """Strategy-driven sweeps across coercion / range / enum rules."""
+
+    @given(conf=st.floats(min_value=0.0, max_value=1.0, allow_nan=False,
+                          allow_infinity=False))
+    @_hyp
+    def test_yolo_confidence_in_range_validates(self, conf):
+        cfg = _valid_config()
+        cfg.set("detector", "yolo_confidence", str(conf))
+        result = validate_config(cfg)
+        assert not any("yolo_confidence" in e for e in result.errors), (
+            f"conf={conf} should be valid but errors={result.errors}"
+        )
+
+    @given(conf=st.floats(min_value=1.01, max_value=1e6, allow_nan=False,
+                          allow_infinity=False))
+    @_hyp
+    def test_yolo_confidence_above_range_fails(self, conf):
+        cfg = _valid_config()
+        cfg.set("detector", "yolo_confidence", str(conf))
+        result = validate_config(cfg)
+        assert any("yolo_confidence" in e for e in result.errors)
+
+    @given(conf=st.floats(min_value=-1e6, max_value=-0.01, allow_nan=False,
+                          allow_infinity=False))
+    @_hyp
+    def test_yolo_confidence_negative_fails(self, conf):
+        cfg = _valid_config()
+        cfg.set("detector", "yolo_confidence", str(conf))
+        result = validate_config(cfg)
+        assert any("yolo_confidence" in e for e in result.errors)
+
+    @given(val=st.sampled_from([
+        "true", "True", "TRUE", "1", "yes", "on", "Yes", "ON",
+        "false", "False", "FALSE", "0", "no", "off", "No", "OFF",
+    ]))
+    @_hyp
+    def test_bool_variants_all_valid(self, val):
+        cfg = _valid_config()
+        cfg.set("mavlink", "enabled", val)
+        result = validate_config(cfg)
+        assert not any(
+            "enabled" in e and "true or false" in e for e in result.errors
+        ), f"bool '{val}' should be valid"
+
+    @given(val=st.text(min_size=1, max_size=20).filter(
+        lambda s: s.lower() not in (
+            "true", "false", "yes", "no", "1", "0", "on", "off",
+        ) and s.strip() != ""
+    ))
+    @_hyp
+    def test_arbitrary_strings_reject_as_bool(self, val):
+        cfg = _valid_config()
+        cfg.set("mavlink", "enabled", val)
+        result = validate_config(cfg)
+        assert any(
+            "enabled" in e and "true or false" in e for e in result.errors
+        ), f"'{val}' should fail bool validation"
+
+    @given(src=st.sampled_from(["auto", "usb", "rtsp", "file", "v4l2", "analog"]))
+    @_hyp
+    def test_source_type_enum_valid(self, src):
+        cfg = _valid_config()
+        cfg.set("camera", "source_type", src)
+        result = validate_config(cfg)
+        assert not any("source_type" in e for e in result.errors)
+
+    @given(src=st.text(min_size=1, max_size=20).filter(
+        lambda s: s.lower() not in (
+            "auto", "usb", "rtsp", "file", "v4l2", "analog",
+        )
+    ))
+    @_hyp
+    def test_source_type_enum_invalid_strings_rejected(self, src):
+        cfg = _valid_config()
+        cfg.set("camera", "source_type", src)
+        result = validate_config(cfg)
+        assert any("source_type" in e for e in result.errors), (
+            f"'{src}' should be rejected as invalid source_type"
+        )

--- a/tests/test_dogleg_rtl.py
+++ b/tests/test_dogleg_rtl.py
@@ -1,0 +1,182 @@
+"""Tests for DoglegRTL — tactical return path that obscures the launch point.
+
+Today this module only has one test (``test_dogleg_rtl_only_for_drone`` in
+``test_mission_profiles.py``) which just validates profile filtering.  Here we
+cover the geometry helper (``compute_dogleg_waypoint``), the phase lifecycle,
+the background thread, and the fallback path on MAVLink errors.
+
+The execute() thread has 25s + 60s polling windows.  We patch
+``hydra_detect.dogleg_rtl.time.sleep`` to a no-op so the thread runs at wall
+speed and tests finish in <1s.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hydra_detect.dogleg_rtl import DoglegRTL, compute_dogleg_waypoint
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mavlink(lat=34.05, lon=-118.25, alt=10.0):
+    mav = MagicMock()
+    mav.get_lat_lon.return_value = (lat, lon, alt)
+    mav.command_guided_to.return_value = True
+    mav.set_mode.return_value = True
+    return mav
+
+
+def _wait_for_phase(dogleg: DoglegRTL, target: str, timeout: float = 3.0) -> bool:
+    """Poll ``dogleg.phase`` until it matches ``target`` or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if dogleg.phase == target:
+            return True
+        time.sleep(0.01)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# compute_dogleg_waypoint
+# ---------------------------------------------------------------------------
+
+class TestComputeDoglegWaypoint:
+    def test_perpendicular_offset_is_orthogonal_to_bearing_home(self):
+        """Offset waypoint should be displaced east/west of a north-south midline."""
+        current = (34.10, -118.20)
+        home = (34.05, -118.20)  # due south of current
+
+        wp_lat, wp_lon = compute_dogleg_waypoint(
+            current[0], current[1], home[0], home[1],
+            offset_distance_m=500.0,
+            offset_bearing="perpendicular",
+        )
+        mid_lon = (current[1] + home[1]) / 2
+        assert abs(wp_lon - mid_lon) > 0.001, "expected east/west displacement"
+
+    def test_explicit_numeric_bearing(self):
+        wp_lat, wp_lon = compute_dogleg_waypoint(
+            34.10, -118.20, 34.05, -118.20,
+            offset_distance_m=200.0,
+            offset_bearing="90",  # pure east
+        )
+        mid_lat = (34.10 + 34.05) / 2
+        assert abs(wp_lat - mid_lat) < 0.001
+
+    def test_invalid_bearing_falls_back_to_perpendicular(self):
+        wp = compute_dogleg_waypoint(
+            34.10, -118.20, 34.05, -118.20,
+            offset_distance_m=200.0,
+            offset_bearing="garbage",
+        )
+        assert isinstance(wp, tuple) and len(wp) == 2
+        assert all(isinstance(x, float) for x in wp)
+
+    def test_offset_distance_scales_linearly(self):
+        current, home = (34.10, -118.20), (34.05, -118.20)
+        wp_100 = compute_dogleg_waypoint(*current, *home, 100.0, "perpendicular")
+        wp_500 = compute_dogleg_waypoint(*current, *home, 500.0, "perpendicular")
+
+        mid = ((current[0] + home[0]) / 2, (current[1] + home[1]) / 2)
+        d100 = math.hypot(wp_100[0] - mid[0], wp_100[1] - mid[1])
+        d500 = math.hypot(wp_500[0] - mid[0], wp_500[1] - mid[1])
+        assert 4.0 < d500 / d100 < 6.0
+
+
+# ---------------------------------------------------------------------------
+# DoglegRTL.execute — thread lifecycle
+# ---------------------------------------------------------------------------
+
+class TestExecute:
+    def test_no_gps_returns_false(self):
+        mav = _make_mavlink()
+        mav.get_lat_lon.return_value = (None, None, None)
+        dog = DoglegRTL(mav, 34.0, -118.0)
+        assert dog.execute() is False
+
+    def test_initial_phase_is_idle(self):
+        mav = _make_mavlink()
+        dog = DoglegRTL(mav, 34.0, -118.0)
+        assert dog.phase == "idle"
+
+    def test_execute_starts_background_thread(self):
+        mav = _make_mavlink()
+        dog = DoglegRTL(mav, 34.0, -118.0, climb_altitude_m=0.0)
+        with patch("hydra_detect.dogleg_rtl.time.sleep", return_value=None):
+            assert dog.execute() is True
+            assert _wait_for_phase(dog, "done", timeout=3.0)
+
+    def test_phase_progression_to_home(self):
+        """With sleep patched and vehicle "at" the waypoint, phase reaches home → done."""
+        mav = _make_mavlink()
+        # Place vehicle near where the waypoint will compute (same current position)
+        # so haversine_m returns 0 and the polling loop breaks immediately
+        dog = DoglegRTL(
+            mav, 34.0, -118.0,
+            offset_distance_m=0.1,   # tiny offset so waypoint ≈ midpoint ≈ current
+            climb_altitude_m=0.0,
+        )
+        with patch("hydra_detect.dogleg_rtl.time.sleep", return_value=None):
+            dog.execute()
+            assert _wait_for_phase(dog, "done", timeout=3.0)
+        mav.set_mode.assert_any_call("SMART_RTL")
+
+    @pytest.mark.regression
+    def test_fallback_to_rtl_on_exception(self):
+        """If SMART_RTL command raises, the exception handler must try RTL."""
+        mav = _make_mavlink()
+        call_log = []
+
+        def fake_set_mode(mode):
+            call_log.append(mode)
+            if mode == "SMART_RTL":
+                raise RuntimeError("link down")
+            return True
+
+        mav.set_mode.side_effect = fake_set_mode
+        dog = DoglegRTL(
+            mav, 34.0, -118.0,
+            offset_distance_m=0.1,
+            climb_altitude_m=0.0,
+        )
+        with patch("hydra_detect.dogleg_rtl.time.sleep", return_value=None):
+            dog.execute()
+            assert _wait_for_phase(dog, "done", timeout=3.0)
+        assert "SMART_RTL" in call_log
+        assert "RTL" in call_log, "fallback RTL must be attempted after SMART_RTL fails"
+
+    def test_climb_phase_commands_waypoint_with_alt(self):
+        """When climb_altitude_m > 0, execute must issue a climb waypoint with alt=."""
+        mav = _make_mavlink(alt=5.0)
+        # Vehicle jumps to target altitude immediately so the climb poll exits
+        climb_log = []
+
+        def fake_get_lat_lon():
+            return (34.05, -118.25, 100.0)
+
+        mav.get_lat_lon.side_effect = fake_get_lat_lon
+
+        def fake_guided(*args, **kw):
+            climb_log.append((args, kw))
+            return True
+
+        mav.command_guided_to.side_effect = fake_guided
+        dog = DoglegRTL(
+            mav, 34.0, -118.0,
+            offset_distance_m=0.1,
+            climb_altitude_m=50.0,
+        )
+        with patch("hydra_detect.dogleg_rtl.time.sleep", return_value=None):
+            dog.execute()
+            assert _wait_for_phase(dog, "done", timeout=3.0)
+        # First command_guided_to should be the climb (alt kwarg set)
+        assert any("alt" in kw and kw["alt"] == 50.0 for _, kw in climb_log), (
+            f"expected climb waypoint with alt=50.0 in {climb_log}"
+        )

--- a/tests/test_mavlink_commands.py
+++ b/tests/test_mavlink_commands.py
@@ -246,3 +246,158 @@ class TestVehicleMode:
 
         mav._update_vehicle_mode(heartbeat)
         assert mav.get_vehicle_mode() is None
+
+
+# ---------------------------------------------------------------------------
+# Outbound command helpers — send_velocity_ned, command_guided_to,
+# estimate_target_position, set_servo, flash_servo, send_raw_message
+# ---------------------------------------------------------------------------
+
+class TestSendVelocityNed:
+    def test_sends_set_position_target_local_ned(self):
+        mav = _make_mavlink_io()
+        mav._mav.target_system = 1
+        mav._mav.target_component = 1
+
+        ok = mav.send_velocity_ned(1.0, 0.5, 0.2, 15.0)
+        assert ok is True
+        mav._mav.mav.set_position_target_local_ned_send.assert_called_once()
+        args = mav._mav.mav.set_position_target_local_ned_send.call_args[0]
+        # (time_boot_ms, tgt_sys, tgt_comp, frame, type_mask,
+        #  x, y, z, vx, vy, vz, afx, afy, afz, yaw, yaw_rate)
+        assert args[8] == 1.0  # vx
+        assert args[9] == 0.5  # vy
+        assert args[10] == 0.2  # vz
+
+    def test_returns_false_when_disconnected(self):
+        mav = _make_mavlink_io()
+        mav._mav = None
+        assert mav.send_velocity_ned(1.0, 0.0, 0.0, 0.0) is False
+
+    def test_exception_swallowed(self):
+        mav = _make_mavlink_io()
+        mav._mav.mav.set_position_target_local_ned_send.side_effect = RuntimeError("x")
+        assert mav.send_velocity_ned(1.0, 0.0, 0.0, 0.0) is False
+
+
+class TestCommandGuidedTo:
+    def test_returns_false_when_disconnected(self):
+        mav = _make_mavlink_io()
+        mav._mav = None
+        assert mav.command_guided_to(34.0, -118.0, alt=50.0) is False
+
+    def test_returns_false_when_guided_not_in_mode_map(self):
+        mav = _make_mavlink_io()
+        mav._mav.mode_mapping.return_value = {"LOITER": 5}
+        assert mav.command_guided_to(34.0, -118.0, alt=50.0) is False
+
+    def test_alt_none_without_gps_returns_false(self):
+        mav = _make_mavlink_io()
+        mav._mav.mode_mapping.return_value = {"GUIDED": 4}
+        # No GPS fix cached
+        mav._last_global_position = None
+        assert mav.command_guided_to(34.0, -118.0) is False
+
+    def test_happy_path_with_explicit_alt(self):
+        mav = _make_mavlink_io()
+        mav._mav.mode_mapping.return_value = {"GUIDED": 4}
+        mav._mav.target_system = 1
+        mav._mav.target_component = 1
+        assert mav.command_guided_to(34.0, -118.0, alt=50.0) is True
+        mav._mav.set_mode_apm.assert_called_with(4)
+        mav._mav.mav.set_position_target_global_int_send.assert_called_once()
+
+
+class TestEstimateTargetPosition:
+    def test_returns_none_without_gps(self):
+        mav = _make_mavlink_io()
+        mav._last_global_position = None
+        mav._last_vfr_hud = None
+        assert mav.estimate_target_position(0.0, 20.0, 60.0) is None
+
+    def test_projects_waypoint(self):
+        mav = _make_mavlink_io()
+        # Stub get_lat_lon and get_heading_deg to known values
+        mav.get_lat_lon = MagicMock(return_value=(34.05, -118.25, 100.0))
+        mav.get_heading_deg = MagicMock(return_value=0.0)  # facing north
+        # Target at image centre (error_x=0) → waypoint should be directly north
+        result = mav.estimate_target_position(0.0, 100.0, 60.0)
+        assert result is not None
+        tlat, tlon = result
+        assert tlat > 34.05  # north of current
+        assert abs(tlon - (-118.25)) < 1e-4  # same longitude (facing due north)
+
+
+class TestSetServo:
+    def test_clamps_pwm_range(self):
+        mav = _make_mavlink_io()
+        mav._mav.target_system = 1
+        mav._mav.target_component = 1
+        mav.set_servo(6, 5000)  # > 2500 → clamp to 2500
+        args = mav._mav.mav.command_long_send.call_args[0]
+        # args: (tgt_sys, tgt_comp, cmd, confirmation, p1=channel, p2=pwm, ...)
+        assert args[5] == 2500
+
+    def test_disconnected_noop(self):
+        mav = _make_mavlink_io()
+        mav._mav = None
+        # Should not raise
+        mav.set_servo(6, 1500)
+
+    def test_exception_swallowed(self):
+        mav = _make_mavlink_io()
+        mav._mav.mav.command_long_send.side_effect = RuntimeError("x")
+        # Should not raise
+        mav.set_servo(6, 1500)
+
+
+class TestCommandDoChangeSpeed:
+    def test_clamps_speed(self):
+        mav = _make_mavlink_io()
+        mav._mav.target_system = 1
+        mav._mav.target_component = 1
+        mav.command_do_change_speed(999.0)
+        args = mav._mav.mav.command_long_send.call_args[0]
+        # p2 is speed
+        assert args[5] <= 100.0
+
+    def test_disconnected_returns_false(self):
+        mav = _make_mavlink_io()
+        mav._mav = None
+        assert mav.command_do_change_speed(5.0) is False
+
+
+class TestSendRawMessage:
+    def test_send_disconnected(self):
+        mav = _make_mavlink_io()
+        mav._mav = None
+        assert mav.send_raw_message(MagicMock()) is False
+
+    def test_send_happy_path(self):
+        mav = _make_mavlink_io()
+        assert mav.send_raw_message(MagicMock()) is True
+        mav._mav.mav.send.assert_called_once()
+
+    def test_send_exception_returns_false(self):
+        mav = _make_mavlink_io()
+        mav._mav.mav.send.side_effect = RuntimeError("broken pipe")
+        assert mav.send_raw_message(MagicMock()) is False
+
+
+class TestSendParamSet:
+    def test_disconnected_returns_false(self):
+        mav = _make_mavlink_io()
+        mav._mav = None
+        assert mav.send_param_set("SR0_RAW_SENS", 2.0) is False
+
+    def test_happy_path(self):
+        mav = _make_mavlink_io()
+        mav._mav.target_system = 1
+        mav._mav.target_component = 1
+        assert mav.send_param_set("SR0_RAW_SENS", 2.0) is True
+        mav._mav.mav.param_set_send.assert_called_once()
+
+    def test_exception_returns_false(self):
+        mav = _make_mavlink_io()
+        mav._mav.mav.param_set_send.side_effect = RuntimeError("x")
+        assert mav.send_param_set("FOO", 1.0) is False

--- a/tests/test_msp_displayport.py
+++ b/tests/test_msp_displayport.py
@@ -1,0 +1,125 @@
+"""Tests for MSP v1 DisplayPort protocol (HDZero OSD driver).
+
+Covers the pure frame-builders against known byte sequences.  We do NOT
+exercise the serial thread — that requires real hardware and adds flakiness.
+"""
+
+from __future__ import annotations
+
+from hydra_detect.msp_displayport import (
+    DEFAULT_CANVAS_COLS,
+    DEFAULT_CANVAS_ROWS,
+    MspOsdData,
+    _msp_frame,
+    clear_frame,
+    draw_frame,
+    heartbeat_frame,
+    write_string_frame,
+)
+
+
+# ---------------------------------------------------------------------------
+# Low-level frame builder
+# ---------------------------------------------------------------------------
+
+class TestMspFrame:
+    def test_frame_structure(self):
+        """Frame = $M< + size + cmd + payload + xor_checksum."""
+        frame = _msp_frame(182, b"\x01\x02\x03")
+        assert frame[:3] == b"$M<"
+        assert frame[3] == 3       # size
+        assert frame[4] == 182     # command
+        assert frame[5:8] == b"\x01\x02\x03"
+        expected_xor = 3 ^ 182 ^ 1 ^ 2 ^ 3
+        assert frame[8] == expected_xor
+
+    def test_empty_payload(self):
+        frame = _msp_frame(100, b"")
+        assert len(frame) == 6  # 3 header + size + cmd + cksum
+        # Checksum = 0 ^ 100 = 100
+        assert frame[5] == 100
+
+    def test_checksum_masks_to_byte(self):
+        """Checksum is &= 0xFF — large XOR must fit in one byte."""
+        frame = _msp_frame(255, bytes([0xFF] * 10))
+        assert 0 <= frame[-1] <= 255
+
+
+# ---------------------------------------------------------------------------
+# High-level frame builders
+# ---------------------------------------------------------------------------
+
+class TestHeartbeat:
+    def test_heartbeat_default_canvas(self):
+        f = heartbeat_frame()
+        # Payload: [sub=0, rows, cols, 0, 0]
+        assert f[5] == 0  # DP_SUB_HEARTBEAT
+        assert f[6] == DEFAULT_CANVAS_ROWS
+        assert f[7] == DEFAULT_CANVAS_COLS
+
+    def test_heartbeat_custom_canvas(self):
+        f = heartbeat_frame(rows=16, cols=30)
+        assert f[6] == 16
+        assert f[7] == 30
+
+
+class TestClear:
+    def test_clear_frame_is_single_sub_command(self):
+        f = clear_frame()
+        # Header(3) + size(1=1) + cmd(182) + sub(2) + cksum
+        assert f[:3] == b"$M<"
+        assert f[3] == 1
+        assert f[4] == 182
+        assert f[5] == 2  # DP_SUB_CLEAR
+
+
+class TestWriteString:
+    def test_write_ascii_text(self):
+        f = write_string_frame(5, 10, "ABC")
+        # payload = [sub=3, row=5, col=10, attr=0, 'A', 'B', 'C']
+        assert f[5] == 3
+        assert f[6] == 5
+        assert f[7] == 10
+        assert f[8] == 0  # attr
+        assert f[9:12] == b"ABC"
+
+    def test_write_non_ascii_replaced(self):
+        f = write_string_frame(0, 0, "héllo")  # é will become '?'
+        # Should not raise, and length is preserved
+        size = f[3]
+        # payload = [sub, row, col, attr] + "h?llo" = 4 + 5 = 9
+        assert size == 9
+
+    def test_attr_byte(self):
+        f = write_string_frame(0, 0, "X", attr=7)
+        assert f[8] == 7
+
+
+class TestDraw:
+    def test_draw_frame_structure(self):
+        f = draw_frame()
+        assert f[:3] == b"$M<"
+        assert f[3] == 1  # size
+        assert f[5] == 4  # DP_SUB_DRAW
+
+
+# ---------------------------------------------------------------------------
+# MspOsdData dataclass
+# ---------------------------------------------------------------------------
+
+class TestMspOsdData:
+    def test_defaults(self):
+        d = MspOsdData()
+        assert d.fps == 0.0
+        assert d.active_tracks == 0
+        assert d.locked_track_id is None
+        assert d.lock_mode is None
+
+    def test_assignable(self):
+        d = MspOsdData(
+            fps=15.5, inference_ms=20.0, active_tracks=3,
+            locked_track_id=42, lock_mode="strike",
+            latest_det_label="person", latest_det_conf=0.87,
+        )
+        assert d.lock_mode == "strike"
+        assert d.latest_det_conf == 0.87

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -1,0 +1,100 @@
+"""Tests for overlay.py — bounding-box drawing, label clamping, strike blinking.
+
+CLAUDE.md calls out bbox coordinate clamping as a known prior bug source
+(negative coords / over-frame dimensions crash OpenCV).  These tests pin that
+behavior.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from hydra_detect.overlay import draw_tracks
+from hydra_detect.tracker import TrackedObject, TrackingResult
+
+
+def _frame(h=480, w=640):
+    return np.zeros((h, w, 3), dtype=np.uint8)
+
+
+def _tracking(*tracks) -> TrackingResult:
+    return TrackingResult(tracks=list(tracks), active_ids=len(tracks))
+
+
+def _track(track_id=1, x1=100.0, y1=100.0, x2=200.0, y2=200.0, label="person"):
+    return TrackedObject(
+        track_id=track_id, x1=x1, y1=y1, x2=x2, y2=y2,
+        confidence=0.9, class_id=0, label=label,
+    )
+
+
+class TestBoundsClamping:
+    def test_negative_coords_do_not_crash(self):
+        frame = _frame()
+        tr = _tracking(_track(x1=-50.0, y1=-50.0, x2=100.0, y2=100.0))
+        # Should not raise — clamping required for OpenCV safety
+        out = draw_tracks(frame, tr)
+        assert out is frame  # in-place
+
+    def test_over_frame_coords_do_not_crash(self):
+        frame = _frame(h=480, w=640)
+        tr = _tracking(_track(x1=600.0, y1=450.0, x2=700.0, y2=550.0))
+        draw_tracks(frame, tr)
+
+    def test_degenerate_box_skipped(self):
+        """x2 <= x1 (fully off-frame) must be skipped silently."""
+        frame = _frame()
+        tr = _tracking(_track(x1=-100.0, y1=-100.0, x2=-50.0, y2=-50.0))
+        draw_tracks(frame, tr)  # no crash
+
+
+class TestLockModes:
+    def test_locked_track_drawn(self):
+        frame = _frame()
+        tr = _tracking(_track(track_id=42))
+        out = draw_tracks(frame, tr, locked_track_id=42, lock_mode="track")
+        # Some non-zero pixels should have been drawn
+        assert out.sum() > 0
+
+    def test_strike_mode_draws_red(self):
+        frame = _frame()
+        tr = _tracking(_track(track_id=7))
+        draw_tracks(frame, tr, locked_track_id=7, lock_mode="strike")
+        # BGR red channel has activity
+        assert frame[:, :, 2].sum() > 0
+
+    def test_hud_always_drawn(self):
+        frame = _frame()
+        tr = _tracking()
+        draw_tracks(frame, tr, fps=30.0, inference_ms=15.0)
+        # HUD text area in top-left should have some non-zero pixels
+        assert frame[:50, :200].sum() > 0
+
+
+class TestAlertClassDimming:
+    def test_matching_label_drawn_full_opacity(self):
+        frame = _frame()
+        tr = _tracking(_track(label="person"))
+        draw_tracks(frame, tr, alert_classes={"person"})
+        assert frame.sum() > 0
+
+    def test_non_matching_label_dimmed(self):
+        full = _frame()
+        dim = _frame()
+        tr = _tracking(_track(label="dog"))
+        draw_tracks(full, tr, alert_classes=None)
+        draw_tracks(dim, tr, alert_classes={"person"})  # dog not in alert list
+        # Dimmed version should have a lower max pixel value
+        assert dim.max() <= full.max()
+
+    def test_locked_overrides_dimming(self):
+        """A locked track must render at full opacity even when dimmed."""
+        frame = _frame()
+        tr = _tracking(_track(track_id=5, label="dog"))
+        draw_tracks(
+            frame, tr,
+            locked_track_id=5, lock_mode="track",
+            alert_classes={"person"},
+        )
+        # Locked should produce strong signal despite being non-alert class
+        assert frame.sum() > 0

--- a/tests/test_pipeline_callbacks.py
+++ b/tests/test_pipeline_callbacks.py
@@ -489,3 +489,140 @@ class TestProfileSwitch:
         p._active_profile = "some-profile"
         p._handle_alert_classes_change(["person"])
         assert p._active_profile is None
+
+
+# ---------------------------------------------------------------------------
+# Approach-mode handlers (drop, follow, pixel_lock, strike, abort)
+# ---------------------------------------------------------------------------
+
+from hydra_detect.approach import ApproachMode  # noqa: E402
+
+
+def _pipeline_with_approach(track_id: int = 3, mode=ApproachMode.IDLE) -> Pipeline:
+    """Build a pipeline with a mocked approach controller + mavlink + one track."""
+    p = _make_pipeline()
+    p._mavlink = MagicMock()
+    p._mavlink.estimate_target_position.return_value = (34.05, -118.25)
+    p._mavlink.command_guided_to.return_value = True
+    p._approach = MagicMock()
+    p._approach.mode = mode
+    p._approach.start_drop.return_value = True
+    p._approach.start_follow.return_value = True
+    p._approach.start_strike.return_value = True
+    p._approach.start_pixel_lock.return_value = True
+    p._camera.source_type = "digital"
+    p._drop_distance_m = 3.0
+    p._last_track_result = _sample_track(track_id=track_id)
+    return p
+
+
+class TestDropCommand:
+    def test_drop_happy_path(self):
+        p = _pipeline_with_approach(track_id=3)
+        assert p._handle_drop_command(3) is True
+        p._approach.start_drop.assert_called_once_with(3, 34.05, -118.25)
+        assert p._locked_track_id == 3
+        assert p._lock_mode == "drop"
+
+    def test_drop_no_approach_controller(self):
+        p = _make_pipeline()
+        p._approach = None
+        assert p._handle_drop_command(3) is False
+
+    def test_drop_already_active_rejected(self):
+        p = _pipeline_with_approach(mode=ApproachMode.FOLLOW)
+        assert p._handle_drop_command(3) is False
+        p._approach.start_drop.assert_not_called()
+
+    def test_drop_no_track(self):
+        p = _pipeline_with_approach()
+        p._last_track_result = None
+        assert p._handle_drop_command(3) is False
+
+    def test_drop_track_not_found(self):
+        p = _pipeline_with_approach(track_id=3)
+        assert p._handle_drop_command(999) is False
+
+    def test_drop_no_gps_rollback(self):
+        p = _pipeline_with_approach(track_id=3)
+        p._mavlink.estimate_target_position.return_value = None
+        assert p._handle_drop_command(3) is False
+        assert p._locked_track_id is None
+
+    def test_drop_start_failure_rolls_back_lock(self):
+        p = _pipeline_with_approach(track_id=3)
+        p._approach.start_drop.return_value = False
+        assert p._handle_drop_command(3) is False
+        assert p._locked_track_id is None
+
+
+class TestFollowCommand:
+    def test_follow_happy_path(self):
+        p = _pipeline_with_approach(track_id=3)
+        assert p._handle_follow_command(3) is True
+        p._approach.start_follow.assert_called_once_with(3)
+        assert p._lock_mode == "follow"
+
+    def test_follow_no_approach_controller(self):
+        p = _make_pipeline()
+        p._approach = None
+        assert p._handle_follow_command(3) is False
+
+    def test_follow_already_active(self):
+        p = _pipeline_with_approach(mode=ApproachMode.DROP)
+        assert p._handle_follow_command(3) is False
+
+    def test_follow_track_not_found(self):
+        p = _pipeline_with_approach(track_id=3)
+        assert p._handle_follow_command(999) is False
+
+    def test_follow_start_failure_rolls_back_lock(self):
+        p = _pipeline_with_approach(track_id=3)
+        p._approach.start_follow.return_value = False
+        assert p._handle_follow_command(3) is False
+        assert p._locked_track_id is None
+
+
+class TestPixelLockCommand:
+    def test_pixel_lock_happy_path(self):
+        p = _pipeline_with_approach(track_id=3)
+        assert p._handle_pixel_lock_command(3) is True
+        p._approach.start_pixel_lock.assert_called_once_with(3)
+        assert p._lock_mode == "pixel_lock"
+
+    def test_pixel_lock_already_active(self):
+        p = _pipeline_with_approach(mode=ApproachMode.FOLLOW)
+        assert p._handle_pixel_lock_command(3) is False
+
+    def test_pixel_lock_start_failure_rolls_back(self):
+        p = _pipeline_with_approach(track_id=3)
+        p._approach.start_pixel_lock.return_value = False
+        assert p._handle_pixel_lock_command(3) is False
+        assert p._locked_track_id is None
+
+    def test_pixel_lock_event_logged(self):
+        p = _pipeline_with_approach(track_id=3)
+        p._handle_pixel_lock_command(3)
+        p._event_logger.log_action.assert_any_call(
+            "pixel_lock", {"track_id": 3, "label": "person"},
+        )
+
+
+class TestApproachAbort:
+    def test_abort_calls_controller_and_unlocks(self):
+        p = _pipeline_with_approach(track_id=3, mode=ApproachMode.FOLLOW)
+        p._locked_track_id = 3
+        p._lock_mode = "follow"
+        p._handle_approach_abort()
+        # abort() may be invoked via both the explicit call and the unlock path
+        assert p._approach.abort.called
+        assert p._locked_track_id is None
+
+    def test_abort_no_controller_still_unlocks(self):
+        p = _make_pipeline()
+        p._approach = None
+        p._locked_track_id = 3
+        p._lock_mode = "follow"
+        # Should not raise
+        p._handle_approach_abort()
+        assert p._locked_track_id is None

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,155 @@
+"""Tests for system.py — Jetson/Linux hardware introspection helpers.
+
+Real hardware calls (``nvpmodel``, ``/sys/devices/platform/gpu.0/load``) are
+mocked.  Tests that require a real Jetson are marked ``@pytest.mark.hardware``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hydra_detect import system
+
+
+# ---------------------------------------------------------------------------
+# query_nvpmodel_sync
+# ---------------------------------------------------------------------------
+
+class TestQueryNvpmodel:
+    def test_sync_parses_output(self):
+        fake = MagicMock(stdout="NV Power Mode: MAXN\n", stderr="", returncode=0)
+        with patch("hydra_detect.system.subprocess.run", return_value=fake):
+            assert system.query_nvpmodel_sync() == "MAXN"
+
+    def test_sync_returns_none_on_missing_binary(self):
+        with patch(
+            "hydra_detect.system.subprocess.run",
+            side_effect=FileNotFoundError(),
+        ):
+            assert system.query_nvpmodel_sync() is None
+
+    def test_sync_returns_none_on_timeout(self):
+        with patch(
+            "hydra_detect.system.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="nvpmodel", timeout=2),
+        ):
+            assert system.query_nvpmodel_sync() is None
+
+
+# ---------------------------------------------------------------------------
+# list_power_modes
+# ---------------------------------------------------------------------------
+
+class TestListPowerModes:
+    def test_parses_verbose_output(self):
+        out = (
+            "NVPM VERB: POWER_MODEL: ID=0 NAME=15W\n"
+            "NVPM VERB: POWER_MODEL: ID=1 NAME=7W\n"
+            "NVPM VERB: POWER_MODEL: ID=2 NAME=MAXN\n"
+        )
+        fake = MagicMock(stdout="", stderr=out, returncode=0)
+        with patch("hydra_detect.system.subprocess.run", return_value=fake):
+            modes = system.list_power_modes()
+        assert {"id": 0, "name": "15W"} in modes
+        assert {"id": 2, "name": "MAXN"} in modes
+        assert len(modes) == 3
+
+    def test_missing_binary_returns_empty(self):
+        with patch(
+            "hydra_detect.system.subprocess.run",
+            side_effect=FileNotFoundError(),
+        ):
+            assert system.list_power_modes() == []
+
+
+# ---------------------------------------------------------------------------
+# set_power_mode
+# ---------------------------------------------------------------------------
+
+class TestSetPowerMode:
+    def test_success(self):
+        ok = MagicMock(returncode=0, stdout="", stderr="")
+
+        def fake_run(argv, *a, **kw):
+            assert argv[0] in ("nvpmodel", "jetson_clocks")
+            return ok
+
+        with patch("hydra_detect.system.subprocess.run", side_effect=fake_run):
+            r = system.set_power_mode(0)
+        assert r["status"] == "ok"
+        assert any("Power mode" in a for a in r["actions"])
+
+    def test_nvpmodel_failure(self):
+        bad = MagicMock(returncode=1, stdout="", stderr="bad mode")
+        with patch("hydra_detect.system.subprocess.run", return_value=bad):
+            r = system.set_power_mode(99)
+        assert r["status"] == "error"
+        assert "bad mode" in r["error"]
+
+    def test_missing_binary(self):
+        with patch(
+            "hydra_detect.system.subprocess.run",
+            side_effect=FileNotFoundError("nvpmodel"),
+        ):
+            r = system.set_power_mode(0)
+        assert r["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# list_models
+# ---------------------------------------------------------------------------
+
+class TestListModels:
+    def test_discovers_model_files(self, tmp_path):
+        (tmp_path / "yolov8n.pt").write_bytes(b"0" * (1024 * 1024))
+        (tmp_path / "yolov8s.engine").write_bytes(b"0" * (2 * 1024 * 1024))
+        (tmp_path / "readme.txt").write_text("ignored")
+
+        models = system.list_models(str(tmp_path))
+        names = {m["name"] for m in models}
+        assert "yolov8n.pt" in names
+        assert "yolov8s.engine" in names
+        assert "readme.txt" not in names
+
+    def test_deduplicates_by_name(self, tmp_path):
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        dir_a.mkdir()
+        dir_b.mkdir()
+        (dir_a / "model.pt").write_bytes(b"first")
+        (dir_b / "model.pt").write_bytes(b"second")
+
+        models = system.list_models(str(dir_a), str(dir_b))
+        assert len(models) == 1
+        # First directory wins
+        assert models[0]["path"].startswith(str(dir_a))
+
+    def test_missing_directory_skipped(self):
+        assert system.list_models("/does/not/exist") == []
+
+    def test_reports_size_mb(self, tmp_path):
+        (tmp_path / "big.pt").write_bytes(b"0" * (5 * 1024 * 1024))
+        models = system.list_models(str(tmp_path))
+        assert models[0]["size_mb"] == pytest.approx(5.0, abs=0.1)
+
+
+# ---------------------------------------------------------------------------
+# read_thermal — sysfs access
+# ---------------------------------------------------------------------------
+
+class TestReadThermal:
+    def test_parses_sysfs_temp(self):
+        mock_path = MagicMock()
+        mock_path.read_text.return_value = "45678\n"
+        with patch("hydra_detect.system.Path", return_value=mock_path):
+            t = system.read_thermal("1")
+        assert t == pytest.approx(45.7, abs=0.1)
+
+    def test_missing_zone_returns_none(self):
+        mock_path = MagicMock()
+        mock_path.read_text.side_effect = FileNotFoundError()
+        with patch("hydra_detect.system.Path", return_value=mock_path):
+            assert system.read_thermal("99") is None

--- a/tests/test_tls.py
+++ b/tests/test_tls.py
@@ -1,0 +1,54 @@
+"""Tests for tls.py — self-signed certificate generation."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from hydra_detect.tls import ensure_tls_cert
+
+
+class TestEnsureTlsCert:
+    def test_skips_when_both_files_exist(self, tmp_path):
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        cert.write_text("existing cert")
+        key.write_text("existing key")
+
+        with patch("hydra_detect.tls.subprocess.run") as mock_run:
+            assert ensure_tls_cert(str(cert), str(key)) is True
+            mock_run.assert_not_called()
+
+    def test_generates_when_missing(self, tmp_path):
+        cert = tmp_path / "certs" / "cert.pem"
+        key = tmp_path / "certs" / "key.pem"
+        with patch("hydra_detect.tls.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            assert ensure_tls_cert(str(cert), str(key)) is True
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0][0]
+            assert args[0] == "openssl"
+            assert "-x509" in args
+
+    def test_openssl_not_installed(self, tmp_path):
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        with patch(
+            "hydra_detect.tls.subprocess.run",
+            side_effect=FileNotFoundError("no openssl"),
+        ):
+            assert ensure_tls_cert(str(cert), str(key)) is False
+
+    def test_openssl_failure(self, tmp_path):
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        err = subprocess.CalledProcessError(1, "openssl", stderr=b"oops")
+        with patch("hydra_detect.tls.subprocess.run", side_effect=err):
+            assert ensure_tls_cert(str(cert), str(key)) is False
+
+    def test_timeout(self, tmp_path):
+        cert = tmp_path / "cert.pem"
+        key = tmp_path / "key.pem"
+        err = subprocess.TimeoutExpired(cmd="openssl", timeout=30)
+        with patch("hydra_detect.tls.subprocess.run", side_effect=err):
+            assert ensure_tls_cert(str(cert), str(key)) is False

--- a/tests/test_verify_log.py
+++ b/tests/test_verify_log.py
@@ -1,0 +1,113 @@
+"""Tests for verify_log — SHA-256 chain integrity validator.
+
+Security-relevant: this is the tamper-detection mechanism for detection logs.
+Zero test coverage before this file.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from hydra_detect.verify_log import verify
+
+
+GENESIS = "0" * 64
+
+
+def _append_record(path: Path, prev_hash: str, payload: dict) -> str:
+    """Append a record + chain_hash to the file, return the new chain hash."""
+    record_json = json.dumps(payload, sort_keys=True)
+    chain_hash = hashlib.sha256((record_json + prev_hash).encode()).hexdigest()
+    record = dict(payload)
+    record["chain_hash"] = chain_hash
+    with open(path, "a") as f:
+        f.write(json.dumps(record) + "\n")
+    return chain_hash
+
+
+class TestVerify:
+    def test_missing_file_returns_false(self, tmp_path):
+        ok, count, msg = verify(tmp_path / "nope.jsonl")
+        assert ok is False
+        assert count == 0
+        assert "not found" in msg.lower()
+
+    def test_empty_file_is_valid(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        p.write_text("")
+        ok, count, msg = verify(p)
+        assert ok is True
+        assert count == 0
+
+    def test_valid_chain_verifies(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        h = GENESIS
+        h = _append_record(p, h, {"t": 1, "label": "person"})
+        h = _append_record(p, h, {"t": 2, "label": "car"})
+        h = _append_record(p, h, {"t": 3, "label": "truck"})
+
+        ok, count, msg = verify(p)
+        assert ok is True
+        assert count == 3
+        assert "3 records verified" in msg
+
+    def test_broken_chain_detected(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        h = GENESIS
+        h = _append_record(p, h, {"t": 1, "label": "person"})
+        # Now corrupt the chain by appending with the WRONG prev hash
+        bad_record = {"t": 2, "label": "car"}
+        bad_hash = hashlib.sha256(
+            (json.dumps(bad_record, sort_keys=True) + "deadbeef" * 8).encode()
+        ).hexdigest()
+        bad_record["chain_hash"] = bad_hash
+        with open(p, "a") as f:
+            f.write(json.dumps(bad_record) + "\n")
+
+        ok, count, msg = verify(p)
+        assert ok is False
+        assert count == 2
+        assert "chain broken" in msg
+
+    def test_missing_chain_hash_field(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        p.write_text(json.dumps({"t": 1, "label": "person"}) + "\n")
+        ok, count, msg = verify(p)
+        assert ok is False
+        assert "missing chain_hash" in msg
+
+    def test_truncated_final_record_tolerated(self, tmp_path):
+        """A partially-written final line (incomplete JSON) is skipped, not failed."""
+        p = tmp_path / "log.jsonl"
+        h = GENESIS
+        _append_record(p, h, {"t": 1, "label": "person"})
+        # Append garbage (simulating power loss mid-write)
+        with open(p, "a") as f:
+            f.write('{"t": 2, "label": "car", "chain_hash": "af')
+
+        ok, count, msg = verify(p)
+        assert ok is True
+        assert count == 1
+        assert "truncated" in msg
+
+    def test_invalid_json_midfile_fails(self, tmp_path):
+        """JSON errors mid-file (not just final line) must fail hard."""
+        p = tmp_path / "log.jsonl"
+        h = GENESIS
+        _append_record(p, h, {"t": 1, "label": "person"})
+        with open(p, "a") as f:
+            f.write("garbage not json\n")
+        # Still add a valid-looking final record so the garbage isn't "truncated"
+        _append_record(p, GENESIS, {"t": 3, "label": "truck"})
+
+        ok, count, msg = verify(p)
+        assert ok is False
+        assert "invalid JSON" in msg
+
+    def test_accepts_path_as_string(self, tmp_path):
+        p = tmp_path / "log.jsonl"
+        _append_record(p, GENESIS, {"t": 1, "label": "person"})
+        ok, _, _ = verify(str(p))
+        assert ok is True

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -964,3 +964,250 @@ class TestResponseCaching:
         resp = client.get("/api/tracks")
         assert resp.status_code == 200
         assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# Malformed-JSON fuzz table — every POST endpoint should return 400 (not 500)
+# on bad input.  Auth must be disabled so the body actually gets parsed.
+# ---------------------------------------------------------------------------
+
+_POST_ENDPOINTS_TAKING_JSON = [
+    # (path, sample_body_or_none_for_skip)
+    "/api/config/prompts",
+    "/api/config/threshold",
+    "/api/config/alert-classes",
+    "/api/target/lock",
+    "/api/target/strike",
+    "/api/vehicle/mode",
+    "/api/rtsp/toggle",
+    "/api/mavlink-video/toggle",
+    "/api/mavlink-video/tune",
+    "/api/profiles/switch",
+    "/api/rf/start",
+    "/api/approach/drop/5",
+    "/api/approach/strike/5",
+    "/api/stream/quality",
+]
+
+
+class TestMalformedJsonFuzz:
+    """Every POST endpoint accepting a body must return 400 (not 500) on junk input."""
+
+    @pytest.mark.parametrize("path", _POST_ENDPOINTS_TAKING_JSON)
+    def test_malformed_json_returns_400(self, client, path):
+        resp = client.post(
+            path,
+            content=b"{not valid json",
+            headers={"Content-Type": "application/json"},
+        )
+        # 400 (malformed body) or 413 (oversize); never a 500
+        assert resp.status_code < 500, (
+            f"{path} returned {resp.status_code} on malformed JSON"
+        )
+
+    @pytest.mark.parametrize("path", _POST_ENDPOINTS_TAKING_JSON)
+    def test_non_utf8_body_does_not_500(self, client, path):
+        resp = client.post(
+            path,
+            content=b"\xff\xfe\x00invalid-utf8",
+            headers={"Content-Type": "application/json"},
+        )
+        assert resp.status_code < 500
+
+    @pytest.mark.parametrize("path", _POST_ENDPOINTS_TAKING_JSON)
+    def test_empty_body_does_not_500(self, client, path):
+        resp = client.post(path, content=b"", headers={"Content-Type": "application/json"})
+        assert resp.status_code < 500
+
+
+# ---------------------------------------------------------------------------
+# /auth/login rate-limiting
+# ---------------------------------------------------------------------------
+
+class TestAuthLoginRateLimit:
+    def test_login_succeeds_with_correct_password(self, client):
+        configure_web_password("good-pw")
+        resp = client.post("/auth/login", json={"password": "good-pw"})
+        assert resp.status_code == 200
+
+    def test_login_rejects_wrong_password(self, client):
+        configure_web_password("good-pw")
+        resp = client.post("/auth/login", json={"password": "wrong"})
+        assert resp.status_code == 401
+
+    def test_login_missing_password_returns_400(self, client):
+        configure_web_password("good-pw")
+        resp = client.post("/auth/login", json={})
+        assert resp.status_code == 400
+
+    def test_rate_limit_after_50_failures(self, client):
+        """51st consecutive wrong-password attempt must return 429."""
+        from hydra_detect.web.server import _AUTH_FAIL_MAX
+        configure_web_password("good-pw")
+        # Fire _AUTH_FAIL_MAX bad attempts
+        for _ in range(_AUTH_FAIL_MAX):
+            resp = client.post("/auth/login", json={"password": "wrong"})
+            assert resp.status_code == 401
+        # Next attempt — even with correct password — must be 429
+        resp = client.post("/auth/login", json={"password": "good-pw"})
+        assert resp.status_code == 429
+
+
+# ---------------------------------------------------------------------------
+# Approach-mode endpoints (follow / drop / strike / pixel_lock / abort)
+# ---------------------------------------------------------------------------
+
+class TestApproachEndpoints:
+    def test_approach_status_no_callback(self, client):
+        resp = client.get("/api/approach/status")
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "idle"
+
+    def test_approach_status_with_callback(self, client):
+        stream_state.set_callbacks(
+            get_approach_status=lambda: {"mode": "follow", "active": True},
+        )
+        resp = client.get("/api/approach/status")
+        assert resp.json() == {"mode": "follow", "active": True}
+
+    def test_follow_unavailable_when_no_callback(self, client):
+        resp = client.post("/api/approach/follow/5")
+        assert resp.status_code == 503
+
+    def test_follow_success(self, client):
+        stream_state.set_callbacks(on_follow_command=lambda tid: True)
+        resp = client.post("/api/approach/follow/5")
+        assert resp.status_code == 200
+        assert resp.json()["track_id"] == 5
+        assert resp.json()["mode"] == "follow"
+
+    def test_follow_failure(self, client):
+        stream_state.set_callbacks(on_follow_command=lambda tid: False)
+        resp = client.post("/api/approach/follow/5")
+        assert resp.status_code == 503
+
+    def test_drop_requires_confirm(self, client):
+        stream_state.set_callbacks(on_drop_command=lambda tid: True)
+        # Missing confirm
+        resp = client.post("/api/approach/drop/5", json={})
+        assert resp.status_code == 400
+        # confirm=false
+        resp = client.post("/api/approach/drop/5", json={"confirm": False})
+        assert resp.status_code == 400
+
+    def test_drop_happy_path(self, client):
+        stream_state.set_callbacks(on_drop_command=lambda tid: True)
+        resp = client.post("/api/approach/drop/5", json={"confirm": True})
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "drop"
+
+    def test_approach_strike_requires_confirm(self, client):
+        stream_state.set_callbacks(on_approach_strike_command=lambda tid: True)
+        resp = client.post("/api/approach/strike/5", json={})
+        assert resp.status_code == 400
+
+    def test_approach_strike_happy_path(self, client):
+        stream_state.set_callbacks(on_approach_strike_command=lambda tid: True)
+        resp = client.post("/api/approach/strike/5", json={"confirm": True})
+        assert resp.status_code == 200
+
+    def test_pixel_lock_no_body_required(self, client):
+        stream_state.set_callbacks(on_pixel_lock_command=lambda tid: True)
+        resp = client.post("/api/approach/pixel_lock/5")
+        assert resp.status_code == 200
+
+    def test_pixel_lock_failure_returns_503(self, client):
+        stream_state.set_callbacks(on_pixel_lock_command=lambda tid: False)
+        resp = client.post("/api/approach/pixel_lock/5")
+        assert resp.status_code == 503
+
+    def test_abort_no_callback_is_handled(self, client):
+        """Abort must not crash even when no callback is wired."""
+        resp = client.post("/api/approach/abort")
+        # 503 (no controller) or 200 (ok) — never an unhandled 500
+        assert resp.status_code in (200, 503)
+
+
+# ---------------------------------------------------------------------------
+# RF start / stop endpoints
+# ---------------------------------------------------------------------------
+
+class TestRfEndpoints:
+    def test_rf_start_missing_callback(self, client):
+        resp = client.post("/api/rf/start", json={})
+        assert resp.status_code == 503
+
+    def test_rf_start_validates_mode(self, client):
+        stream_state.set_callbacks(on_rf_start=lambda body: True)
+        resp = client.post("/api/rf/start", json={"mode": "bogus"})
+        assert resp.status_code == 400
+
+    def test_rf_start_wifi_requires_bssid(self, client):
+        stream_state.set_callbacks(on_rf_start=lambda body: True)
+        resp = client.post("/api/rf/start", json={"mode": "wifi"})
+        assert resp.status_code == 400
+
+    def test_rf_start_bssid_format_validated(self, client):
+        stream_state.set_callbacks(on_rf_start=lambda body: True)
+        resp = client.post(
+            "/api/rf/start",
+            json={"mode": "wifi", "target_bssid": "not-a-mac"},
+        )
+        assert resp.status_code == 400
+
+    def test_rf_start_freq_range_validated(self, client):
+        stream_state.set_callbacks(on_rf_start=lambda body: True)
+        resp = client.post(
+            "/api/rf/start",
+            json={"mode": "sdr", "target_freq_mhz": 99999.0},
+        )
+        assert resp.status_code == 400
+
+    def test_rf_start_happy_path_sdr(self, client):
+        stream_state.set_callbacks(on_rf_start=lambda body: True)
+        resp = client.post(
+            "/api/rf/start",
+            json={"mode": "sdr", "target_freq_mhz": 2437.0},
+        )
+        assert resp.status_code == 200
+
+    def test_rf_stop_no_callback(self, client):
+        resp = client.post("/api/rf/stop")
+        assert resp.status_code == 503
+
+    def test_rf_stop_happy_path(self, client):
+        stream_state.set_callbacks(on_rf_stop=lambda: None)
+        resp = client.post("/api/rf/stop")
+        assert resp.status_code == 200
+
+    def test_rf_status_read(self, client):
+        resp = client.get("/api/rf/status")
+        # Auth-free read — never 5xx on empty pipeline
+        assert resp.status_code < 500
+
+
+# ---------------------------------------------------------------------------
+# Streaming endpoints — /stream.jpg (snapshot polling)
+# ---------------------------------------------------------------------------
+
+class TestStreamingEndpoints:
+    def test_stream_jpg_no_frame(self, client):
+        """With no frame published, /stream.jpg returns a valid response (never 5xx)."""
+        resp = client.get("/stream.jpg")
+        # 200 (placeholder), 204 (no content), 404, or 503 — never an unhandled 500
+        assert resp.status_code in (200, 204, 404, 503)
+
+    def test_stream_jpg_returns_jpeg_content_type_when_frame_set(self, client):
+        import numpy as np
+        # Publish a tiny test frame
+        frame = np.zeros((120, 160, 3), dtype=np.uint8)
+        stream_state.update_frame(frame)
+        resp = client.get("/stream.jpg")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"] == "image/jpeg"
+        # JPEG magic bytes
+        assert resp.content[:3] == b"\xff\xd8\xff"
+
+    def test_stream_quality_post_accepts_preferences(self, client):
+        resp = client.post("/api/stream/quality", json={"quality": 70})
+        assert resp.status_code < 500


### PR DESCRIPTION
## Summary

Implements all ten items from the earlier test-coverage audit. Adds **199 tests** across 8 new files and 4 extended files, establishes a coverage metric in CI (baseline-first, no `--cov-fail-under` floor yet), and closes the biggest gaps in safety-critical paths.

Overall line coverage on `hydra_detect/` now runs at **71%**.

## What changed

### Infrastructure
- `requirements-dev.txt` — pins `pytest-cov` and `hypothesis`
- `pytest.ini` — adds `slow` + `regression` markers
- `Makefile` — new `test-cov` target; fast suite now excludes `slow` tests
- `.github/workflows/ci.yml` — runs `pytest --cov`, uploads `coverage.xml` artifact
- `tests/README.md` — documents mock conventions + regression-test pattern

### New test files (84 tests)
| File | Tests | Covers |
|---|---|---|
| `tests/test_approach.py` | 22 | Follow + Pixel-Lock modes, min-altitude clamp, GUIDED-mode safety invariant, abort-restores-pre-approach-mode regression |
| `tests/test_dogleg_rtl.py` | 10 | `execute()` thread lifecycle, `compute_dogleg_waypoint` geometry, SMART_RTL → RTL fallback |
| `tests/test_overlay.py` | 9 | Bbox clamping (negative/over-frame), strike-mode blinking, alert-class dimming |
| `tests/test_verify_log.py` | 8 | SHA-256 chain validation, truncated-final tolerance, tamper detection |
| `tests/test_msp_displayport.py` | 12 | MSP v1 frame builders against known byte sequences (HDZero protocol 42) |
| `tests/test_system.py` | 14 | `nvpmodel`/`read_thermal`/`list_models` with mocked subprocess + sysfs |
| `tests/test_tls.py` | 5 | Self-signed cert generation, OpenSSL failure modes |
| `tests/test_concurrency_stress.py` | 4 | Lock invariants under contention (marked `@pytest.mark.slow`) |

### Extensions to existing files (115 tests)
- **`test_pipeline_callbacks.py`** (+18): `_handle_drop_command`, `_handle_follow_command`, `_handle_pixel_lock_command`, `_handle_approach_abort` with rollback-on-failure
- **`test_web_api.py`** (+70): parameterized malformed-JSON fuzz over 14 POST endpoints × 3 variants, `/auth/login` 50-attempt rate-limit, approach/RF/stream endpoint coverage
- **`test_mavlink_commands.py`** (+20): `send_velocity_ned`, `command_guided_to`, `estimate_target_position`, `set_servo`, `command_do_change_speed`, `send_raw_message`, `send_param_set`
- **`test_config_schema.py`** (+7): hypothesis property-based strategies for float ranges, bool coercion, enum validation

## Coverage snapshot (post-change)

| Module | Coverage |
|---|---|
| `approach.py` | **93%** |
| `dogleg_rtl.py` | **96%** |
| `guidance.py` | **99%** |
| `overlay.py` | **99%** |
| `verify_log.py` | **85%** |
| `msp_displayport.py` | **74%** |
| `tls.py` | **100%** |
| `config_schema.py` | **100%** |
| `web/server.py` | 73% |
| `mavlink_io.py` | 69% |
| `pipeline/facade.py` | 30% (2,578 LOC — big-rock refactor out of scope here) |
| **TOTAL** | **71%** |

## Test plan
- [x] `python -m pytest tests/` — 1,691 passing (3 pre-existing UI failures unchanged)
- [x] `python -m pytest tests/test_concurrency_stress.py -v` — 4 passed (slow suite)
- [x] `python -m pytest tests/ --cov=hydra_detect --cov-report=term` — baseline captured
- [x] `flake8` on all new + modified test files — clean (3 pre-existing errors in unrelated files untouched)
- [ ] Verify CI green on the `Test (with coverage)` step
- [ ] Confirm `coverage.xml` uploads as artifact

## Known pre-existing issues NOT touched
The branch was already red on `main` before these changes:
- 3 UI template tests (`test_ops_layout.py`, `test_tak_view.py`) missing expected HTML fragments
- 3 unused-import flake8 warnings in `test_detection_logger_writer_resilience.py`, `test_event_logger_ring_buffer.py`

These are orthogonal to test coverage work — they belong in a separate PR.

https://claude.ai/code/session_01GnGSVF3hrx8spWn79v6uQo