### PR TITLE
fix: address codex review findings across PRs #124-#130

### DIFF
--- a/docs/setup/qspi-update.md
+++ b/docs/setup/qspi-update.md
@@ -47,8 +47,20 @@ One JP 5.1.3 SD card handles all devices. After the first Jetson completes the U
 | Device | Steps | Time |
 |--------|-------|------|
 | Jetson #1 | Boot JP 5.1.3 → OOBE wizard → `apt install` updater → reboot → halt | ~10 min |
-| Jetson #2 | Boot JP 5.1.3 (skips OOBE) → `apt install` updater (cached) → reboot → halt | ~5 min |
+| Jetson #2 | Boot JP 5.1.3 (skips OOBE) → `apt install --reinstall` updater → reboot → halt | ~5 min |
 | Jetson #3+ | Same as #2 | ~5 min each |
+
+<Warning>
+On every device after #1 you must pass `--reinstall`. The package is already
+marked installed on the reused SD card, so plain `apt install` is a no-op and
+the post-install QSPI flash hook won't re-run — leaving factory QSPI intact.
+</Warning>
+
+```bash
+# Jetson #2+ — reuse the same JP 5.1.3 SD card
+sudo apt-get install --reinstall nvidia-l4t-jetson-orin-nano-qspi-updater
+sudo reboot
+```
 
 After QSPI update, swap in the golden image card and boot. Per-device customization: set callsign via the setup wizard at `/setup` or edit `config.ini` directly.
 

--- a/hydra_detect/autonomous.py
+++ b/hydra_detect/autonomous.py
@@ -400,8 +400,46 @@ class AutonomousController:
             self._record_decision(None, "", "defer", "no qualifying track")
             return
 
-        # All criteria met — initiate autonomous strike
+        # All criteria met — dispatch based on runtime autonomy mode.
+        # ``_mode`` is the operator-facing safety switch surfaced on the Autonomy
+        # view. It gates execution independently of ``self.enabled``:
+        #   - dryrun   evaluate + log, never touch lock_cb / strike_cb
+        #   - shadow   lock the track for operator review, never strike_cb
+        #   - live     full engage
+        # Without this branch, selecting DRYRUN in the UI would still fire real
+        # strikes — the mode picker would be cosmetic rather than protective.
+        mode = self.get_mode()
         pos_str = getattr(mavlink, "get_position_string", lambda: None)()
