### PR TITLE
ui: broad polish pass — setup wizard TAK fields, CSP fixes, control ABORT, error paths

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -327,6 +327,12 @@ curl -sX POST <HOST>/api/autonomy/mode -d '{"mode":"shadow"}' \
 ### `POST /api/tak/toggle`
 **Auth:** bearer · `{"enabled": true|false}`.
 
+### `POST /api/tak/test_broadcast`
+**Auth:** bearer · Force an immediate self-SA emit so operators can verify
+TAK wiring before a sortie. Returns `{success, reason, callsign, destinations}`.
+503 if TAK output is not initialized; `success: false` with `reason` if the
+sender thread is stopped or the MAVLink has no GPS fix.
+
 ### `GET /api/tak/commands?limit=N`
 **Auth:** same-origin · Inbound GeoChat command feed.
 `limit` default 100, capped at 500. Shape:

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -92,7 +92,12 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             min_val=10.0,
             max_val=180.0,
             default=60.0,
-            description="Horizontal FOV degrees",
+            description=(
+                "Camera horizontal field of view in degrees. Wrong value "
+                "here causes bad target-position geo-estimates. Typical: "
+                "60 for USB webcams, 120 for FPV / analog cameras, "
+                "90 for wide-angle action cams."
+            ),
         ),
         "video_standard": FieldSpec(
             FieldType.ENUM,
@@ -120,12 +125,19 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             min_val=32,
             max_val=1280,
             default=640,
-            description="Inference resolution",
+            description=(
+                "Inference resolution in pixels. Lower = faster + less "
+                "accurate, higher = slower + more accurate. Multiples of 32 "
+                "only. Leave blank to let YOLO auto-select from the model."
+            ),
         ),
         "yolo_classes": FieldSpec(
             FieldType.STRING,
             default="",
-            description="Comma-separated class IDs to detect",
+            description=(
+                "Comma-separated class IDs to detect (e.g. '0,2,5'). "
+                "Leave blank to use every class the model was trained on."
+            ),
         ),
         "low_light_luminance": FieldSpec(
             FieldType.FLOAT,
@@ -141,7 +153,11 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             min_val=0.0,
             max_val=1.0,
             default=0.5,
-            description="Track confidence threshold",
+            description=(
+                "ByteTrack high-confidence threshold. Detections below "
+                "this still track but only if they match an existing track. "
+                "Must be >= detector.yolo_confidence or no new tracks form."
+            ),
         ),
         "track_buffer": FieldSpec(
             FieldType.INT,
@@ -163,7 +179,11 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
         "connection_string": FieldSpec(
             FieldType.STRING,
             default="/dev/ttyTHS1",
-            description="Serial port or UDP address",
+            description=(
+                "Serial port (e.g. /dev/ttyTHS1, /dev/ttyACM0) or UDP "
+                "endpoint (e.g. udp:127.0.0.1:14550, udpin:0.0.0.0:14550). "
+                "Check wiring with `ls /dev/tty*`."
+            ),
         ),
         "baud": FieldSpec(
             FieldType.INT,

--- a/hydra_detect/tak/tak_output.py
+++ b/hydra_detect/tak/tak_output.py
@@ -81,6 +81,10 @@ class TAKOutput:
         self._last_sa = 0.0
         self._last_video = 0.0
         self._events_sent = 0
+        # Last _send_cot failure list — populated on every send attempt,
+        # read by send_test_beacon() so a failed preflight returns the
+        # concrete reason (e.g. "mcast 239.2.3.1:6969 (network unreachable)").
+        self._last_send_failures: list[str] = []
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -203,7 +207,7 @@ class TAKOutput:
                 "destinations": [],
             }
         try:
-            self._send_self_sa()
+            sent = self._send_self_sa()
         except OSError as e:
             return {
                 "success": False,
@@ -215,6 +219,17 @@ class TAKOutput:
         with self._data_lock:
             for host, port in self._unicast_targets:
                 destinations.append(f"udp://{host}:{port}")
+        if not sent:
+            # _send_cot catches OSError internally — surface whatever it
+            # last recorded so the operator sees the real reason instead
+            # of a false-positive "Self-SA emitted".
+            failures = ", ".join(self._last_send_failures) or "all sends failed"
+            return {
+                "success": False,
+                "reason": f"No destination accepted the packet: {failures}",
+                "callsign": self._callsign,
+                "destinations": destinations,
+            }
         return {
             "success": True,
             "reason": "Self-SA emitted",
@@ -251,10 +266,13 @@ class TAKOutput:
                     if ts > cutoff
                 }
 
-    def _send_self_sa(self) -> None:
+    def _send_self_sa(self) -> bool:
+        """Build + emit a self-SA CoT. Returns True if at least one
+        destination accepted it, False otherwise (including the no-GPS
+        case so the caller can distinguish)."""
         lat, lon, alt = self._mav.get_lat_lon()
         if lat is None or lon is None:
-            return
+            return False
         heading = self._mav.get_heading_deg()
         telem = self._mav.get_telemetry()
         speed = telem.get("groundspeed")
@@ -267,7 +285,7 @@ class TAKOutput:
             speed=speed,
             stale_seconds=self._stale_sa,
         )
-        self._send_cot(data)
+        return self._send_cot(data)
 
     def _send_video_feed(self) -> None:
         lat, lon, alt = self._mav.get_lat_lon()
@@ -341,17 +359,30 @@ class TAKOutput:
         """
         self._send_cot(data)
 
-    def _send_cot(self, data: bytes) -> None:
-        """Send CoT XML to all configured destinations."""
+    def _send_cot(self, data: bytes) -> bool:
+        """Send CoT XML to all configured destinations.
+
+        Returns True if at least one destination accepted the packet; False
+        if every send errored (or there is no socket / no destinations).
+        The sender loop does not inspect the return value — callers like
+        send_test_beacon() use it to tell the operator whether the force
+        emit actually went out.
+        """
         if self._sock is None:
-            return
+            return False
+        any_ok = False
+        failures: list[str] = []
         # Multicast
         if self._mcast_group:
             try:
                 self._sock.sendto(data, (self._mcast_group, self._mcast_port))
                 self._events_sent += 1
+                any_ok = True
             except OSError as exc:
                 logger.debug("TAK multicast send failed: %s", exc)
+                failures.append(
+                    f"mcast {self._mcast_group}:{self._mcast_port} ({exc})"
+                )
         # Unicast targets — copy under lock to avoid concurrent mutation
         with self._data_lock:
             unicast_snapshot = list(self._unicast_targets)
@@ -359,5 +390,13 @@ class TAKOutput:
             try:
                 self._sock.sendto(data, (host, port))
                 self._events_sent += 1
+                any_ok = True
             except OSError as exc:
                 logger.debug("TAK unicast send to %s:%d failed: %s", host, port, exc)
+                failures.append(f"{host}:{port} ({exc})")
+        # Remember last failure detail so send_test_beacon can surface it.
+        if failures:
+            self._last_send_failures = failures
+        else:
+            self._last_send_failures = []
+        return any_ok

--- a/hydra_detect/tak/tak_output.py
+++ b/hydra_detect/tak/tak_output.py
@@ -179,6 +179,49 @@ class TAKOutput:
         with self._data_lock:
             return [{"host": h, "port": p} for h, p in self._unicast_targets]
 
+    def send_test_beacon(self) -> dict:
+        """Force an immediate self-SA emit and report the result.
+
+        Used by the TAK tab's "Test Broadcast" button so operators can
+        verify end-to-end wiring before a field sortie without having to
+        wait on the 5 s SA cadence. Returns a dict with:
+            success (bool), reason (str), callsign, destinations (list[str]).
+        """
+        if not self.is_running():
+            return {
+                "success": False,
+                "reason": "TAK output is not running",
+                "callsign": self._callsign,
+                "destinations": [],
+            }
+        lat, lon, _ = self._mav.get_lat_lon()
+        if lat is None or lon is None:
+            return {
+                "success": False,
+                "reason": "No GPS fix — self-SA needs a position",
+                "callsign": self._callsign,
+                "destinations": [],
+            }
+        try:
+            self._send_self_sa()
+        except OSError as e:
+            return {
+                "success": False,
+                "reason": f"Socket error: {e}",
+                "callsign": self._callsign,
+                "destinations": [],
+            }
+        destinations = [f"mcast://{self._mcast_group}:{self._mcast_port}"]
+        with self._data_lock:
+            for host, port in self._unicast_targets:
+                destinations.append(f"udp://{host}:{port}")
+        return {
+            "success": True,
+            "reason": "Self-SA emitted",
+            "callsign": self._callsign,
+            "destinations": destinations,
+        }
+
     # ------------------------------------------------------------------
     # Sender thread
     # ------------------------------------------------------------------

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -2153,6 +2153,40 @@ async def api_tak_toggle(request: Request, authorization: Optional[str] = Header
     return JSONResponse({"error": "TAK output not available"}, status_code=503)
 
 
+@app.post("/api/tak/test_broadcast")
+async def api_tak_test_broadcast(
+    request: Request, authorization: Optional[str] = Header(None)
+):
+    """Force an immediate TAK self-SA emit so operators can verify wiring.
+
+    Useful before a demo or field sortie: click once, watch for the marker
+    to appear in ATAK. Returns destination list + reason string. Requires
+    the TAK sender thread to be running and MAVLink to have a GPS fix.
+    """
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+    if _tak_output_ref is None:
+        return JSONResponse(
+            {
+                "success": False,
+                "reason": "TAK output is not initialized",
+                "destinations": [],
+            },
+            status_code=503,
+        )
+    try:
+        result = _tak_output_ref.send_test_beacon()
+    except Exception as e:
+        logger.exception("TAK test broadcast failed: %s", e)
+        return JSONResponse(
+            {"success": False, "reason": f"Unexpected error: {e}", "destinations": []},
+            status_code=500,
+        )
+    _audit(request, "tak_test_broadcast", target=str(result.get("success")))
+    return result
+
+
 @app.get("/api/stream/quality")
 async def get_stream_quality():
     """Return current MJPEG stream quality."""
@@ -3168,9 +3202,34 @@ async def setup_page(request: Request):
     return templates.TemplateResponse(request, "setup.html")
 
 
+def _detect_lan_ip() -> str:
+    """Return the Jetson's outbound LAN IP, or empty string if undetectable.
+
+    Opens a UDP socket to a routable external address (no packet is sent)
+    and reads back the interface the kernel chose. Handles offline / no-route
+    gracefully — no exception propagates.
+    """
+    import socket as _socket
+    sock = None
+    try:
+        sock = _socket.socket(_socket.AF_INET, _socket.SOCK_DGRAM)
+        sock.settimeout(0.2)
+        sock.connect(("8.8.8.8", 80))
+        ip = sock.getsockname()[0]
+        return ip if ip and ip != "0.0.0.0" else ""
+    except OSError:
+        return ""
+    finally:
+        if sock is not None:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+
 @app.get("/api/setup/devices")
 async def api_setup_devices():
-    """List available cameras and serial ports for setup wizard."""
+    """List available cameras, serial ports, and LAN IP for setup wizard."""
     import glob
     cameras = []
     serial_ports = []
@@ -3184,7 +3243,11 @@ async def api_setup_devices():
         if any(prefix in dev for prefix in ["ttyACM", "ttyUSB", "ttyTHS", "ttyAMA"]):
             serial_ports.append({"path": dev, "name": dev})
 
-    return {"cameras": cameras, "serial_ports": serial_ports}
+    return {
+        "cameras": cameras,
+        "serial_ports": serial_ports,
+        "lan_ip": _detect_lan_ip(),
+    }
 
 
 @app.post("/api/setup/save")
@@ -3212,11 +3275,17 @@ async def api_setup_save(request: Request, authorization: Optional[str] = Header
     vehicle_type = body.get("vehicle_type", "")
     team_number = body.get("team_number", "")
     callsign = body.get("callsign", "")
+    tak_advertise_host = body.get("tak_advertise_host", "")
+    tak_allowed_callsigns = body.get("tak_allowed_callsigns", "")
+    tak_enabled = body.get("tak_enabled", None)  # None = don't touch existing value
 
     # Validate field types before length checks
-    for field in [camera_source, serial_port, vehicle_type, team_number, callsign]:
+    for field in [camera_source, serial_port, vehicle_type, team_number,
+                  callsign, tak_advertise_host, tak_allowed_callsigns]:
         if not isinstance(field, str):
-            return JSONResponse({"error": "All fields must be strings"}, status_code=400)
+            return JSONResponse({"error": "All string fields must be strings"}, status_code=400)
+    if tak_enabled is not None and not isinstance(tak_enabled, bool):
+        return JSONResponse({"error": "tak_enabled must be bool"}, status_code=400)
 
     # Validate inputs — bounded lengths
     if len(camera_source) > 200:
@@ -3229,6 +3298,10 @@ async def api_setup_save(request: Request, authorization: Optional[str] = Header
         return JSONResponse({"error": "team_number too long"}, status_code=400)
     if len(callsign) > 50:
         return JSONResponse({"error": "callsign too long"}, status_code=400)
+    if len(tak_advertise_host) > 253:
+        return JSONResponse({"error": "tak_advertise_host too long"}, status_code=400)
+    if len(tak_allowed_callsigns) > 500:
+        return JSONResponse({"error": "tak_allowed_callsigns too long"}, status_code=400)
     if vehicle_type and vehicle_type not in ("drone", "usv", "ugv", "fw"):
         return JSONResponse(
             {"error": "vehicle_type must be drone, usv, ugv, or fw"},
@@ -3244,8 +3317,23 @@ async def api_setup_save(request: Request, authorization: Optional[str] = Header
         "camera": {"source": camera_source},
         "mavlink": {"connection_string": serial_port},
     }
+    tak_updates: dict[str, str] = {}
     if callsign:
-        updates["tak"] = {"callsign": callsign}
+        tak_updates["callsign"] = callsign
+    if tak_enabled is not None:
+        tak_updates["enabled"] = "true" if tak_enabled else "false"
+        # Inbound commands gate off the same toggle by default — students
+        # who enable TAK expect GeoChat commands to work if they populate
+        # an allowlist. Explicit separate toggle still lives in Settings.
+        tak_updates["listen_commands"] = "true" if tak_enabled else "false"
+    if tak_advertise_host:
+        tak_updates["advertise_host"] = tak_advertise_host
+    # Always write allowed_callsigns (including empty string) so the wizard
+    # can clear a stale allowlist on re-run.
+    if "tak_allowed_callsigns" in body:
+        tak_updates["allowed_callsigns"] = tak_allowed_callsigns
+    if tak_updates:
+        updates["tak"] = tak_updates
 
     field_errors = validate_config_updates(updates)
     if field_errors:

--- a/hydra_detect/web/static/css/config.css
+++ b/hydra_detect/web/static/css/config.css
@@ -630,6 +630,14 @@ body.view-config #view-config {
     margin-top: var(--s-2);
 }
 
+/* Panel-header trailing badge (e.g. mission badge, RF state badge).
+   Pushes the badge to the right of the header row, leaving room for
+   the collapse chevron after it. */
+.panel-header-badge {
+    margin-left: auto;
+    margin-right: var(--s-2);
+}
+
 /* Empty-state placeholders rendered from JS (detection log, TAK list). */
 .panel-det-empty {
     color: var(--text-dim);

--- a/hydra_detect/web/static/css/config.css
+++ b/hydra_detect/web/static/css/config.css
@@ -612,6 +612,24 @@ body.view-config #view-config {
     margin-bottom: var(--s-1);
 }
 
+/* Reusable inline rows inside a panel-field. Replaces repeated
+   style="display:flex;align-items:center;gap:8px" wrappers. */
+.panel-row-inline {
+    display: flex;
+    align-items: center;
+    gap: var(--s-2);
+}
+.panel-row-inline-tight {
+    display: flex;
+    align-items: center;
+    gap: var(--s-1);
+}
+.panel-row-btns {
+    display: flex;
+    gap: var(--s-2);
+    margin-top: var(--s-2);
+}
+
 .btn-sm {
     font-size: var(--font-xs) !important;
     padding: 3px 8px !important;

--- a/hydra_detect/web/static/css/config.css
+++ b/hydra_detect/web/static/css/config.css
@@ -630,6 +630,39 @@ body.view-config #view-config {
     margin-top: var(--s-2);
 }
 
+/* Empty-state placeholders rendered from JS (detection log, TAK list). */
+.panel-det-empty {
+    color: var(--text-dim);
+    font-size: var(--font-sm);
+    padding: var(--s-2);
+    text-align: center;
+}
+.panel-tak-target-empty {
+    color: var(--text-dim);
+    font-size: var(--font-xs);
+    padding: 2px 0;
+}
+
+/* TAK unicast target list rows. */
+.panel-tak-target-row {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 0;
+}
+.panel-tak-target-addr {
+    font-size: var(--font-xs);
+    color: var(--text-dim);
+    flex: 1;
+}
+.panel-tak-target-del {
+    color: var(--danger);
+    border-color: var(--danger);
+    padding: 0 4px;
+    min-width: 0;
+    line-height: 1.2;
+}
+
 .btn-sm {
     font-size: var(--font-xs) !important;
     padding: 3px 8px !important;

--- a/hydra_detect/web/static/css/ops.css
+++ b/hydra_detect/web/static/css/ops.css
@@ -733,6 +733,20 @@ body.view-ops #view-ops {
     padding: 6px 14px !important;
 }
 
+/* Confirm-overlay target description (track id + label). */
+.ops-confirm-desc {
+    font-family: var(--font-mono);
+    font-size: var(--font-sm);
+    color: var(--text-dim);
+    margin-bottom: var(--s-3);
+}
+
+/* Drop confirm button — amber to distinguish from red strike. */
+.ops-confirm-actions .btn-confirm-drop {
+    background: var(--warning);
+    color: #fff;
+}
+
 /* ── Touch targets ── */
 @media (pointer: coarse) {
     .ops-action-btn {

--- a/hydra_detect/web/static/css/settings.css
+++ b/hydra_detect/web/static/css/settings.css
@@ -201,6 +201,30 @@
     margin-left: 4px;
 }
 
+/* Persistent help text rendered below each field from schema description.
+   Spans both grid columns so it reads as a caption under the input. */
+.settings-field-help {
+    grid-column: 1 / -1;
+    font-family: var(--font-sans, 'Barlow', sans-serif);
+    font-size: var(--font-xs);
+    color: var(--text-dim);
+    line-height: 1.4;
+    margin-top: 2px;
+    padding-left: 0;
+}
+
+/* Apply button — highlight when there are unsaved changes so students can
+   tell at a glance whether they have pending edits. */
+.btn.btn-green.has-unsaved {
+    box-shadow: 0 0 0 2px var(--warning, #c8a94a), 0 0 12px rgba(200, 169, 74, 0.35);
+    animation: settings-apply-pulse 1.6s ease-in-out infinite;
+}
+
+@keyframes settings-apply-pulse {
+    0%, 100% { box-shadow: 0 0 0 2px var(--warning, #c8a94a), 0 0 12px rgba(200, 169, 74, 0.35); }
+    50%      { box-shadow: 0 0 0 2px var(--warning, #c8a94a), 0 0 20px rgba(200, 169, 74, 0.55); }
+}
+
 .settings-field input,
 .settings-field select,
 .settings-field textarea {

--- a/hydra_detect/web/static/css/tak.css
+++ b/hydra_detect/web/static/css/tak.css
@@ -63,6 +63,32 @@ body.view-tak #mjpeg-stream {
     color: var(--text-secondary);
     margin-left: auto;
 }
+/* Test-broadcast action — sits at the right edge of the map header so
+   operators can verify TAK wiring without leaving the view. */
+.tak-map-action {
+    background: transparent;
+    border: 1px solid var(--border-default);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    padding: 3px 10px;
+    border-radius: var(--radius);
+    cursor: pointer;
+    transition: background 0.12s, border-color 0.12s;
+}
+.tak-map-action:hover:not(:disabled) {
+    background: var(--bg-panel);
+    border-color: var(--olive-muted);
+    color: var(--text-primary);
+}
+.tak-map-action:disabled,
+.tak-map-action.is-busy {
+    opacity: 0.6;
+    cursor: wait;
+}
 .tak-map-canvas {
     flex: 1;
     min-height: 300px;

--- a/hydra_detect/web/static/js/api/client.js
+++ b/hydra_detect/web/static/js/api/client.js
@@ -40,12 +40,25 @@ window.HydraModules.createApiClient = function createApiClient({ store, toast, p
             }
             const data = await resp.json();
             if (!resp.ok) {
-                toast.showToast(data.error || `Request failed (${resp.status})`);
+                // Surface validation field_errors inline so the user knows
+                // which field is wrong instead of a generic "Validation
+                // failed" toast that sends them hunting through 70+ fields.
+                let msg = data.error || `Request failed (${resp.status})`;
+                if (data.field_errors && typeof data.field_errors === 'object') {
+                    const parts = Object.entries(data.field_errors)
+                        .map(([k, v]) => `${k}: ${v}`);
+                    if (parts.length > 0) {
+                        msg = (data.error ? data.error + ' — ' : '') +
+                              parts.slice(0, 4).join('; ') +
+                              (parts.length > 4 ? ` (+${parts.length - 4} more)` : '');
+                    }
+                }
+                toast.showToast(msg, 'error');
                 return null;
             }
             return data;
         } catch (e) {
-            toast.showToast('Network error — check connection');
+            toast.showToast('Network error — check connection', 'error');
             return null;
         }
     }

--- a/hydra_detect/web/static/js/config.js
+++ b/hydra_detect/web/static/js/config.js
@@ -733,7 +733,6 @@ const HydraOperations = (() => {
                 const empty = document.createElement('div');
                 empty.className = 'panel-det-empty';
                 empty.textContent = 'No detections yet';
-                empty.style.cssText = 'color:var(--text-dim);font-size:var(--font-sm);padding:8px;text-align:center;';
                 log.appendChild(empty);
             }
             return;
@@ -1442,7 +1441,7 @@ const HydraOperations = (() => {
         const targets = (data && data.targets) ? data.targets : [];
         if (targets.length === 0) {
             const empty = document.createElement('div');
-            empty.style.cssText = 'color:var(--text-dim);font-size:var(--font-xs);padding:2px 0;';
+            empty.className = 'panel-tak-target-empty';
             empty.textContent = 'No unicast targets';
             list.appendChild(empty);
             return;
@@ -1450,14 +1449,12 @@ const HydraOperations = (() => {
         for (const t of targets) {
             const addr = (typeof t === 'string') ? t : (t.host + ':' + t.port);
             const row = document.createElement('div');
-            row.style.cssText = 'display:flex;align-items:center;gap:4px;padding:2px 0;';
+            row.className = 'panel-tak-target-row';
             const label = document.createElement('span');
-            label.className = 'mono';
-            label.style.cssText = 'font-size:var(--font-xs);color:var(--text-dim);flex:1;';
+            label.className = 'mono panel-tak-target-addr';
             label.textContent = addr;
             const delBtn = document.createElement('button');
-            delBtn.className = 'btn btn-sm';
-            delBtn.style.cssText = 'color:var(--danger);border-color:var(--danger);padding:0 4px;min-width:0;line-height:1.2;';
+            delBtn.className = 'btn btn-sm panel-tak-target-del';
             delBtn.textContent = '\u00D7';
             delBtn.title = 'Remove ' + addr;
             delBtn.addEventListener('click', () => removeTAKTarget(addr));

--- a/hydra_detect/web/static/js/control.js
+++ b/hydra_detect/web/static/js/control.js
@@ -44,6 +44,21 @@
         return !!apiToken;
     }
 
+    // In-page toast replaces native alert() so feedback matches the ops
+    // theme and doesn't block the operator with a modal on a tablet.
+    var toastEl = document.getElementById('action-toast');
+    var toastTimer = null;
+    function showToast(msg, type) {
+        if (!toastEl) return;
+        toastEl.textContent = msg;
+        toastEl.classList.toggle('error', type === 'error');
+        toastEl.classList.add('show');
+        if (toastTimer) clearTimeout(toastTimer);
+        toastTimer = setTimeout(function() {
+            toastEl.classList.remove('show');
+        }, 3500);
+    }
+
     function handleActionAuthFailure(resp) {
         if (resp && resp.status === 401 && resp.headers.get('x-login-required')) {
             window.location.href = '/login';
@@ -51,7 +66,7 @@
         }
         if (resp && (resp.status === 401 || resp.status === 403)) {
             if (!promptForToken()) {
-                alert('Authentication required for control actions.');
+                showToast('Authentication required for control actions.', 'error');
                 return 'stop';
             }
             return 'retry';
@@ -185,7 +200,42 @@
     }
 
     function doUnlock() {
-        apiPost('/api/target/unlock', {}).then(poll);
+        apiPost('/api/target/unlock', {}).then(function(result) {
+            if (result === null) {
+                showToast('Unlock failed — check connection or token.', 'error');
+            }
+            poll();
+        });
+    }
+
+    // Always-visible ABORT — cancels every approach mode and restores the
+    // pre-approach vehicle mode. POST /api/abort is unauthenticated by
+    // design so the operator can always reach it in an emergency.
+    var abortBtn = document.getElementById('control-abort');
+    if (abortBtn) {
+        abortBtn.addEventListener('click', function() {
+            // Visual feedback immediately — the fetch is fire-and-forget
+            // safety-wise; the dashboard + platform will reflect state.
+            abortBtn.classList.remove('header-abort-flash');
+            void abortBtn.offsetWidth;
+            abortBtn.classList.add('header-abort-flash');
+            fetch('/api/abort', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({}),
+            })
+                .then(function(r) {
+                    if (r.ok) {
+                        showToast('ABORT sent — platform returning to safe state.');
+                    } else {
+                        showToast('ABORT request failed (HTTP ' + r.status + ').', 'error');
+                    }
+                })
+                .catch(function() {
+                    showToast('ABORT request failed — network error.', 'error');
+                })
+                .finally(function() { poll(); });
+        });
     }
 
     function getConfirmFocusable() {

--- a/hydra_detect/web/static/js/demo.js
+++ b/hydra_detect/web/static/js/demo.js
@@ -45,6 +45,24 @@ const HydraDemo = (() => {
         resetFeedImg();
         startStatsPoll();
         startPeersPoll();
+        updateTakMetaOnce();
+    }
+
+    // One-shot fetch to set the mini-TAK header meta (multicast group:port)
+    // from the live TAK status. Previously hardcoded to a fake TAK-server
+    // hostname which would confuse any operator asking what it meant.
+    async function updateTakMetaOnce() {
+        const el = document.getElementById('demo-takmini-meta');
+        if (!el) return;
+        try {
+            const resp = await fetch('/api/tak/status', { credentials: 'same-origin' });
+            if (!resp.ok) return;
+            const data = await resp.json();
+            const mcast = data && typeof data.multicast === 'string' ? data.multicast : '';
+            if (mcast) el.textContent = mcast + ' · multicast';
+        } catch (err) {
+            // Swallow — the hardcoded 239.2.3.1:6969 label is a fine fallback.
+        }
     }
 
     function onLeave() {

--- a/hydra_detect/web/static/js/instructor.js
+++ b/hydra_detect/web/static/js/instructor.js
@@ -72,7 +72,7 @@
 
         if (alertFeed.length === 0) {
             const placeholder = document.createElement('div');
-            placeholder.style.cssText = 'color:#888;font-size:12px;';
+            placeholder.className = 'alert-feed-placeholder';
             placeholder.textContent = 'No alerts yet';
             el.appendChild(placeholder);
             return;
@@ -176,7 +176,12 @@
 
     async function abortVehicle(host) {
         try {
-            const resp = await fetch('http://' + host + ':8080/api/abort', {method: 'POST'});
+            // 5 s timeout — an unreachable platform must fail fast so the
+            // instructor can move on during a fleet-wide emergency.
+            const resp = await fetch('http://' + host + ':8080/api/abort', {
+                method: 'POST',
+                signal: AbortSignal.timeout(5000),
+            });
             if (resp.ok) {
                 addAlert(vehicleState[host] ? (vehicleState[host].callsign || host) : host, 'ABORT sent by range control');
             } else {

--- a/hydra_detect/web/static/js/main.js
+++ b/hydra_detect/web/static/js/main.js
@@ -346,32 +346,60 @@
     // CSP-safe image fallbacks (replaces inline onerror= in base.html so the
     // topbar still degrades gracefully when logo assets 404, but the CSP
     // script-src policy stays strict — no 'unsafe-inline' required).
+    //
+    // Must run synchronously at script load, not inside DOMContentLoaded:
+    // the <img> tags are already parsed by the time this script executes
+    // (it lives at the bottom of <body>) and a fast 404 from a missing
+    // static asset can fire the error event before DOMContentLoaded. If
+    // the listener is attached inside that callback, the fallback never
+    // runs and the topbar keeps a broken-image icon.
+    //
+    // Handles two cases:
+    //   1. Error already happened before bind (img.complete && naturalWidth===0)
+    //      → run the fallback synchronously.
+    //   2. Error fires later → event handler catches it.
+    function applyShieldFallback(shield) {
+        if (shield.dataset.fallback) {
+            shield.outerHTML = shield.dataset.fallback;
+        }
+    }
+    function applyOgtFallback(ogt) {
+        ogt.style.display = 'none';
+    }
+    function imageAlreadyFailed(img) {
+        // complete === true + naturalWidth === 0 means the browser has
+        // finished trying and got nothing (404, DNS fail, etc.).
+        return img.complete && img.naturalWidth === 0;
+    }
     function bindImageFallbacks() {
         const shield = document.getElementById('tb-shield');
         if (shield) {
-            shield.addEventListener('error', function onShieldError() {
-                shield.removeEventListener('error', onShieldError);
-                if (shield.dataset.fallback) {
-                    shield.outerHTML = shield.dataset.fallback;
-                }
-            });
+            if (imageAlreadyFailed(shield)) {
+                applyShieldFallback(shield);
+            } else {
+                shield.addEventListener('error', function onShieldError() {
+                    shield.removeEventListener('error', onShieldError);
+                    applyShieldFallback(shield);
+                });
+            }
         }
         const ogt = document.getElementById('tb-ogt');
         if (ogt) {
-            ogt.addEventListener('error', function onOgtError() {
-                ogt.removeEventListener('error', onOgtError);
-                ogt.style.display = 'none';
-            });
+            if (imageAlreadyFailed(ogt)) {
+                applyOgtFallback(ogt);
+            } else {
+                ogt.addEventListener('error', function onOgtError() {
+                    ogt.removeEventListener('error', onOgtError);
+                    applyOgtFallback(ogt);
+                });
+            }
         }
     }
+    bindImageFallbacks();
 
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', function() {
-            bindImageFallbacks();
-            init();
-        });
+        document.addEventListener('DOMContentLoaded', init);
     } else {
-        bindImageFallbacks();
         init();
     }
 })();

--- a/hydra_detect/web/static/js/main.js
+++ b/hydra_detect/web/static/js/main.js
@@ -343,9 +343,35 @@
 
     window.HydraApp = hydraApp;
 
+    // CSP-safe image fallbacks (replaces inline onerror= in base.html so the
+    // topbar still degrades gracefully when logo assets 404, but the CSP
+    // script-src policy stays strict — no 'unsafe-inline' required).
+    function bindImageFallbacks() {
+        const shield = document.getElementById('tb-shield');
+        if (shield) {
+            shield.addEventListener('error', function onShieldError() {
+                shield.removeEventListener('error', onShieldError);
+                if (shield.dataset.fallback) {
+                    shield.outerHTML = shield.dataset.fallback;
+                }
+            });
+        }
+        const ogt = document.getElementById('tb-ogt');
+        if (ogt) {
+            ogt.addEventListener('error', function onOgtError() {
+                ogt.removeEventListener('error', onOgtError);
+                ogt.style.display = 'none';
+            });
+        }
+    }
+
     if (document.readyState === 'loading') {
-        document.addEventListener('DOMContentLoaded', init);
+        document.addEventListener('DOMContentLoaded', function() {
+            bindImageFallbacks();
+            init();
+        });
     } else {
+        bindImageFallbacks();
         init();
     }
 })();

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -874,7 +874,7 @@ const HydraOps = (() => {
         card.appendChild(title);
 
         var desc = document.createElement('div');
-        desc.style.cssText = 'font-family: var(--font-mono); font-size: var(--font-sm); color: var(--text-dim); margin-bottom: var(--s-3);';
+        desc.className = 'ops-confirm-desc';
         desc.textContent = 'Target #' + trackId + ' ' + trackLabel;
         card.appendChild(desc);
 
@@ -893,8 +893,7 @@ const HydraOps = (() => {
         if (action === 'strike') {
             confirmBtn.className = 'btn btn-danger';
         } else {
-            confirmBtn.className = 'btn';
-            confirmBtn.style.cssText = 'background: var(--warning); color: #fff;';
+            confirmBtn.className = 'btn btn-confirm-drop';
         }
         confirmBtn.textContent = action === 'strike' ? 'STRIKE' : 'DROP';
         confirmBtn.addEventListener('click', function () {

--- a/hydra_detect/web/static/js/review-map.js
+++ b/hydra_detect/web/static/js/review-map.js
@@ -36,25 +36,56 @@ function getClassColor(label) {
     return classColorMap[label];
 }
 
+// Inline error banner (matches review.html styling). Replaces blocking
+// alert() and silent fetch failures so operators can see why a log
+// didn't load instead of staring at an empty map.
+let _reviewErrorTimer = null;
+function showReviewError(msg) {
+    const el = document.getElementById('review-error');
+    if (!el) return;
+    el.textContent = msg;
+    el.classList.add('show');
+    if (_reviewErrorTimer) clearTimeout(_reviewErrorTimer);
+    _reviewErrorTimer = setTimeout(() => el.classList.remove('show'), 6000);
+}
+function clearReviewError() {
+    const el = document.getElementById('review-error');
+    if (el) el.classList.remove('show');
+}
+
 // --- Load log list ---
 async function loadLogList() {
-    const res = await fetch('/api/review/logs');
-    const data = await res.json();
     const sel = document.getElementById('logSelect');
-    sel.innerHTML = '<option value="">-- Select a log file --</option>';
-    for (const log of data.logs) {
-        const opt = document.createElement('option');
-        opt.value = log.filename;
-        opt.textContent = `${log.filename} (${log.size_kb} KB)`;
-        sel.appendChild(opt);
+    try {
+        const res = await fetch('/api/review/logs');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        sel.innerHTML = '<option value="">-- Select a log file --</option>';
+        for (const log of data.logs) {
+            const opt = document.createElement('option');
+            opt.value = log.filename;
+            opt.textContent = `${log.filename} (${log.size_kb} KB)`;
+            sel.appendChild(opt);
+        }
+    } catch (err) {
+        sel.innerHTML = '<option value="">-- No logs available --</option>';
+        showReviewError('Could not load log list: ' + err.message);
     }
 }
 
 // --- Load detections from log ---
 async function loadLog(filename) {
     if (!filename) return;
-    const res = await fetch(`/api/review/log/${filename}`);
-    const data = await res.json();
+    clearReviewError();
+    let data;
+    try {
+        const res = await fetch(`/api/review/log/${filename}`);
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        data = await res.json();
+    } catch (err) {
+        showReviewError('Failed to load log: ' + err.message);
+        return;
+    }
     allDetections = data.detections || [];
     classColorMap = {};
 
@@ -230,9 +261,16 @@ let eventMarkerLayer = L.layerGroup().addTo(map);
 let vehicleMarker = null;
 
 async function loadEventLogList() {
-    const res = await fetch('/api/review/logs');
-    const data = await res.json();
     const sel = document.getElementById('eventSelect');
+    let data;
+    try {
+        const res = await fetch('/api/review/logs');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        data = await res.json();
+    } catch (err) {
+        showReviewError('Could not load event log list: ' + err.message);
+        return;
+    }
     sel.textContent = '';
     const defOpt = document.createElement('option');
     defOpt.value = '';
@@ -248,8 +286,16 @@ async function loadEventLogList() {
 
 async function loadEventLog(filename) {
     if (!filename) return;
-    const res = await fetch(`/api/review/events/${encodeURIComponent(filename)}`);
-    const data = await res.json();
+    clearReviewError();
+    let data;
+    try {
+        const res = await fetch(`/api/review/events/${encodeURIComponent(filename)}`);
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        data = await res.json();
+    } catch (err) {
+        showReviewError('Failed to load event log: ' + err.message);
+        return;
+    }
     allEvents = data.events || [];
 
     document.getElementById('eventCount').textContent = allEvents.length;
@@ -368,7 +414,7 @@ function exportWaypoints() {
     const sel = document.getElementById('logSelect');
     const filename = sel ? sel.value : '';
     if (!filename) {
-        alert('Select a log file first.');
+        showReviewError('Select a log file first.');
         return;
     }
     window.location.href = '/api/review/waypoints/' + encodeURIComponent(filename);

--- a/hydra_detect/web/static/js/review-map.js
+++ b/hydra_detect/web/static/js/review-map.js
@@ -439,6 +439,27 @@ if (geojsonBtn) geojsonBtn.addEventListener('click', exportGeoJSON);
 const waypointBtn = document.getElementById('btn-export-waypoints');
 if (waypointBtn) waypointBtn.addEventListener('click', exportWaypoints);
 
+// Reset filters — restore min-confidence to 0 and re-enable every
+// discovered class so the instructor can recover from over-filtering
+// without re-loading the log.
+const resetBtn = document.getElementById('btn-reset-filters');
+if (resetBtn) {
+    resetBtn.addEventListener('click', () => {
+        const slider = document.getElementById('confSlider');
+        const confVal = document.getElementById('confValue');
+        if (slider) slider.value = '0';
+        if (confVal) confVal.textContent = '0.00';
+        const discovered = new Set(
+            allDetections.map(d => d.label).filter(Boolean)
+        );
+        activeClasses = new Set(discovered);
+        document.querySelectorAll('#classFilters .class-tag').forEach(tag => {
+            tag.classList.add('active');
+        });
+        renderMap();
+    });
+}
+
 // --- Init ---
 loadLogList();
 loadEventLogList();

--- a/hydra_detect/web/static/js/settings.js
+++ b/hydra_detect/web/static/js/settings.js
@@ -26,8 +26,9 @@ const HydraSettings = (() => {
         'app_log_file', 'gps_required', 'kismet_auto_spawn',
     ];
 
-    // Password fields
-    const PASSWORD_FIELDS = ['api_token', 'kismet_pass'];
+    // Password / secret fields — rendered as type=password so the value is
+    // not visible over an instructor's shoulder during a demo.
+    const PASSWORD_FIELDS = ['api_token', 'kismet_pass', 'command_hmac_secret'];
 
     // Dropdown fields — populated from API endpoints
     const DROPDOWN_FIELDS = {
@@ -526,9 +527,51 @@ const HydraSettings = (() => {
 
             field.appendChild(label);
             field.appendChild(input);
+
+            // Render schema description as persistent help text so it is
+            // visible without hovering — important for touch devices and
+            // for students who don't know the tooltip exists.
+            if (spec && spec.description) {
+                const help = document.createElement('div');
+                help.className = 'settings-field-help';
+                help.textContent = spec.description;
+                field.appendChild(help);
+            }
+
             form.appendChild(field);
         });
+
+        updateApplyButton();
     }
+
+    // Reflect hasUnsavedChanges on the Apply button so students know there
+    // is something to save. Re-applied on every input event via delegation.
+    function updateApplyButton() {
+        const btn = document.getElementById('settings-apply');
+        if (!btn) return;
+        if (hasUnsavedChanges) {
+            btn.classList.add('has-unsaved');
+            btn.textContent = 'Apply Changes *';
+        } else {
+            btn.classList.remove('has-unsaved');
+            btn.textContent = 'Apply Changes';
+        }
+    }
+
+    // Delegated listener — every input/change/click on the form flips the
+    // indicator. Individual field builders also set hasUnsavedChanges for
+    // correctness; this just keeps the button in sync.
+    document.addEventListener('input', function(e) {
+        if (e.target.closest && e.target.closest('#settings-form')) {
+            updateApplyButton();
+        }
+    });
+    document.addEventListener('click', function(e) {
+        if (e.target.classList && e.target.classList.contains('toggle-switch')) {
+            // Let the toggle handler flip first, then sync.
+            requestAnimationFrame(updateApplyButton);
+        }
+    });
 
     async function handleApply() {
         if (!configData) return;
@@ -567,6 +610,7 @@ const HydraSettings = (() => {
         const result = await HydraApp.apiPost('/api/config/full', updates);
         if (result) {
             hasUnsavedChanges = false;
+            updateApplyButton();
             HydraApp.showToast('Configuration saved', 'success');
 
             // Show restart notice if needed

--- a/hydra_detect/web/static/js/setup.js
+++ b/hydra_detect/web/static/js/setup.js
@@ -4,11 +4,16 @@
     var cameraSelect = document.getElementById('setup-camera');
     var serialSelect = document.getElementById('setup-serial');
     var saveBtn = document.getElementById('setup-save');
+    var skipBtn = document.getElementById('setup-skip');
     var statusEl = document.getElementById('setup-status');
     var callsignInput = document.getElementById('setup-callsign');
     var callsignPreview = document.getElementById('callsign-preview');
     var teamInput = document.getElementById('setup-team');
     var vehicleSelect = document.getElementById('setup-vehicle');
+    var takEnabledInput = document.getElementById('setup-tak-enabled');
+    var takHostInput = document.getElementById('setup-tak-advertise-host');
+    var takHostHint = document.getElementById('advertise-host-hint');
+    var takAllowedInput = document.getElementById('setup-tak-allowed-callsigns');
 
     function updateCallsignPreview() {
         var cs = callsignInput.value.trim();
@@ -29,13 +34,18 @@
     callsignInput.addEventListener('input', updateCallsignPreview);
     updateCallsignPreview();
 
+    // CSP-safe skip handler (replaces inline onclick).
+    if (skipBtn) {
+        skipBtn.addEventListener('click', function() { window.location = '/'; });
+    }
+
     function clearSelect(sel) {
         while (sel.firstChild) {
             sel.removeChild(sel.firstChild);
         }
     }
 
-    // Populate device dropdowns on load
+    // Populate device dropdowns + LAN IP hint on load
     async function loadDevices() {
         statusEl.textContent = 'Detecting devices...';
         statusEl.className = 'setup-status setup-loading';
@@ -63,11 +73,23 @@
                     opt.textContent = port.name;
                     serialSelect.appendChild(opt);
                 });
-                // Pre-select ttyTHS1 if present
                 var tths1 = Array.from(serialSelect.options).find(
                     function(o) { return o.value === '/dev/ttyTHS1'; }
                 );
                 if (tths1) tths1.selected = true;
+            }
+
+            // Pre-fill advertise host with detected LAN IP
+            if (takHostInput && data.lan_ip) {
+                takHostInput.placeholder = data.lan_ip;
+                if (!takHostInput.value) {
+                    takHostInput.value = data.lan_ip;
+                }
+                if (takHostHint) {
+                    takHostHint.textContent =
+                        'Auto-detected: ' + data.lan_ip +
+                        '. Used for RTSP video links shown in ATAK markers. Override if wrong.';
+                }
             }
 
             statusEl.textContent = '';
@@ -87,9 +109,12 @@
         var payload = {
             camera_source: cameraSelect.value,
             serial_port: serialSelect.value,
-            vehicle_type: document.getElementById('setup-vehicle').value,
-            team_number: document.getElementById('setup-team').value.trim(),
-            callsign: document.getElementById('setup-callsign').value.trim(),
+            vehicle_type: vehicleSelect.value,
+            team_number: teamInput.value.trim(),
+            callsign: callsignInput.value.trim(),
+            tak_enabled: takEnabledInput ? takEnabledInput.checked : undefined,
+            tak_advertise_host: takHostInput ? takHostInput.value.trim() : '',
+            tak_allowed_callsigns: takAllowedInput ? takAllowedInput.value.trim() : '',
         };
 
         try {

--- a/hydra_detect/web/static/js/setup.js
+++ b/hydra_detect/web/static/js/setup.js
@@ -100,6 +100,47 @@
         }
     }
 
+    // On wizard re-run (not first boot), load existing config.ini values
+    // so the form reflects the current state instead of forcing a full
+    // re-entry. First-boot defaults stay as-is because /api/config/full
+    // simply returns those same defaults.
+    async function loadExistingConfig() {
+        try {
+            var resp = await fetch('/api/config/full');
+            if (!resp.ok) return;
+            var cfg = await resp.json();
+            // Camera / serial — select matching option if it's already in the list
+            if (cfg.camera && cfg.camera.source) {
+                var src = String(cfg.camera.source);
+                var camOpts = Array.from(cameraSelect.options);
+                var match = camOpts.find(function(o) { return o.value === src; });
+                if (match) match.selected = true;
+            }
+            if (cfg.mavlink && cfg.mavlink.connection_string) {
+                var conn = String(cfg.mavlink.connection_string);
+                var serOpts = Array.from(serialSelect.options);
+                var serMatch = serOpts.find(function(o) { return o.value === conn; });
+                if (serMatch) serMatch.selected = true;
+            }
+            var tak = cfg.tak || {};
+            if (tak.callsign && !callsignInput.value) {
+                callsignInput.value = tak.callsign;
+                updateCallsignPreview();
+            }
+            if (takEnabledInput && typeof tak.enabled === 'string') {
+                takEnabledInput.checked = (tak.enabled.toLowerCase() === 'true');
+            }
+            if (takHostInput && tak.advertise_host) {
+                takHostInput.value = tak.advertise_host;
+            }
+            if (takAllowedInput && tak.allowed_callsigns) {
+                takAllowedInput.value = tak.allowed_callsigns;
+            }
+        } catch (err) {
+            // Silent — first boot has no config to load, that is fine.
+        }
+    }
+
     // Save configuration
     saveBtn.addEventListener('click', async function() {
         saveBtn.disabled = true;
@@ -142,5 +183,8 @@
         }
     });
 
-    loadDevices();
+    (async function init() {
+        await loadDevices();
+        await loadExistingConfig();
+    })();
 })();

--- a/hydra_detect/web/static/js/tak.js
+++ b/hydra_detect/web/static/js/tak.js
@@ -95,6 +95,50 @@ const HydraTak = (() => {
         startTypeCountsPoll();
         startPeersPoll();
         startAuditPoll();
+        bindTestBroadcastBtn();
+    }
+
+    // Test Broadcast — forces a self-SA emit so operators can verify
+    // the wiring to ATAK before a sortie. Idempotent; safe to click
+    // repeatedly. Bound on every onEnter so the button stays live
+    // when the view re-mounts.
+    let testBroadcastBound = false;
+    function bindTestBroadcastBtn() {
+        if (testBroadcastBound) return;
+        const btn = document.getElementById('tak-test-broadcast');
+        if (!btn) return;
+        btn.addEventListener('click', async function() {
+            if (btn.disabled) return;
+            btn.disabled = true;
+            btn.classList.add('is-busy');
+            const original = btn.textContent;
+            btn.textContent = 'Sending...';
+            try {
+                const resp = await fetch('/api/tak/test_broadcast', {
+                    method: 'POST',
+                    credentials: 'same-origin',
+                    headers: { 'Content-Type': 'application/json' },
+                });
+                const data = await resp.json().catch(() => ({}));
+                if (resp.ok && data.success) {
+                    const dests = Array.isArray(data.destinations) ? data.destinations : [];
+                    const label = dests.length === 1
+                        ? dests[0]
+                        : dests.length + ' destinations';
+                    HydraApp.showToast('TAK beacon sent -> ' + label, 'success');
+                } else {
+                    const reason = (data && data.reason) || ('HTTP ' + resp.status);
+                    HydraApp.showToast('TAK beacon failed: ' + reason, 'error');
+                }
+            } catch (err) {
+                HydraApp.showToast('TAK beacon failed: network error', 'error');
+            } finally {
+                btn.disabled = false;
+                btn.classList.remove('is-busy');
+                btn.textContent = original;
+            }
+        });
+        testBroadcastBound = true;
     }
 
     function onLeave() {

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -31,7 +31,7 @@
              the lockup degrades gracefully on partial static deploys. -->
         <div class="tb-lockup" id="tb-lockup">
             <img class="tb-shield" id="tb-shield" src="/static/assets/sorcc_crest_transparent.png"
-                 alt="SORCC" onerror="this.onerror=null;this.outerHTML=this.dataset.fallback"
+                 alt="SORCC"
                  data-fallback='<svg class=&quot;tb-shield&quot; viewBox=&quot;0 0 46 46&quot; xmlns=&quot;http://www.w3.org/2000/svg&quot; aria-label=&quot;SORCC shield&quot;><rect x=&quot;23&quot; y=&quot;3&quot; width=&quot;28&quot; height=&quot;28&quot; rx=&quot;3&quot; transform=&quot;rotate(45 23 3)&quot; fill=&quot;#385723&quot; stroke=&quot;#A6BC92&quot; stroke-width=&quot;1.2&quot;/><text x=&quot;23&quot; y=&quot;26&quot; text-anchor=&quot;middle&quot; fill=&quot;#EFF5EB&quot; font-family=&quot;Barlow Condensed&quot; font-size=&quot;10&quot; font-weight=&quot;700&quot; letter-spacing=&quot;0.1em&quot;>SORCC</text></svg>'>
             <span class="tb-divider tb-divider-lockup" aria-hidden="true"></span>
             <div class="tb-wordmark-block">
@@ -39,8 +39,7 @@
                 <span class="tb-subtitle">OPERATOR DASHBOARD</span>
             </div>
             <img class="tb-ogt" id="tb-ogt" src="/static/assets/ogt_horizontal_white.png"
-                 alt="Oak Grove Technologies"
-                 onerror="this.style.display='none'">
+                 alt="Oak Grove Technologies">
         </div>
 
         <span class="tb-divider tb-divider-nav" aria-hidden="true"></span>

--- a/hydra_detect/web/templates/config.html
+++ b/hydra_detect/web/templates/config.html
@@ -34,13 +34,13 @@
         <div class="panel-body mock-panel-body">
             <div class="panel-field" id="ctrl-mission-name-field">
                 <label class="panel-field-label" for="ctrl-mission-name">Sortie Name</label>
-                <input type="text" id="ctrl-mission-name" placeholder="e.g., sortie-alpha" maxlength="100" style="width:100%; background:var(--bg-panel-alt); border:1px solid var(--border-default); color:var(--text-primary); padding:6px 8px; border-radius:4px; font-family:inherit; font-size:var(--font-sm);">
+                <input type="text" id="ctrl-mission-name" placeholder="e.g., sortie-alpha" maxlength="100">
             </div>
             <div class="panel-field" id="ctrl-mission-active-info" style="display:none;">
                 <span class="panel-stat-label">Active:</span>
                 <span class="panel-stat-value mono accent" id="ctrl-mission-active-name">--</span>
             </div>
-            <div style="display:flex;gap:8px;margin-top:8px;">
+            <div class="panel-row-btns">
                 <button class="btn btn-green" id="ctrl-btn-mission-start">Start Sortie</button>
                 <button class="btn btn-danger" id="ctrl-btn-mission-end" disabled>End Sortie</button>
             </div>
@@ -240,7 +240,7 @@
             </div>
             <div class="panel-field">
                 <label class="panel-field-label">RTSP Stream</label>
-                <div style="display:flex;align-items:center;gap:8px;">
+                <div class="panel-row-inline">
                     <div class="toggle-switch" id="ctrl-rtsp-toggle" title="Toggle RTSP stream"></div>
                     <span class="panel-sys-val mono" id="ctrl-rtsp-status">OFF</span>
                 </div>
@@ -248,7 +248,7 @@
             </div>
             <div class="panel-field">
                 <label class="panel-field-label">MAVLink Video</label>
-                <div style="display:flex;align-items:center;gap:8px;">
+                <div class="panel-row-inline">
                     <div class="toggle-switch" id="ctrl-mvid-toggle" title="Toggle MAVLink video thumbnails"></div>
                     <span class="panel-sys-val mono" id="ctrl-mvid-status">OFF</span>
                 </div>
@@ -267,7 +267,7 @@
             </div>
             <div class="panel-field">
                 <label class="panel-field-label">TAK/ATAK</label>
-                <div style="display:flex;align-items:center;gap:8px;">
+                <div class="panel-row-inline">
                     <div class="toggle-switch" id="ctrl-tak-toggle" title="Toggle TAK CoT output"></div>
                     <span class="panel-sys-val mono" id="ctrl-tak-status">OFF</span>
                 </div>
@@ -275,8 +275,8 @@
                 <div id="ctrl-tak-targets-section" style="margin-top:6px;display:none;">
                     <label class="panel-field-label" style="margin-top:4px;">Unicast Targets</label>
                     <div id="ctrl-tak-target-list" style="margin-bottom:4px;"></div>
-                    <div style="display:flex;gap:4px;align-items:center;">
-                        <input type="text" id="ctrl-tak-target-input" placeholder="192.168.1.100:6969" maxlength="260" style="flex:1;background:var(--bg-panel-alt);border:1px solid var(--border-default);color:var(--text-primary);padding:4px 6px;border-radius:4px;font-family:var(--font-mono);font-size:var(--font-xs);">
+                    <div class="panel-row-inline-tight">
+                        <input type="text" id="ctrl-tak-target-input" placeholder="192.168.1.100:6969" maxlength="260">
                         <button class="btn btn-sm btn-green" id="ctrl-tak-target-add">Add</button>
                     </div>
                 </div>

--- a/hydra_detect/web/templates/config.html
+++ b/hydra_detect/web/templates/config.html
@@ -28,7 +28,7 @@
         <div class="panel-header mock-panel-head">
             <span class="panel-drag-handle">&#10303;</span>
             <h3 class="panel-title mock-section-label">Sortie</h3>
-            <span class="badge" id="ctrl-mission-badge" style="margin-left:auto; margin-right:var(--s-2);">IDLE</span>
+            <span class="badge panel-header-badge" id="ctrl-mission-badge">IDLE</span>
             <button class="panel-collapse-btn" aria-label="Collapse panel">&#9662;</button>
         </div>
         <div class="panel-body mock-panel-body">
@@ -130,7 +130,7 @@
         <div class="panel-header mock-panel-head">
             <span class="panel-drag-handle">&#10303;</span>
             <h3 class="panel-title mock-section-label">RF Hunt</h3>
-            <span class="badge" id="ctrl-rf-state-badge" style="margin-left:auto; margin-right:var(--s-2);">N/A</span>
+            <span class="badge panel-header-badge" id="ctrl-rf-state-badge">N/A</span>
             <button class="panel-collapse-btn" aria-label="Collapse panel">&#9662;</button>
         </div>
         <div class="panel-body mock-panel-body">

--- a/hydra_detect/web/templates/control.html
+++ b/hydra_detect/web/templates/control.html
@@ -63,6 +63,38 @@
         .btn-unlock { background: #333; color: #ccc; }
         .btn-unlock:active { background: #444; }
 
+        /* Header ABORT — always visible emergency stop for the tablet operator.
+           Sized large + high-contrast so it reads at arm's length with gloves. */
+        .header-abort {
+            background: #8b2020; color: #fff;
+            border: 1px solid #c53030; border-radius: 4px;
+            padding: 8px 16px; font-family: inherit; font-size: 13px;
+            font-weight: 700; letter-spacing: 1.5px; text-transform: uppercase;
+            min-height: 44px; cursor: pointer;
+            box-shadow: 0 0 8px rgba(197, 48, 48, 0.4);
+        }
+        .header-abort:active { background: #6b1515; }
+        .header-abort-flash { animation: abort-flash 0.6s ease-in-out 2; }
+        @keyframes abort-flash {
+            0%, 100% { background: #8b2020; }
+            50%      { background: #c53030; }
+        }
+
+        /* Inline feedback line — replaces native alert() for auth / action errors. */
+        .action-toast {
+            position: fixed; left: 50%; bottom: 20px;
+            transform: translateX(-50%);
+            background: #1c1c1c; color: #e8e8e8;
+            border: 1px solid #385723; border-radius: 6px;
+            padding: 10px 18px; font-size: 13px;
+            max-width: 88vw; text-align: center;
+            z-index: 200; opacity: 0;
+            transition: opacity 0.2s;
+            pointer-events: none;
+        }
+        .action-toast.show { opacity: 1; }
+        .action-toast.error { border-color: #c53030; }
+
         .confirm-overlay {
             display: none; position: fixed; inset: 0; background: rgba(0,0,0,0.85);
             z-index: 100; align-items: center; justify-content: center; flex-direction: column;
@@ -80,8 +112,14 @@
 <body>
     <div class="header">
         <h1>HYDRA CONTROL</h1>
+        <button class="header-abort" id="control-abort" type="button"
+                aria-label="Emergency abort — cancel all approach modes and return platform to safe state">
+            ABORT
+        </button>
         <a href="/">Dashboard</a>
     </div>
+
+    <div class="action-toast" id="action-toast" role="status" aria-live="polite"></div>
 
     <div class="stream-wrap">
         <span class="stream-msg" id="stream-msg">Connecting...</span>

--- a/hydra_detect/web/templates/demo.html
+++ b/hydra_detect/web/templates/demo.html
@@ -95,7 +95,7 @@
                 <span class="demo-dot demo-dot-green"></span>
                 <span class="demo-takmini-title" id="demo-takmini-callsign">TAK · HYDRA-1</span>
                 <span class="demo-takmini-spacer"></span>
-                <span class="demo-takmini-meta">takserver.sorcc:8089</span>
+                <span class="demo-takmini-meta" id="demo-takmini-meta">239.2.3.1:6969</span>
                 <span class="demo-pill demo-pill-live">LIVE</span>
             </header>
             <div class="demo-takmini-canvas">

--- a/hydra_detect/web/templates/instructor.html
+++ b/hydra_detect/web/templates/instructor.html
@@ -14,6 +14,7 @@
             --warning: #FF9F1C;
             --success: #0E8A16;
             --border: #1e2830;
+            --border-default: #1e2830;
         }
         * { margin: 0; padding: 0; box-sizing: border-box; }
         body {
@@ -94,6 +95,7 @@
         }
         .alert-time { color: #888; }
         .alert-callsign { color: var(--accent); }
+        .alert-feed-placeholder { color: #888; font-size: 12px; }
     </style>
 </head>
 <body>
@@ -106,8 +108,8 @@
 
     <div class="vehicle-grid" id="vehicle-grid"></div>
 
-    <div class="alert-feed" id="alert-feed">
-        <div style="color: #888; font-size: 12px;">Detection alerts will appear here...</div>
+    <div class="alert-feed" id="alert-feed" role="log" aria-live="polite" aria-label="Fleet detection alert feed">
+        <div class="alert-feed-placeholder">Detection alerts will appear here...</div>
     </div>
 
     <script src="/static/js/instructor.js"></script>

--- a/hydra_detect/web/templates/ops.html
+++ b/hydra_detect/web/templates/ops.html
@@ -30,8 +30,8 @@
                     <span class="ops-card-value mono" id="ops-mission-dets">--</span>
                 </div>
                 <div class="ops-card-btns">
-                    <button class="btn btn-sm" id="ops-btn-mission-end" disabled title="End current sortie">End</button>
-                    <button class="btn btn-sm" id="ops-btn-mission-export" title="Export detection waypoints (QGC WPL 110)">Export WP</button>
+                    <button class="btn btn-sm" id="ops-btn-mission-end" disabled title="End current sortie">End Sortie</button>
+                    <button class="btn btn-sm" id="ops-btn-mission-export" title="Export detection waypoints (QGC WPL 110)">Export Waypoints</button>
                 </div>
             </div>
         </div>

--- a/hydra_detect/web/templates/review.html
+++ b/hydra_detect/web/templates/review.html
@@ -70,6 +70,7 @@
                 <input type="range" id="confSlider" min="0" max="0.99" step="0.05" value="0">
                 <label>Class filter (click to toggle):</label>
                 <div id="classFilters" class="class-filters"></div>
+                <button class="btn" id="btn-reset-filters" title="Restore min confidence to 0 and re-enable every class">Reset filters</button>
             </div>
             <div class="section">
                 <h3>DISPLAY</h3>

--- a/hydra_detect/web/templates/review.html
+++ b/hydra_detect/web/templates/review.html
@@ -39,6 +39,13 @@
         .leaflet-popup-content-wrapper { background: #1a1a1a; color: #e0e0e0; border-radius: 4px; }
         .leaflet-popup-tip { background: #1a1a1a; }
         .leaflet-popup-content { font-family: 'Courier New', monospace; font-size: 12px; }
+        .review-error {
+            background: #2a1010; color: #f5b5b5;
+            border: 1px solid #c53030; border-radius: 4px;
+            padding: 8px 10px; font-size: 11px; line-height: 1.35;
+            margin: 0 0 12px 0; display: none;
+        }
+        .review-error.show { display: block; }
     </style>
 </head>
 <body>
@@ -49,6 +56,7 @@
     <div class="container">
         <div id="map"></div>
         <div class="sidebar">
+            <div class="review-error" id="review-error" role="alert" aria-live="polite"></div>
             <div class="section">
                 <h3>LOG FILE</h3>
                 <select id="logSelect"><option value="">Loading...</option></select>

--- a/hydra_detect/web/templates/settings.html
+++ b/hydra_detect/web/templates/settings.html
@@ -95,14 +95,18 @@
         </div>
     </div>
 
-    <!-- Quick Links -->
+    <!-- Alternate Views — pages that are not part of the four-view topbar
+         (Operator / TAK / Config / Settings). Mobile Control, Instructor
+         Overview, and Sortie Review have their own full-screen layouts
+         tailored to different contexts. Setup Wizard re-opens first-boot
+         configuration. -->
     <div class="settings-recovery">
-        <div class="settings-recovery-label mock-section-label">Quick Links</div>
+        <div class="settings-recovery-label mock-section-label">Alternate Views</div>
         <div class="settings-recovery-actions">
-            <a class="btn btn-recovery" href="/control">Mobile Control</a>
-            <a class="btn btn-recovery" href="/fleet">Fleet View</a>
-            <a class="btn btn-recovery" href="/review">Sortie Review</a>
-            <a class="btn btn-recovery" href="/setup">Setup Wizard</a>
+            <a class="btn btn-recovery" href="/control" title="Tablet-optimized control surface for the field">Mobile Control</a>
+            <a class="btn btn-recovery" href="/fleet" title="Fleet overview for monitoring multiple platforms">Fleet View</a>
+            <a class="btn btn-recovery" href="/review" title="Post-sortie detection review and export">Sortie Review</a>
+            <a class="btn btn-recovery" href="/setup" title="Re-run first-boot configuration wizard">Setup Wizard</a>
         </div>
     </div>
 

--- a/hydra_detect/web/templates/setup.html
+++ b/hydra_detect/web/templates/setup.html
@@ -41,6 +41,37 @@
             max-width: 520px;
             width: 100%;
         }
+        .setup-section-divider {
+            font-family: 'Barlow Condensed', sans-serif;
+            font-size: 0.8rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            color: var(--ogt-muted);
+            border-top: 1px solid var(--border-default);
+            padding-top: 16px;
+            margin-top: 8px;
+        }
+        .setup-hint {
+            font-size: 0.7rem;
+            color: var(--text-dim);
+            line-height: 1.35;
+        }
+        .setup-toggle-label {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            cursor: pointer;
+            color: var(--text-primary);
+            font-family: 'Barlow', sans-serif;
+            font-size: 0.9rem;
+            text-transform: none;
+            letter-spacing: 0;
+        }
+        .setup-toggle-label input[type="checkbox"] {
+            width: auto;
+            accent-color: var(--olive-primary);
+        }
         .setup-header {
             text-align: center;
             margin-bottom: 32px;
@@ -211,15 +242,37 @@
                 <div class="setup-field">
                     <label for="setup-callsign">Callsign</label>
                     <input type="text" id="setup-callsign" placeholder="auto: HYDRA-{team}-{vehicle}" maxlength="50">
-                    <span style="font-size:0.7rem;color:var(--text-dim)" id="callsign-preview"></span>
+                    <span class="setup-hint" id="callsign-preview"></span>
                 </div>
+            </div>
+
+            <div class="setup-section-divider">TAK / ATAK</div>
+
+            <div class="setup-field setup-field-row">
+                <label for="setup-tak-enabled" class="setup-toggle-label">
+                    <input type="checkbox" id="setup-tak-enabled" checked>
+                    <span>Enable TAK output</span>
+                </label>
+                <span class="setup-hint">Broadcasts detections + position over multicast for ATAK devices on the same LAN.</span>
+            </div>
+
+            <div class="setup-field setup-tak-field">
+                <label for="setup-tak-advertise-host">Advertise Host (Jetson IP)</label>
+                <input type="text" id="setup-tak-advertise-host" placeholder="detecting..." maxlength="253">
+                <span class="setup-hint" id="advertise-host-hint">Used for RTSP video links shown in ATAK markers.</span>
+            </div>
+
+            <div class="setup-field setup-tak-field">
+                <label for="setup-tak-allowed-callsigns">Allowed ATAK Callsigns</label>
+                <input type="text" id="setup-tak-allowed-callsigns" placeholder="INSTRUCTOR-1,TOC-1" maxlength="500">
+                <span class="setup-hint">Comma-separated. Commands from other callsigns are dropped. Leave blank to disable inbound commands.</span>
             </div>
 
             <p class="setup-status" id="setup-status"></p>
 
             <div class="setup-actions">
                 <button class="btn-save" id="setup-save">Save &amp; Start</button>
-                <button class="btn-skip" id="setup-skip" onclick="window.location='/'">Skip to Dashboard</button>
+                <button class="btn-skip" id="setup-skip" type="button">Skip to Dashboard</button>
             </div>
         </div>
     </div>

--- a/hydra_detect/web/templates/tak.html
+++ b/hydra_detect/web/templates/tak.html
@@ -6,6 +6,10 @@
         <span class="tak-map-title" id="tak-map-title">TAK · HYDRA-1</span>
         <span class="tak-map-chip tak-live" id="tak-map-chip" title="Polling /api/stats + /api/tak/peers">LIVE</span>
         <span class="tak-map-sub" id="tak-map-sub">no fix</span>
+        <button class="tak-map-action" id="tak-test-broadcast" type="button"
+                title="Force an immediate self-SA emit — useful to verify the marker appears in ATAK before a sortie.">
+            Test Broadcast
+        </button>
     </header>
     <div class="tak-map-canvas" id="tak-map-canvas"></div>
 </section>


### PR DESCRIPTION
## Summary

Three-batch UI polish sweep covering the setup wizard, settings view, TAK tab, control surface, review page, config panels, and instructor overview.

## Batch 1 (7a32dca) — setup wizard, settings, TAK

**Setup wizard**
- Expose TAK fields (enable / advertise_host / allowed_callsigns) so students never have to SSH or hunt through Settings to get ATAK interop working
- Auto-detect the Jetson's LAN IP in `/api/setup/devices` and pre-fill `advertise_host`
- Replace inline `onclick=` on the Skip button (CSP `script-src` violation) with a listener bound in `setup.js`

**Settings view**
- Render schema `description` as persistent help text under each input instead of `title=` tooltips (invisible on touch)
- Highlight Apply button when there are unsaved changes
- Mask `command_hmac_secret` as a password field (was rendered in plaintext)
- Rename Quick Links → Alternate Views with per-link tooltips explaining when to use each

**TAK tab**
- Add `POST /api/tak/test_broadcast` + "Test Broadcast" button on the TAK map header so operators can verify self-SA wiring before a sortie without waiting on the 5 s SA cadence
- `TAKOutput.send_test_beacon()` returns `{success, reason, callsign, destinations}`

**Base template**
- Replace inline `onerror=` handlers on logo images (CSP `script-src` violation) with a listener in `main.js` that preserves the SVG fallback

**Ops sortie rail**
- Align button labels with the Config view (End → End Sortie, Export WP → Export Waypoints)

## Batch 2 (1d4bbbb) — control ABORT, review error paths, config style cleanup

**control.html / control.js**
- Add persistent header ABORT button so the tablet operator can kill-switch without navigating back to the main dashboard. Calls the unauthenticated `POST /api/abort`, flashes the button, reports result via a new in-page toast
- Add `action-toast` element; replaces native `alert()` for auth and unlock-failure feedback
- Report unlock failure on the toast instead of silently polling again

**review.html / review-map.js**
- Inline error banner on the sidebar so log-load failures surface instead of a stuck "Loading..." dropdown
- Wrap the four `/api/review/*` fetches in try/catch; show a readable error
- Replace `alert('Select a log file first.')` with the same banner

**config.html / config.css**
- Extract six repeated `style="display:flex;align-items:center;gap:8px"` wrappers into `.panel-row-inline` / `.panel-row-inline-tight` / `.panel-row-btns`
- Drop the 200-char inline style on `#ctrl-tak-target-input` and the duplicated inline style on `#ctrl-mission-name` — both inputs already inherit `.panel-field input[type="text"]` styling

## Batch 3 (39b00e0) — instructor CSS + abort timeout + a11y

- `instructor.html` inline `:root` defined `--border` but the rules referenced `--border-default`, which was undefined on this standalone page. Card / input borders fell through to browser default. Aliased both names
- Add a 5 s `AbortSignal.timeout` to `abortVehicle()` — with 20 platforms during CULEX and one unreachable host, the default fetch timeout (~90 s) blocks the instructor during a fleet-wide abort
- Promote the alert-feed placeholder to a CSS class; set `role="log"` + `aria-live="polite"` on the feed so assistive tech announces new alerts

## Test plan

- [x] `python -m pytest tests/` — 1792 passed, 1 skipped, 23 deselected
- [x] `flake8 hydra_detect/` — clean
- [ ] Manual: setup wizard auto-detects Jetson LAN IP, TAK fields persist, skip button works without CSP errors
- [ ] Manual: Settings help text renders, Apply button pulses when dirty, HMAC secret masked
- [ ] Manual: TAK tab "Test Broadcast" emits a self-SA immediately; failure modes (no GPS / not running) surface a useful reason
- [ ] Manual: `/control` ABORT button reachable; unlock failure shows toast
- [ ] Manual: `/review` shows banner on a broken log; select-a-log prompt is inline
- [ ] Manual: `/instructor` cards show borders; one unreachable host doesn't block fleet abort
