### PR TITLE
preflight: close gaps from field-test readiness audit

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,14 +18,14 @@ sudo docker build -t hydra-detect:latest .
 echo "=== Restarting service ==="
 sudo systemctl restart hydra-detect
 
-echo "=== Waiting for startup (20s) ==="
-sleep 20
+echo "=== Waiting for startup (35s — YOLO model load) ==="
+sleep 35
 
 echo "=== Verifying ==="
-HTTP=$(curl --max-time 3 -s -o /dev/null -w "%{http_code}" http://localhost:8080/stream.jpg)
+HTTP=$(curl --max-time 3 -s -o /dev/null -w "%{http_code}" http://localhost:8080/api/health)
 if [ "$HTTP" = "200" ]; then
-    echo "DEPLOY OK — /stream.jpg returns 200"
+    echo "DEPLOY OK — /api/health returns 200"
 else
-    echo "DEPLOY WARNING — /stream.jpg returned $HTTP"
+    echo "DEPLOY WARNING — /api/health returned $HTTP"
     echo "Check: sudo docker logs hydra-detect --tail 30"
 fi

--- a/scripts/jetson_preflight.sh
+++ b/scripts/jetson_preflight.sh
@@ -94,10 +94,16 @@ fi
 
 check_cmd v4l2-ctl "v4l2-ctl is installed (v4l-utils, needed for analog cameras)"
 
-if [ -e /dev/ttyACM0 ] || [ -e /dev/ttyUSB0 ]; then
-  ok "Telemetry serial device present"
+SERIAL_FOUND=""
+for dev in /dev/ttyTHS1 /dev/ttyTHS2 /dev/ttyACM0 /dev/ttyUSB0; do
+  if [ -e "$dev" ]; then
+    SERIAL_FOUND="${SERIAL_FOUND:+$SERIAL_FOUND, }$dev"
+  fi
+done
+if [ -n "$SERIAL_FOUND" ]; then
+  ok "Telemetry serial device present: $SERIAL_FOUND"
 else
-  warn "No telemetry serial device found (/dev/ttyACM0 or /dev/ttyUSB0)"
+  warn "No telemetry serial device found (checked /dev/ttyTHS1, /dev/ttyTHS2, /dev/ttyACM0, /dev/ttyUSB0)"
 fi
 
 if id -nG | grep -qw dialout; then
@@ -122,6 +128,87 @@ if [ -d "$MODEL_DIR" ] && ls "$MODEL_DIR"/*.pt "$MODEL_DIR"/*.engine "$MODEL_DIR
   ok "Model files found in models/"
 else
   warn "No model files found in models/. Download one: wget -P models https://github.com/ultralytics/assets/releases/download/v8.2.0/yolov8s.pt"
+fi
+
+# Verify fail-safe defaults are set in config.ini (checklist sec 12)
+if [ -r config.ini ]; then
+  fail_safe_ok=1
+  for key in "autonomous.enabled" "rf_homing.enabled"; do
+    section="${key%%.*}"
+    setting="${key#*.}"
+    val="$(awk -v s="[$section]" -v k="$setting" '
+      $0==s {in_s=1; next}
+      /^\[/ {in_s=0}
+      in_s && $0 ~ "^[[:space:]]*"k"[[:space:]]*=" {
+        sub(/^[^=]*=[[:space:]]*/, "")
+        sub(/[[:space:]]*$/, "")
+        print
+        exit
+      }' config.ini 2>/dev/null)"
+    if [ "$val" = "false" ] || [ "$val" = "False" ] || [ "$val" = "0" ] || [ "$val" = "no" ]; then
+      ok "Fail-safe default: [$section] $setting = $val"
+    else
+      warn "Fail-safe default: [$section] $setting = '$val' (expected false)"
+      fail_safe_ok=0
+    fi
+  done
+  drop_ch="$(awk '/^\[drop\]/{in_s=1; next} /^\[/{in_s=0} in_s && /^[[:space:]]*servo_channel[[:space:]]*=/ {sub(/^[^=]*=[[:space:]]*/, ""); sub(/[[:space:]]*$/, ""); print; exit}' config.ini 2>/dev/null)"
+  if [ "$drop_ch" = "0" ]; then
+    ok "Fail-safe default: [drop] servo_channel = 0 (disabled)"
+  else
+    warn "Fail-safe default: [drop] servo_channel = '$drop_ch' (expected 0 if drop disarmed)"
+  fi
+fi
+
+# RTL-SDR dongle (only relevant if RF hunt enabled)
+if command -v rtl_test >/dev/null 2>&1; then
+  if rtl_test -t 2>&1 | grep -qiE "found.*device|tuner"; then
+    ok "RTL-SDR dongle detected"
+  else
+    warn "rtl_test installed but no RTL-SDR dongle responded (skip if not using RF hunt)"
+  fi
+else
+  warn "rtl_test not installed (skip if not using RF hunt; otherwise: sudo apt install rtl-sdr)"
+fi
+
+# Kismet service (only relevant if RF hunt enabled)
+if command -v systemctl >/dev/null 2>&1; then
+  kismet_state="$(systemctl is-active kismet 2>/dev/null || true)"
+  case "$kismet_state" in
+    active) ok "kismet service is active" ;;
+    inactive|failed) warn "kismet service is $kismet_state (skip if not using RF hunt)" ;;
+    *) warn "kismet service status: ${kismet_state:-unknown} (skip if not using RF hunt)" ;;
+  esac
+fi
+
+# Disk space — fail under 1 GB on /, warn under 5 GB
+root_free_kb="$(df --output=avail / 2>/dev/null | tail -1 | tr -d ' ')"
+if [ -n "$root_free_kb" ]; then
+  root_free_gb=$((root_free_kb / 1024 / 1024))
+  if [ "$root_free_kb" -lt 1048576 ]; then
+    fail "Root filesystem free: ${root_free_gb} GB (< 1 GB — clear space before deploy)"
+  elif [ "$root_free_kb" -lt 5242880 ]; then
+    warn "Root filesystem free: ${root_free_gb} GB (< 5 GB recommended)"
+  else
+    ok "Root filesystem free: ${root_free_gb} GB"
+  fi
+fi
+if [ -d output_data ]; then
+  out_free_kb="$(df --output=avail output_data 2>/dev/null | tail -1 | tr -d ' ')"
+  if [ -n "$out_free_kb" ] && [ "$out_free_kb" -lt 1048576 ]; then
+    warn "output_data/ filesystem free: $((out_free_kb / 1024)) MB (< 1 GB — logs may fill quickly)"
+  fi
+fi
+
+# /api/health probe (only if service is already running and curl is available)
+if command -v curl >/dev/null 2>&1; then
+  health_code="$(curl --max-time 2 -s -o /dev/null -w "%{http_code}" http://localhost:8080/api/health 2>/dev/null || true)"
+  health_code="${health_code:-000}"
+  case "$health_code" in
+    200) ok "/api/health responding (200)" ;;
+    000) ;; # service not running — silent (preflight is pre-deploy)
+    *) warn "/api/health returned $health_code (service running but unhealthy?)" ;;
+  esac
 fi
 
 echo


