### PR TITLE
Add performance benchmarks for tracker stability and overlay rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,5 +34,8 @@ certs/
 # Claude Code / Superpowers
 .superpowers/
 
+# Evo experiment workspace
+.evo/
+
 # Local environment (secrets, IPs)
 .env.local

--- a/benchmarks/bench_overlay.py
+++ b/benchmarks/bench_overlay.py
@@ -1,0 +1,89 @@
+"""Benchmark overlay rendering throughput.
+
+Measures how many frames/sec draw_tracks() can process on a synthetic
+workload: 1080p frame with 15 tracked objects (mixed locked/dimmed).
+This is the hot-path rendering cost paid every frame in the pipeline.
+
+Usage:
+    python benchmarks/bench_overlay.py          # prints JSON result
+    python benchmarks/bench_overlay.py --frames 500
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+
+import numpy as np
+
+sys.path.insert(0, ".")
+from hydra_detect.overlay import draw_tracks
+from hydra_detect.tracker import TrackedObject, TrackingResult
+
+
+def _make_tracks(n: int, w: int, h: int) -> list[TrackedObject]:
+    rng = np.random.default_rng(42)
+    tracks = []
+    for i in range(n):
+        cx = rng.integers(100, w - 100)
+        cy = rng.integers(100, h - 100)
+        bw = rng.integers(40, 200)
+        bh = rng.integers(40, 200)
+        tracks.append(TrackedObject(
+            track_id=i + 1,
+            x1=float(cx - bw // 2),
+            y1=float(cy - bh // 2),
+            x2=float(cx + bw // 2),
+            y2=float(cy + bh // 2),
+            confidence=rng.uniform(0.4, 0.95),
+            class_id=i % 10,
+            label=f"class_{i % 5}",
+        ))
+    return tracks
+
+
+def run_benchmark(num_frames: int = 300) -> dict:
+    W, H = 1920, 1080
+    tracks = _make_tracks(15, W, H)
+    tracking = TrackingResult(tracks=tracks, active_ids=len(tracks))
+    alert_classes = {"class_0", "class_1", "class_2"}
+    base_frame = np.zeros((H, W, 3), dtype=np.uint8)
+
+    times = []
+    for i in range(num_frames):
+        frame = base_frame.copy()
+        t0 = time.perf_counter()
+        draw_tracks(
+            frame,
+            tracking,
+            inference_ms=12.5,
+            fps=30.0,
+            locked_track_id=3,
+            lock_mode="strike" if i % 2 == 0 else "track",
+            alert_classes=alert_classes,
+        )
+        times.append(time.perf_counter() - t0)
+
+    times_ms = [t * 1000 for t in times]
+    avg_ms = sum(times_ms) / len(times_ms)
+    p50 = sorted(times_ms)[len(times_ms) // 2]
+    p99 = sorted(times_ms)[int(len(times_ms) * 0.99)]
+    fps = 1000.0 / avg_ms if avg_ms > 0 else 0
+
+    return {
+        "frames": num_frames,
+        "avg_ms": round(avg_ms, 3),
+        "p50_ms": round(p50, 3),
+        "p99_ms": round(p99, 3),
+        "fps": round(fps, 1),
+        "score": round(fps, 1),
+    }
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--frames", type=int, default=300)
+    args = parser.parse_args()
+    result = run_benchmark(args.frames)
+    print(json.dumps(result))

--- a/benchmarks/bench_tracker_stability.py
+++ b/benchmarks/bench_tracker_stability.py
@@ -1,0 +1,161 @@
+"""Benchmark tracker ID stability.
+
+Generates synthetic moving objects across 200 frames with realistic
+challenges (occlusion, confidence jitter, missed detections) and
+counts track ID switches. Lower = better.
+
+The tracker parameters are read from config.ini [tracker] section,
+so evo can mutate them and re-run.
+
+Usage:
+    python benchmarks/bench_tracker_stability.py
+"""
+from __future__ import annotations
+
+import configparser
+import json
+import sys
+import types
+
+# supervision 0.27 needs the `deprecate` package which has a broken build.
+# Provide a no-op shim so the import chain succeeds.
+if "deprecate" not in sys.modules:
+    _shim = types.ModuleType("deprecate")
+    def _deprecated(func=None, **kwargs):
+        return (lambda f: f) if func is None else func
+    _shim.deprecated = _deprecated
+    sys.modules["deprecate"] = _shim
+
+import numpy as np
+
+sys.path.insert(0, ".")
+from hydra_detect.detectors.base import Detection, DetectionResult
+from hydra_detect.tracker import ByteTracker
+
+
+NUM_OBJECTS = 8
+NUM_FRAMES = 200
+FRAME_W, FRAME_H = 1920, 1080
+
+
+def _generate_sequence(
+    rng: np.random.Generator,
+) -> list[list[Detection]]:
+    """Generate moving objects with occlusion gaps and confidence jitter."""
+    starts_x = rng.uniform(200, FRAME_W - 200, size=NUM_OBJECTS)
+    starts_y = rng.uniform(200, FRAME_H - 200, size=NUM_OBJECTS)
+    vel_x = rng.uniform(-8, 8, size=NUM_OBJECTS)
+    vel_y = rng.uniform(-5, 5, size=NUM_OBJECTS)
+    box_w = rng.uniform(60, 180, size=NUM_OBJECTS)
+    box_h = rng.uniform(60, 180, size=NUM_OBJECTS)
+
+    frames: list[list[Detection]] = []
+    for f in range(NUM_FRAMES):
+        dets = []
+        for i in range(NUM_OBJECTS):
+            cx = starts_x[i] + vel_x[i] * f
+            cy = starts_y[i] + vel_y[i] * f
+            cx = np.clip(cx, box_w[i] / 2, FRAME_W - box_w[i] / 2)
+            cy = np.clip(cy, box_h[i] / 2, FRAME_H - box_h[i] / 2)
+
+            if rng.random() < 0.08:
+                continue
+
+            conf = np.clip(rng.normal(0.75, 0.12), 0.15, 0.99)
+
+            jx = rng.normal(0, 3)
+            jy = rng.normal(0, 3)
+
+            dets.append(Detection(
+                x1=float(cx - box_w[i] / 2 + jx),
+                y1=float(cy - box_h[i] / 2 + jy),
+                x2=float(cx + box_w[i] / 2 + jx),
+                y2=float(cy + box_h[i] / 2 + jy),
+                confidence=float(conf),
+                class_id=i % 3,
+                label=f"class_{i % 3}",
+            ))
+        frames.append(dets)
+    return frames
+
+
+def _count_id_switches(
+    sequence: list[list[Detection]],
+    tracker: ByteTracker,
+) -> int:
+    """Run tracker on sequence and count ID switches.
+
+    An ID switch occurs when the same spatial object (matched by IoU
+    to the previous frame's position) gets a different track_id.
+    """
+    prev_positions: dict[int, tuple[float, float]] = {}
+    obj_to_track: dict[int, int] = {}
+    switches = 0
+
+    for frame_dets in sequence:
+        det_result = DetectionResult(detections=frame_dets)
+        track_result = tracker.update(det_result)
+
+        curr_positions: dict[int, tuple[float, float]] = {}
+        for track in track_result:
+            cx, cy = track.center
+            curr_positions[track.track_id] = (cx, cy)
+
+            best_obj = -1
+            best_dist = float("inf")
+            for obj_idx, (px, py) in prev_positions.items():
+                d = ((cx - px) ** 2 + (cy - py) ** 2) ** 0.5
+                if d < best_dist and d < 150:
+                    best_dist = d
+                    best_obj = obj_idx
+
+            if best_obj >= 0:
+                if best_obj in obj_to_track and obj_to_track[best_obj] != track.track_id:
+                    switches += 1
+                obj_to_track[best_obj] = track.track_id
+
+        prev_positions = curr_positions
+
+    return switches
+
+
+def run_benchmark() -> dict:
+    cfg = configparser.ConfigParser()
+    cfg.read("config.ini")
+
+    track_thresh = cfg.getfloat("tracker", "track_thresh", fallback=0.5)
+    track_buffer = cfg.getint("tracker", "track_buffer", fallback=30)
+    match_thresh = cfg.getfloat("tracker", "match_thresh", fallback=0.8)
+
+    scores = []
+    for seed in range(5):
+        rng = np.random.default_rng(seed)
+        sequence = _generate_sequence(rng)
+
+        tracker = ByteTracker(
+            track_thresh=track_thresh,
+            track_buffer=track_buffer,
+            match_thresh=match_thresh,
+            frame_rate=30,
+        )
+        tracker.init()
+
+        switches = _count_id_switches(sequence, tracker)
+        scores.append(switches)
+
+    avg_switches = sum(scores) / len(scores)
+
+    return {
+        "track_thresh": track_thresh,
+        "track_buffer": track_buffer,
+        "match_thresh": match_thresh,
+        "seeds": len(scores),
+        "switches_per_seed": scores,
+        "avg_switches": round(avg_switches, 1),
+        "score": round(avg_switches, 1),
+    }
+
+
+if __name__ == "__main__":
+    result = run_benchmark()
+    print(json.dumps(result))


### PR DESCRIPTION
## Summary
This PR adds two new performance benchmarks to measure critical aspects of the tracking and rendering pipeline: tracker ID stability under realistic conditions and overlay rendering throughput.

## Key Changes
- **`benchmarks/bench_tracker_stability.py`**: New benchmark that generates synthetic moving objects across 200 frames with realistic challenges (occlusion, confidence jitter, missed detections) and measures track ID switches. The benchmark reads tracker parameters from `config.ini` to support automated parameter tuning via external tools like evo.
  - Generates 8 objects with random velocities, sizes, and trajectories
  - Simulates 8% missed detection rate and confidence jitter
  - Counts ID switches by spatial matching (IoU-based) across frames
  - Runs 5 seeds and reports average switches as the optimization metric

- **`benchmarks/bench_overlay.py`**: New benchmark measuring `draw_tracks()` rendering throughput on a synthetic 1080p workload with 15 tracked objects in mixed lock states.
  - Measures frames/sec, average latency, p50, and p99 percentiles
  - Supports configurable frame count via `--frames` argument
  - Reports FPS as the optimization metric

- **`.gitignore`**: Added `.evo/` directory to ignore experiment workspace artifacts from the evo optimization framework

## Implementation Details
- Both benchmarks output JSON for easy integration with automated optimization pipelines
- `bench_tracker_stability.py` includes a workaround for the broken `deprecate` package dependency in supervision 0.27
- Benchmarks use realistic parameters (1920x1080 frames, 30 FPS) matching production scenarios
- Results include both detailed metrics and a single `score` field for optimization targets

https://claude.ai/code/session_01FtMBqFYzCEmgrRxFuqBSfn