### PR TITLE
audit followups: wire post_drop_mode + vehicle.* prefix validator

### DIFF
--- a/hydra_detect/approach.py
+++ b/hydra_detect/approach.py
@@ -55,6 +55,17 @@ class ApproachConfig:
     abort_mode: str = "LOITER"  # Mode to switch to on abort
     waypoint_interval: float = 0.5  # Min seconds between waypoint sends
 
+    # Post-action mode transitions. Resolved from [autonomous] after the
+    # vehicle-profile merge, so [vehicle.drone] autonomous.post_drop_mode
+    # flows in automatically. Empty/None disables the transition (preserves
+    # prior behavior where the vehicle stayed in its current mode).
+    #
+    # Fixed-wing uses post_action_mode for both drop and strike; multirotor,
+    # rover, and USV use per-action keys. Pipeline picks the right one at
+    # init time and leaves the unused fields as None.
+    post_drop_mode: str | None = None
+    post_strike_mode: str | None = None  # Hook only — no auto-trigger yet.
+
 
 class ApproachController:
     """Manages Follow, Drop, and Strike approach modes.
@@ -459,6 +470,25 @@ class ApproachController:
                 threading.Thread(
                     target=_revert, daemon=True, name="drop-revert",
                 ).start()
+
+            # Post-drop flight mode transition. Happens even when drop_channel
+            # is 0 (simulated drop) so vehicle-profile post_drop_mode still
+            # fires for dry-run training. Runs after the servo fire so the
+            # audit log records release first, mode change second. set_mode
+            # swallows its own exceptions and returns bool.
+            post_mode = self._cfg.post_drop_mode
+            if post_mode:
+                if self._mavlink.set_mode(post_mode):
+                    logger.info("Post-drop mode transition: %s", post_mode)
+                    audit_log.info("POST_DROP_MODE: %s", post_mode)
+                else:
+                    logger.warning(
+                        "Post-drop set_mode(%s) rejected or disconnected",
+                        post_mode,
+                    )
+                with self._lock:
+                    self._mode = ApproachMode.IDLE
+                    self._running = False
 
     def _update_strike(self, track, fw: int, fh: int) -> None:
         """Update strike mode — continuous approach at max speed."""

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1194,6 +1194,112 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
 }
 
 
+# Non-dotted keys allowed at the vehicle-profile level (not tied to a base
+# section). Everything else in [vehicle.<name>] must be a "section.option"
+# override so the pipeline's vehicle-merge pass can slot it into the right
+# section.
+_VEHICLE_LOCAL_KEYS = {"reserved_channels"}
+
+
+def _validate_scalar(
+    section: str,
+    key: str,
+    raw: str,
+    spec: FieldSpec,
+    result: ValidationResult,
+) -> None:
+    """Type-check a single raw value against its spec. Appends to result."""
+    try:
+        if spec.type == FieldType.BOOL:
+            if raw.lower() not in ("true", "false", "yes", "no", "1", "0", "on", "off"):
+                result.errors.append(
+                    f"[{section}] {key} must be true or false, got \"{raw}\""
+                )
+
+        elif spec.type == FieldType.INT:
+            val = int(raw)
+            if spec.min_val is not None and val < spec.min_val:
+                result.errors.append(
+                    f"[{section}] {key} must be at least {int(spec.min_val)}, got {val}"
+                )
+            if spec.max_val is not None and val > spec.max_val:
+                result.errors.append(
+                    f"[{section}] {key} must be at most {int(spec.max_val)}, got {val}"
+                )
+
+        elif spec.type == FieldType.FLOAT:
+            val_f = float(raw)
+            if spec.min_val is not None and val_f < spec.min_val:
+                result.errors.append(
+                    f"[{section}] {key} must be at least {spec.min_val}, got {val_f}"
+                )
+            if spec.max_val is not None and val_f > spec.max_val:
+                result.errors.append(
+                    f"[{section}] {key} must be at most {spec.max_val}, got {val_f}"
+                )
+
+        elif spec.type == FieldType.ENUM:
+            if spec.choices and raw.lower() not in [c.lower() for c in spec.choices]:
+                result.errors.append(
+                    f"[{section}] {key} must be one of {spec.choices}, got \"{raw}\""
+                )
+
+    except ValueError:
+        is_numeric = spec.type in (FieldType.INT, FieldType.FLOAT)
+        expected = "a number" if is_numeric else spec.type.value
+        result.errors.append(
+            f"[{section}] {key} must be {expected}, got \"{raw}\""
+        )
+
+
+def _validate_vehicle_sections(
+    cfg: configparser.ConfigParser, result: ValidationResult,
+) -> None:
+    """Validate [vehicle.*] sections via dotted-key lookup into base schemas.
+
+    A section like [vehicle.drone] with ``camera.source = /dev/video2`` gets
+    validated as if ``source`` were set in [camera]. Typos like
+    ``camara.source`` are flagged as unknown base sections; real-key typos
+    like ``camera.sauce`` are flagged against [camera]'s schema. Sections
+    already in SCHEMA (e.g. vehicle.fw) skip this pass — the main loop
+    covers them with explicit field specs.
+    """
+    for section in cfg.sections():
+        if not section.startswith("vehicle."):
+            continue
+        if section in SCHEMA:
+            continue
+
+        for key in cfg.options(section):
+            if "." not in key:
+                if key not in _VEHICLE_LOCAL_KEYS:
+                    result.warnings.append(
+                        f"[{section}] unknown key '{key}' — expected "
+                        "'section.option' override (e.g. 'camera.source')"
+                    )
+                continue
+
+            base_section, option = key.split(".", 1)
+            if base_section not in SCHEMA:
+                result.warnings.append(
+                    f"[{section}] override '{key}' — unknown base section "
+                    f"'{base_section}'"
+                )
+                continue
+
+            base_fields = SCHEMA[base_section]
+            if option not in base_fields:
+                result.warnings.append(
+                    f"[{section}] override '{key}' — no key '{option}' in "
+                    f"[{base_section}] schema"
+                )
+                continue
+
+            raw = cfg.get(section, key).strip()
+            if raw:
+                _validate_scalar(section, key, raw, base_fields[option], result)
+
+
 def validate_config(cfg: configparser.ConfigParser) -> ValidationResult:
     """Validate entire config against schema. Returns errors and warnings."""
     result = ValidationResult()
@@ -1218,48 +1324,7 @@ def validate_config(cfg: configparser.ConfigParser) -> ValidationResult:
             if not raw and not spec.required:
                 continue
 
-            # Type validation
-            try:
-                if spec.type == FieldType.BOOL:
-                    if raw.lower() not in ("true", "false", "yes", "no", "1", "0", "on", "off"):
-                        result.errors.append(
-                            f"[{section}] {key} must be true or false, got \"{raw}\""
-                        )
-
-                elif spec.type == FieldType.INT:
-                    val = int(raw)
-                    if spec.min_val is not None and val < spec.min_val:
-                        result.errors.append(
-                            f"[{section}] {key} must be at least {int(spec.min_val)}, got {val}"
-                        )
-                    if spec.max_val is not None and val > spec.max_val:
-                        result.errors.append(
-                            f"[{section}] {key} must be at most {int(spec.max_val)}, got {val}"
-                        )
-
-                elif spec.type == FieldType.FLOAT:
-                    val = float(raw)
-                    if spec.min_val is not None and val < spec.min_val:
-                        result.errors.append(
-                            f"[{section}] {key} must be at least {spec.min_val}, got {val}"
-                        )
-                    if spec.max_val is not None and val > spec.max_val:
-                        result.errors.append(
-                            f"[{section}] {key} must be at most {spec.max_val}, got {val}"
-                        )
-
-                elif spec.type == FieldType.ENUM:
-                    if spec.choices and raw.lower() not in [c.lower() for c in spec.choices]:
-                        result.errors.append(
-                            f"[{section}] {key} must be one of {spec.choices}, got \"{raw}\""
-                        )
-
-            except ValueError:
-                is_numeric = spec.type in (FieldType.INT, FieldType.FLOAT)
-                expected = "a number" if is_numeric else spec.type.value
-                result.errors.append(
-                    f"[{section}] {key} must be {expected}, got \"{raw}\""
-                )
+            _validate_scalar(section, key, raw, spec, result)
 
         # Check for unknown keys (typo detection)
         for key in cfg.options(section):
@@ -1267,5 +1332,8 @@ def validate_config(cfg: configparser.ConfigParser) -> ValidationResult:
                 result.warnings.append(
                     f"[{section}] unknown key '{key}' — possible typo?"
                 )
+
+    # Vehicle-profile sections: dotted overrides validated against base schema
+    _validate_vehicle_sections(cfg, result)
 
     return result

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -77,6 +77,34 @@ def _build_detector(cfg: configparser.ConfigParser, models_dir: Path | None = No
     return build_detector(cfg, models_dir)
 
 
+def _resolve_post_action_mode(
+    cfg: configparser.ConfigParser,
+    vehicle_type: str | None,
+    action: str,
+) -> str | None:
+    """Resolve the configured post-action flight mode for drop/strike.
+
+    Fixed-wing collapses drop and strike under a single post_action_mode
+    (no hover-to-drop or terminal dive on FW). Other vehicle types use the
+    per-action keys. Returns None when the key is absent or empty, which
+    disables the post-action transition.
+
+    These keys arrive in [autonomous] after the vehicle-profile merge in
+    Pipeline.__init__ — e.g. [vehicle.drone] autonomous.post_drop_mode
+    becomes [autonomous] post_drop_mode before this runs.
+    """
+    if vehicle_type == "fw":
+        key = "post_action_mode"
+    elif action == "drop":
+        key = "post_drop_mode"
+    elif action == "strike":
+        key = "post_strike_mode"
+    else:
+        return None
+    val = cfg.get("autonomous", key, fallback="").strip()
+    return val or None
+
+
 class Pipeline:
     """Top-level orchestrator that ties all modules together."""
 
@@ -455,6 +483,13 @@ class Pipeline:
                     "approach", "abort_mode", fallback="LOITER"),
                 waypoint_interval=self._cfg.getfloat(
                     "approach", "waypoint_interval", fallback=0.5),
+                # Post-action mode hooks — resolved after the vehicle-profile
+                # merge. Fixed-wing unifies both actions under
+                # post_action_mode; other vehicles use per-action keys.
+                post_drop_mode=_resolve_post_action_mode(
+                    self._cfg, self._vehicle, "drop"),
+                post_strike_mode=_resolve_post_action_mode(
+                    self._cfg, self._vehicle, "strike"),
                 guidance_cfg=GuidanceConfig(
                     fwd_gain=self._cfg.getfloat("guidance", "fwd_gain", fallback=2.0),
                     lat_gain=self._cfg.getfloat("guidance", "lat_gain", fallback=1.5),

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -480,6 +480,83 @@ class TestFallbackAlignment:
 
 
 # ---------------------------------------------------------------------------
+# Vehicle-profile prefix-aware validation
+# ---------------------------------------------------------------------------
+
+class TestVehicleSectionValidation:
+    """[vehicle.*] sections validate dotted overrides against base schema."""
+
+    def _base(self) -> configparser.ConfigParser:
+        cfg = _valid_config()
+        return cfg
+
+    def test_valid_dotted_override_accepted(self):
+        cfg = self._base()
+        cfg.add_section("vehicle.drone")
+        cfg.set("vehicle.drone", "camera.source", "/dev/video2")
+        cfg.set("vehicle.drone", "camera.fps", "15")
+        cfg.set("vehicle.drone", "reserved_channels", "1,2,3,4")
+        result = validate_config(cfg)
+        assert result.ok, f"unexpected errors: {result.errors}"
+        # No warnings about the three keys above
+        bad = [w for w in result.warnings if "[vehicle.drone]" in w]
+        assert not bad, f"unexpected warnings: {bad}"
+
+    def test_unknown_base_section_warns(self):
+        cfg = self._base()
+        cfg.add_section("vehicle.drone")
+        cfg.set("vehicle.drone", "camara.source", "/dev/video2")  # typo
+        result = validate_config(cfg)
+        matched = [w for w in result.warnings if "camara.source" in w]
+        assert matched, f"expected warning for typo; got {result.warnings}"
+        assert "unknown base section" in matched[0]
+
+    def test_unknown_key_in_base_section_warns(self):
+        cfg = self._base()
+        cfg.add_section("vehicle.drone")
+        cfg.set("vehicle.drone", "camera.sauce", "/dev/video2")  # typo
+        result = validate_config(cfg)
+        matched = [w for w in result.warnings if "camera.sauce" in w]
+        assert matched, f"expected warning for key typo; got {result.warnings}"
+        assert "no key 'sauce'" in matched[0]
+
+    def test_non_dotted_unknown_key_warns(self):
+        cfg = self._base()
+        cfg.add_section("vehicle.drone")
+        cfg.set("vehicle.drone", "mystery_key", "42")
+        result = validate_config(cfg)
+        matched = [w for w in result.warnings if "mystery_key" in w]
+        assert matched, f"expected warning; got {result.warnings}"
+
+    def test_reserved_channels_accepted_as_local_key(self):
+        cfg = self._base()
+        cfg.add_section("vehicle.drone")
+        cfg.set("vehicle.drone", "reserved_channels", "1,2,3,4")
+        result = validate_config(cfg)
+        matched = [w for w in result.warnings
+                   if "reserved_channels" in w and "[vehicle.drone]" in w]
+        assert not matched, f"reserved_channels should not warn; got {matched}"
+
+    def test_out_of_range_override_errors(self):
+        cfg = self._base()
+        cfg.add_section("vehicle.drone")
+        cfg.set("vehicle.drone", "camera.width", "99999")  # > max 3840
+        result = validate_config(cfg)
+        matched = [e for e in result.errors
+                   if "[vehicle.drone]" in e and "camera.width" in e]
+        assert matched, f"expected error; got {result.errors}"
+
+    def test_vehicle_fw_still_uses_main_validator(self):
+        """vehicle.fw has explicit schema — _validate_vehicle_sections skips it."""
+        cfg = self._base()
+        cfg.add_section("vehicle.fw")
+        cfg.set("vehicle.fw", "autonomous.post_action_mode", "LOITER")
+        cfg.set("vehicle.fw", "autonomous.min_track_frames", "2")
+        result = validate_config(cfg)
+        assert result.ok, f"unexpected errors: {result.errors}"
+
+
+# ---------------------------------------------------------------------------
 # Property-based tests via hypothesis
 # ---------------------------------------------------------------------------
 

--- a/tests/test_drop_strike.py
+++ b/tests/test_drop_strike.py
@@ -113,6 +113,52 @@ class TestDropMode:
         ctrl.update(None, 640, 480)
         assert ctrl.drop_complete is False
 
+    def test_post_drop_mode_transitions_on_release(self):
+        """When post_drop_mode is set, set_mode is called and controller idles."""
+        ctrl, mav = _make_controller(
+            drop_distance_m=5.0, post_drop_mode="SMART_RTL",
+        )
+        ctrl.start_drop(1, 34.05, -118.25)
+
+        mav.get_lat_lon.return_value = (34.05, -118.25, 10.0)
+        mav.set_mode.reset_mock()
+        ctrl.update(None, 640, 480)
+
+        mav.set_mode.assert_called_once_with("SMART_RTL")
+        assert ctrl.drop_complete is True
+        assert ctrl.mode == ApproachMode.IDLE
+
+    def test_no_post_drop_mode_keeps_controller_in_drop(self):
+        """Without post_drop_mode the controller preserves prior behavior."""
+        ctrl, mav = _make_controller(drop_distance_m=5.0)
+        ctrl.start_drop(1, 34.05, -118.25)
+
+        mav.get_lat_lon.return_value = (34.05, -118.25, 10.0)
+        mav.set_mode.reset_mock()
+        ctrl.update(None, 640, 480)
+
+        mav.set_mode.assert_not_called()
+        assert ctrl.drop_complete is True
+        assert ctrl.mode == ApproachMode.DROP
+
+    def test_post_drop_mode_rejected_still_idles(self):
+        """Autopilot rejecting the mode doesn't leave the controller wedged in DROP."""
+        ctrl, mav = _make_controller(
+            drop_distance_m=5.0, post_drop_mode="INVALID_MODE",
+        )
+        ctrl.start_drop(1, 34.05, -118.25)
+
+        mav.get_lat_lon.return_value = (34.05, -118.25, 10.0)
+        mav.set_mode.return_value = False
+        ctrl.update(None, 640, 480)
+
+        mav.set_mode.assert_called_once_with("INVALID_MODE")
+        assert ctrl.drop_complete is True
+        # Operator's intent was to leave DROP — idle locally even if the
+        # autopilot rejected the requested mode. A stuck-in-DROP controller
+        # would keep trying to fire the already-released servo.
+        assert ctrl.mode == ApproachMode.IDLE
+
 
 # ---------------------------------------------------------------------------
 # Strike mode