### PR DESCRIPTION
## Summary

Closes 9 gaps surfaced by a field-test readiness audit against `docs/jetson-hardware-testing-checklist.md`. Two files, no behavior changes to the runtime — only deployment + preflight tooling.

### `scripts/jetson_preflight.sh`
- Detect `/dev/ttyTHS1` and `/dev/ttyTHS2` in addition to `ACM/USB` (field UART for Pixhawk TELEM)
- Verify fail-safe defaults in `config.ini`: `[autonomous].enabled`, `[rf_homing].enabled`, `[drop].servo_channel` — checklist sec 12
- RTL-SDR dongle detection via `rtl_test` (warn-only — RF hunt is optional)
- Kismet service status (warn-only — RF hunt is optional)
- Disk-free check on `/` (FAIL < 1 GB, WARN < 5 GB) and `output_data/`
- `/api/health` probe (silent if service not yet running — preflight is pre-deploy)

### `scripts/deploy.sh`
- Bump post-restart sleep `20s → 35s` per CLAUDE.md ("allow ~35 seconds for YOLO model load before health check responds")
- Verify against `/api/health` (canonical, matches Dockerfile `HEALTHCHECK`) instead of `/stream.jpg`

## Audit context

Source report: `/tmp/reports/field_test_readiness_20260421T044745Z.md`. Pre-PR state @ `772daf0`:
- Tests: **1766 + 11 + 4** passed (default + integration + slow markers), 0 failures
- flake8 clean; mypy 158 pre-existing (not a CI gate)
- Safety review of `df763d9..HEAD`: PASS (PR #136 closes the autonomy mode-gate P1 from 04-20 baseline)
- Config schema↔ini parity: OK

Items intentionally **not** added (out of scope for an unattended preflight):
- Docker device passthrough smoke (heavy, requires `docker run`)
- `systemctl restart hydra-detect` 5s port check (disruptive — restarts the service the operator may already be using)
- MAVLink heartbeat smoke (invasive — opens serial; covered by the `mavlink-diag` subagent on real hardware)

## Test plan

- [x] `bash -n scripts/jetson_preflight.sh && bash -n scripts/deploy.sh` — clean
- [x] `bash scripts/jetson_preflight.sh` smoke run on dev host — exits 1 only because of expected non-Jetson FAILs (`nvpmodel`, `tegrastats`, `v4l2-ctl` missing); new checks all behave correctly (fail-safe defaults PASS, `/api/health` silent on no-service, disk PASS, RTL/kismet WARN-only)
- [x] `python scripts/check_config_consistency.py` — OK (188 fields, 20 sections aligned)
- [x] `flake8 hydra_detect/ tests/` — clean
- [x] Full pytest sweep pre-change — 1781 passed total, no regressions expected (no Python touched)
- [ ] Run `bash scripts/jetson_preflight.sh` on actual Jetson before next sortie — confirm new checks PASS for fail-safe defaults and `/dev/ttyTHS1` is detected
- [ ] Run `bash scripts/deploy.sh` on actual Jetson — confirm `/api/health` returns 200 within 35s