+        conf_detail = f"conf={best_track.confidence:.2f} frames={best_frames}"
+
+        if mode == "dryrun":
+            audit_log.info(
+                "AUTONOMY DRYRUN (no-op): track_id=%d label=%s %s vehicle_mode=%s position=%s",
+                best_track.track_id, best_track.label, conf_detail,
+                vehicle_mode, pos_str,
+            )
+            self._record_decision(
+                best_track.track_id, best_track.label, "passthrough",
+                f"dryrun (would engage) {conf_detail}",
+            )
+            return
+
+        if mode == "shadow":
+            audit_log.info(
+                "AUTONOMY SHADOW (lock only): track_id=%d label=%s %s vehicle_mode=%s position=%s",
+                best_track.track_id, best_track.label, conf_detail,
+                vehicle_mode, pos_str,
+            )
+            # Lock the track so operators see what the controller would target,
+            # but skip strike_cb — no kinetic action in shadow mode.
+            lock_cb(best_track.track_id, "shadow")
+            self._record_decision(
+                best_track.track_id, best_track.label, "passthrough",
+                f"shadow (locked, no strike) {conf_detail}",
+            )
+            return
+
+        # mode == "live" — actual autonomous strike
         audit_log.info(
             "AUTONOMOUS STRIKE INITIATED: track_id=%d label=%s confidence=%.3f "
             "frames=%d vehicle_mode=%s position=%s",
@@ -431,7 +469,7 @@ class AutonomousController:
             self._last_strike_time = now
             self._record_decision(
                 best_track.track_id, best_track.label, "engage",
-                f"conf={best_track.confidence:.2f} frames={best_frames}",
+                conf_detail,
             )
             audit_log.info(
                 "AUTONOMOUS STRIKE CONFIRMED: track_id=%d", best_track.track_id

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -52,6 +52,7 @@ from ..web.server import (
     configure_auth,
     configure_web_password,
     run_server,
+    set_autonomous_controller,
     set_tak_input,
     set_tak_output,
     stream_state,
@@ -397,6 +398,10 @@ class Pipeline:
                 self._cfg.getint("autonomous", "min_track_frames", fallback=5),
                 classes_raw or "NONE (fail-closed)",
             )
+            # Register with the web server so /api/autonomy/{status,mode}
+            # reach the live controller. Without this the endpoints fall back
+            # to the idle placeholder and the mode picker returns 503.
+            set_autonomous_controller(self._autonomous)
 
         # Approach controller (Follow / Drop / Strike)
         self._approach: ApproachController | None = None
@@ -2644,6 +2649,8 @@ class Pipeline:
         if self._tak_input is not None:
             self._tak_input.stop()
             set_tak_input(None)
+        if self._autonomous is not None:
+            set_autonomous_controller(None)
         if self._servo_tracker is not None:
             self._servo_tracker.safe()
         self._camera.close()

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -1625,12 +1625,20 @@ const HydraOps = (() => {
             });
         }
 
-        // Quick action: Beep — apiPost handles error toasts itself
+        // Quick action: Beep — apiPost handles transport error toasts; we still
+        // need to distinguish backend {status:"ok"} from {status:"failed"} (HTTP
+        // 200 with failed callback — operator would otherwise see "Beep sent"
+        // during degraded MAVLink even though the tune never went out).
         var beepBtn = document.getElementById('ops-btn-beep');
         if (beepBtn) {
             beepBtn.addEventListener('click', function () {
                 HydraApp.apiPost('/api/vehicle/beep', { tune: 'alert' }).then(function (r) {
-                    if (r) HydraApp.showToast('Beep sent', 'success');
+                    if (!r) return; // transport error already toasted by apiPost
+                    if (r.status === 'ok') {
+                        HydraApp.showToast('Beep sent', 'success');
+                    } else {
+                        HydraApp.showToast('Beep failed — MAVLink degraded', 'error');
+                    }
                 });
             });
         }

--- a/tests/test_autonomous.py
+++ b/tests/test_autonomous.py
@@ -46,7 +46,14 @@ def _make_tracks(*specs) -> TrackingResult:
 
 
 def _make_controller(**overrides) -> AutonomousController:
-    """Build an AutonomousController with sensible test defaults."""
+    """Build an AutonomousController with sensible test defaults.
+
+    The production default mode is ``dryrun`` (safety default — fresh
+    controller will not fire strike_cb). Existing tests here exercise the
+    live strike path, so the helper promotes to ``live`` by default. Pass
+    ``mode="dryrun"`` or ``mode="shadow"`` to override.
+    """
+    mode = overrides.pop("mode", "live")
     defaults = dict(
         enabled=True,
         geofence_lat=34.05,
@@ -60,7 +67,9 @@ def _make_controller(**overrides) -> AutonomousController:
         require_operator_lock=False,  # tests override; production default is True
     )
     defaults.update(overrides)
-    return AutonomousController(**defaults)
+    ctrl = AutonomousController(**defaults)
+    ctrl.set_mode(mode)
+    return ctrl
 
 
 # ---------------------------------------------------------------------------
@@ -381,3 +390,110 @@ class TestEvaluate:
             ctrl.evaluate(tracks, mav, MagicMock(), strike_cb)
 
         strike_cb.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Runtime autonomy mode — safety-critical gate for strike_cb
+# ---------------------------------------------------------------------------
+
+class TestAutonomyModeGating:
+    """``_mode`` must gate execution, not just dashboard display.
+
+    Regression guard: before this gate was wired in, selecting DRYRUN on the
+    Autonomy view still allowed the full strike path to run because
+    ``evaluate()`` only checked ``self.enabled``. Operators would see a
+    non-LIVE label while actual strikes were firing.
+    """
+
+    def _qualify(self, ctrl, mav, lock_cb, strike_cb, frames=3):
+        tracks = _make_tracks((1, "mine", 0.92))
+        for _ in range(frames):
+            ctrl.evaluate(tracks, mav, lock_cb, strike_cb)
+
+    def test_default_mode_is_dryrun(self):
+        """Fresh controller must start in dryrun — safety default."""
+        ctrl = AutonomousController(
+            enabled=True,
+            geofence_lat=34.05, geofence_lon=-118.25, geofence_radius_m=500.0,
+            min_confidence=0.80, min_track_frames=3,
+            allowed_classes=["mine"],
+            allowed_vehicle_modes=["AUTO"],
+            require_operator_lock=False,
+        )
+        assert ctrl.get_mode() == "dryrun"
+
+    def test_dryrun_never_calls_strike_or_lock(self):
+        ctrl = _make_controller(mode="dryrun", min_track_frames=3)
+        mav = _make_mavlink()
+        lock_cb = MagicMock(return_value=True)
+        strike_cb = MagicMock(return_value=True)
+
+        self._qualify(ctrl, mav, lock_cb, strike_cb)
+
+        strike_cb.assert_not_called()
+        lock_cb.assert_not_called()
+
+    def test_dryrun_still_records_passthrough_decision(self):
+        ctrl = _make_controller(mode="dryrun", min_track_frames=3)
+        mav = _make_mavlink()
+        self._qualify(ctrl, mav, MagicMock(return_value=True), MagicMock(return_value=True))
+
+        snap = ctrl.get_dashboard_snapshot()
+        assert snap["log"], "decision log should record dryrun passthrough"
+        assert snap["log"][0]["action"] == "passthrough"
+        assert "dryrun" in snap["log"][0]["reason"]
+
+    def test_shadow_locks_but_does_not_strike(self):
+        ctrl = _make_controller(mode="shadow", min_track_frames=3)
+        mav = _make_mavlink()
+        lock_cb = MagicMock(return_value=True)
+        strike_cb = MagicMock(return_value=True)
+
+        self._qualify(ctrl, mav, lock_cb, strike_cb)
+
+        strike_cb.assert_not_called()
+        # Shadow tags the lock reason so downstream can distinguish it from
+        # a real strike lock.
+        lock_cb.assert_called_once_with(1, "shadow")
+
+    def test_shadow_records_passthrough_decision(self):
+        ctrl = _make_controller(mode="shadow", min_track_frames=3)
+        mav = _make_mavlink()
+        self._qualify(ctrl, mav, MagicMock(return_value=True), MagicMock(return_value=True))
+
+        snap = ctrl.get_dashboard_snapshot()
+        assert snap["log"][0]["action"] == "passthrough"
+        assert "shadow" in snap["log"][0]["reason"]
+
+    def test_live_strikes_normally(self):
+        ctrl = _make_controller(mode="live", min_track_frames=3)
+        mav = _make_mavlink()
+        lock_cb = MagicMock(return_value=True)
+        strike_cb = MagicMock(return_value=True)
+
+        self._qualify(ctrl, mav, lock_cb, strike_cb)
+
+        strike_cb.assert_called_once_with(1)
+        lock_cb.assert_called_once_with(1, "strike")
+
+    def test_switching_live_to_dryrun_halts_strikes(self):
+        """Operator flipping to dryrun mid-sortie must stop the strike path."""
+        ctrl = _make_controller(mode="live", min_track_frames=1, strike_cooldown_sec=0.0)
+        mav = _make_mavlink()
+        lock_cb = MagicMock(return_value=True)
+        strike_cb = MagicMock(return_value=True)
+        tracks = _make_tracks((1, "mine", 0.92))
+
+        ctrl.evaluate(tracks, mav, lock_cb, strike_cb)
+        assert strike_cb.call_count == 1
+
+        ctrl.set_mode("dryrun")
+        # Give a different track id to avoid the cooldown skip path
+        tracks2 = _make_tracks((2, "mine", 0.92))
+        ctrl.evaluate(tracks2, mav, lock_cb, strike_cb)
+        assert strike_cb.call_count == 1, "mode=dryrun must not fire strike_cb"
+
+    def test_set_mode_rejects_unknown_value(self):
+        ctrl = _make_controller(mode="live")
+        with pytest.raises(ValueError):
+            ctrl.set_mode("arm")

--- a/tests/test_autonomy_gates_wiring.py
+++ b/tests/test_autonomy_gates_wiring.py
@@ -59,6 +59,10 @@ def _make_tracks(*specs) -> TrackingResult:
 
 
 def _make_controller(**overrides) -> AutonomousController:
+    # Default to live mode — existing gate-wiring tests assert engage/strike
+    # behavior that only runs in live. Pass ``mode="dryrun"`` / ``mode="shadow"``
+    # to test the safety-gated paths.
+    mode = overrides.pop("mode", "live")
     defaults = dict(
         enabled=True,
         geofence_lat=35.0527,
@@ -73,7 +77,9 @@ def _make_controller(**overrides) -> AutonomousController:
         require_operator_lock=False,
     )
     defaults.update(overrides)
-    return AutonomousController(**defaults)
+    ctrl = AutonomousController(**defaults)
+    ctrl.set_mode(mode)
+    return ctrl
 
 
 def _gates(ctrl: AutonomousController) -> dict:

--- a/tests/test_pipeline_subsystems.py
+++ b/tests/test_pipeline_subsystems.py
@@ -257,3 +257,48 @@ def test_pipeline_contract_adapter_callbacks_keep_command_behavior():
     # Spot-check that an invocation forwards args correctly.
     callbacks["on_strike_command"](12)
     cb_owner._handle_strike_command.assert_called_once_with(12)
+
+
+def test_facade_imports_and_invokes_set_autonomous_controller():
+    """Regression guard: pipeline facade MUST wire the live autonomous controller
+    into the web server, otherwise /api/autonomy/status returns the idle
+    placeholder and /api/autonomy/mode 503s in production — the whole mode
+    picker is cosmetic.
+
+    This is a structural check — constructing the full HydraPipeline requires
+    hardware + a config file. We assert on the source that both the import
+    and the registration call exist in the expected code paths.
+    """
+    import ast
+    import inspect
+
+    from hydra_detect.pipeline import facade
+
+    src = inspect.getsource(facade)
+    tree = ast.parse(src)
+
+    # 1. Import must be present
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module == "..web.server":
+            imported.update(a.name for a in node.names)
+    # Relative imports read as just "web.server" in some AST versions — look
+    # for any import bringing `set_autonomous_controller` into module scope.
+    if "set_autonomous_controller" not in imported:
+        assert "from ..web.server import" in src or "from hydra_detect.web.server import" in src
+        assert "set_autonomous_controller" in src, (
+            "facade.py must import set_autonomous_controller"
+        )
+
+    # 2. A call site must exist — both register (on autonomous-enabled branch)
+    #    and unregister (on shutdown). Count the call occurrences.
+    call_count = src.count("set_autonomous_controller(")
+    assert call_count >= 2, (
+        f"expected ≥2 call sites (register + unregister), found {call_count}"
+    )
+    assert "set_autonomous_controller(self._autonomous)" in src, (
+        "must register the live controller on startup"
+    )
+    assert "set_autonomous_controller(None)" in src, (
+        "must unregister on shutdown to avoid stale snapshots after pipeline stop"
+    )

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -991,33 +991,44 @@ _POST_ENDPOINTS_TAKING_JSON = [
 
 
 class TestMalformedJsonFuzz:
-    """Every POST endpoint accepting a body must return 400 (not 500) on junk input."""
+    """Every POST endpoint accepting a body must reject junk input with a 4xx.
+
+    A lax ``< 500`` assertion would pass on a buggy endpoint that silently
+    accepts malformed JSON and returns 200 — exactly the regression this
+    fuzz is supposed to catch. Anchor the lower bound at 400 so success and
+    redirect responses fail the test.
+    """
 
     @pytest.mark.parametrize("path", _POST_ENDPOINTS_TAKING_JSON)
-    def test_malformed_json_returns_400(self, client, path):
+    def test_malformed_json_returns_4xx(self, client, path):
         resp = client.post(
             path,
             content=b"{not valid json",
             headers={"Content-Type": "application/json"},
         )
-        # 400 (malformed body) or 413 (oversize); never a 500
-        assert resp.status_code < 500, (
+        # 400 (malformed body), 401/403 (auth), 413 (oversize), 422 (schema).
+        # Never a 2xx/3xx (silent accept) and never a 5xx (crash).
+        assert 400 <= resp.status_code < 500, (
             f"{path} returned {resp.status_code} on malformed JSON"
         )
 
     @pytest.mark.parametrize("path", _POST_ENDPOINTS_TAKING_JSON)
-    def test_non_utf8_body_does_not_500(self, client, path):
+    def test_non_utf8_body_returns_4xx(self, client, path):
         resp = client.post(
             path,
             content=b"\xff\xfe\x00invalid-utf8",
             headers={"Content-Type": "application/json"},
         )
-        assert resp.status_code < 500
+        assert 400 <= resp.status_code < 500, (
+            f"{path} returned {resp.status_code} on non-UTF8 body"
+        )
 
     @pytest.mark.parametrize("path", _POST_ENDPOINTS_TAKING_JSON)
-    def test_empty_body_does_not_500(self, client, path):
+    def test_empty_body_returns_4xx(self, client, path):
         resp = client.post(path, content=b"", headers={"Content-Type": "application/json"})
-        assert resp.status_code < 500
+        assert 400 <= resp.status_code < 500, (
+            f"{path} returned {resp.status_code} on empty body"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Audits the open review threads left by `chatgpt-codex-connector` on PRs #124–#130 and resolves the five that are still valid in current code. The motivating issue is a P1 autonomy-safety gap on #125 (strike_cb fires regardless of UI mode picker).

## Findings

| # | PR | File | Priority | Status |
|---|----|------|----------|--------|
| 1 | #130 | `tests/test_web_api.py:1004` | P2 | Fixed |
| 2 | #127 | `pipeline/facade.py:1381` | P1 | Already fixed — thread reply posted |
| 3 | #126 | `ops.js:1633` | P2 | Fixed |
| 4 | #125 | `autonomous.py:588` | **P1 safety** | Fixed + 8 regression tests |
| 5 | #125 | `server.py:2141` | P1 | Fixed + 1 regression test |
| 6 | #124 | `docs/setup/qspi-update.md:50` | P1 | Fixed |

## Changes

### Autonomy safety (findings 4 + 5)
- `hydra_detect/autonomous.py` — `evaluate()` now branches on `_mode` **before** calling `strike_cb`:
  - `dryrun` → records `passthrough` in the decision log, returns early; no `lock_cb`, no `strike_cb`
  - `shadow` → `lock_cb(track_id, "shadow")` only; no `strike_cb`
  - `live` → unchanged (full engage)
  - Default mode remains `dryrun`, so a freshly-constructed controller cannot fire strikes.
- `hydra_detect/pipeline/facade.py` — imports `set_autonomous_controller` and calls it at construction when autonomous is enabled, passes `None` in the shutdown path. Without this, `/api/autonomy/status` served the idle placeholder and `/api/autonomy/mode` returned 503 in production.

### Hardening (findings 1 + 3)
- `tests/test_web_api.py` — `TestMalformedJsonFuzz` tightened from `status_code < 500` to `400 <= status_code < 500` across all three fuzz methods. The old assertion would silently pass on a buggy endpoint that accepts junk JSON and returns 200 — exactly the regression this fuzz exists to catch. All 42 parameterized cases still pass.
- `hydra_detect/web/static/js/ops.js` — beep button no longer shows "Beep sent" on `{status:"failed"}`. Now gates on `r.status === 'ok'` and shows an error toast otherwise (the endpoint returns HTTP 200 with `status:"failed"` when MAVLink is degraded).

### Docs (finding 6)
- `docs/setup/qspi-update.md` — assembly-line row for Jetson #2+ changed from plain `apt install` to `apt install --reinstall`. Added a callout explaining why: plain `apt install` is a no-op once the package is already marked installed on the reused SD card, so the post-install QSPI flash hook doesn't re-trigger and the board boots back into JP 5.1.3 instead of halting.

### PR #127 TAK relay thread (finding 2)
No code change — current `_handle_tak_toggle` at `hydra_detect/pipeline/facade.py:2450-2532` already stops both `_tak` and `_mav_relay` on disable. Posted a reply on the discussion thread with line refs; mark the thread resolved when merging this PR.

## Tests

- **New**: `TestAutonomyModeGating` in `tests/test_autonomous.py` — 8 tests covering default mode, dryrun never calls strike/lock, shadow locks without striking, live strikes normally, switching live→dryrun mid-sortie halts strikes, `set_mode` rejects unknown values, dryrun + shadow both record `passthrough` in the decision log.
- **New**: `test_facade_imports_and_invokes_set_autonomous_controller` in `tests/test_pipeline_subsystems.py` — AST-level regression guard asserting the wiring (import + ≥2 call sites).
- **Updated**: `_make_controller` helpers in `tests/test_autonomous.py` and `tests/test_autonomy_gates_wiring.py` now default to `mode="live"` (and accept `mode=` override) so existing engage-path tests stay valid alongside the new gating.

## Test plan

- [x] `python -m pytest tests/ --ignore=tests/test_config_schema.py` → **1,732 passed, 1 skipped** (hypothesis not installed locally — test_config_schema.py is a pre-existing CI dependency issue, untouched here)
- [x] `python -m pytest tests/test_autonomous.py::TestAutonomyModeGating -v` → 8/8 pass
- [x] `python -m pytest tests/test_pipeline_subsystems.py::test_facade_imports_and_invokes_set_autonomous_controller -v` → pass
- [x] `python -m pytest tests/test_web_api.py::TestMalformedJsonFuzz -v` → 42/42 pass (tightened assertions)
- [x] `flake8 hydra_detect/autonomous.py hydra_detect/pipeline/facade.py tests/test_web_api.py tests/test_autonomous.py tests/test_autonomy_gates_wiring.py tests/test_pipeline_subsystems.py` → clean
- [ ] CI green
- [ ] Manual: after deploy, verify `/api/autonomy/status` returns real snapshot (not idle) and `/api/autonomy/mode` accepts live/shadow/dryrun (was 503 before)
- [ ] Manual: on Jetson, flip autonomy mode to `dryrun` and confirm log shows `AUTONOMY DRYRUN (no-op)` rather than `AUTONOMOUS STRIKE INITIATED`

https://claude.ai/code/session_01GnGSVF3hrx8spWn79v6uQo