### PR DESCRIPTION
## Summary

Two deferred items from the #132 config audit.

### 1. `post_drop_mode` wired end-to-end
- `ApproachConfig` gains `post_drop_mode` / `post_strike_mode` fields.
- `approach._update_drop` calls `mavlink.set_mode(post_drop_mode)` after the servo fires, then idles the controller. Empty/missing value preserves prior behavior.
- `facade._resolve_post_action_mode` picks the right key by vehicle type — fixed-wing uses the unified `post_action_mode`, multirotor/rover/USV use per-action keys. Keys flow through the vehicle-profile merge (`[vehicle.drone] autonomous.post_drop_mode` → `[autonomous] post_drop_mode`) so nothing else had to change.
- `post_strike_mode` / `post_action_mode` are loaded and plumbed but **not** auto-triggered — inventing a "strike complete" detector touches live vehicle control and warrants its own PR.

### 2. `[vehicle.*]` prefix-aware validation
Previously `[vehicle.drone|usv|ugv]` sections were silently skipped by the validator since they're not in `SCHEMA`. A typo like `camara.source = /dev/video2` would merge into a non-existent base section and silently disappear.

- New `_validate_vehicle_sections()` iterates `[vehicle.*]` sections that aren't in SCHEMA, splits dotted keys, and validates against the base section's `FieldSpec`.
- Typos like `camara.source` → warn "unknown base section". Typos like `camera.sauce` → warn "no key 'sauce' in [camera] schema". Out-of-range values on dotted overrides → error.
- `reserved_channels` whitelisted as the only non-dotted vehicle-local key.
- Per-field type checking extracted into `_validate_scalar()` so both validators share one implementation.
- `vehicle.fw` keeps its explicit SCHEMA entry and takes the main-loop path unchanged.

### Housekeeping
- Deleted merged branch `claude/clarify-task-xu1Xm`.

## Test plan

- [x] `pytest tests/test_drop_strike.py` → 27 passed (3 new)
- [x] `pytest tests/test_config_schema.py` → 71 passed (7 new)
- [x] `pytest tests/` full suite → **1770 passed**, 1 skipped
- [x] `flake8 --max-line-length 100 --ignore W503` clean on all edited files
- [ ] On Jetson: `--vehicle drone` with `autonomous.post_drop_mode = SMART_RTL` transitions mode after drop servo fires
- [ ] On Jetson: typo like `camara.source` in config.ini surfaces as a validator warning at boot

https://claude.ai/code/session_01CBDvXHcU5j4EyXGd9n5Qe1