### PR TITLE
Normalize approach.mode casing/whitespace and update tests for approach panel

### DIFF
--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -1450,7 +1450,8 @@ const HydraOps = (() => {
         var approach = stats && stats.approach;
         var section = document.getElementById('ops-approach-section');
         if (!section) return;
-        if (!approach || typeof approach.mode !== 'string' || approach.mode === 'idle') {
+        var mode = (approach && typeof approach.mode === 'string') ? approach.mode.trim().toLowerCase() : '';
+        if (!approach || !mode || mode === 'idle') {
             section.style.display = 'none';
             return;
         }
@@ -1460,13 +1461,13 @@ const HydraOps = (() => {
         var modeEl = document.getElementById('ops-approach-mode');
         var elapsedEl = document.getElementById('ops-approach-elapsed');
         var wpEl = document.getElementById('ops-approach-wp');
-        if (modeEl) modeEl.textContent = approach.mode.toUpperCase();
+        if (modeEl) modeEl.textContent = mode.toUpperCase();
         if (elapsedEl) elapsedEl.textContent = (approach.elapsed_sec || 0) + 's';
         if (wpEl) wpEl.textContent = approach.waypoints_sent || 0;
 
         var armPanel = document.getElementById('ops-approach-arm-status');
         if (armPanel) {
-            if (approach.mode === 'strike') {
+            if (mode === 'strike') {
                 armPanel.style.display = 'block';
                 var swArm = document.getElementById('ops-approach-sw-arm');
                 var hwArm = document.getElementById('ops-approach-hw-arm');

--- a/hydra_detect/web/static/js/tests/approach-panel.test.mjs
+++ b/hydra_detect/web/static/js/tests/approach-panel.test.mjs
@@ -48,48 +48,53 @@ function loadOpsHarness() {
   const apiCalls = [];
   let apiResponse = { status: 'ok' };
 
-  global.window = {
-    HydraModules: {},
-    location: { hash: '' },
-    addEventListener: () => {},
-    devicePixelRatio: 1,
-  };
-  global.sessionStorage = { getItem: () => '', setItem: () => {} };
-  global.document = {
-    body: { classList: { remove: () => {}, add: () => {} } },
-    querySelectorAll: () => [],
-    querySelector: () => null,
-    addEventListener: () => {},
-    getElementById(id) {
-      if (!elements.has(id)) elements.set(id, makeEl(id));
-      return elements.get(id);
+  const context = {
+    window: {
+      HydraModules: {},
+      location: { hash: '' },
+      addEventListener: () => {},
+      devicePixelRatio: 1,
     },
-    activeElement: null,
-    contains: () => true,
-    hidden: false,
-    fullscreenElement: null,
-    exitFullscreen: () => {},
-  };
-  global.setInterval = () => 0;
-  global.clearInterval = () => {};
-  global.setTimeout = () => 0;
-
-  global.HydraApp = {
-    state: { stats: {}, target: {}, tracks: [] },
-    apiPost: async (url, body) => {
-      apiCalls.push({ url, body });
-      return apiResponse;
+    sessionStorage: { getItem: () => '', setItem: () => {} },
+    document: {
+      body: { classList: { remove: () => {}, add: () => {} } },
+      querySelectorAll: () => [],
+      querySelector: () => null,
+      addEventListener: () => {},
+      getElementById(id) {
+        if (!elements.has(id)) elements.set(id, makeEl(id));
+        return elements.get(id);
+      },
+      activeElement: null,
+      contains: () => true,
+      hidden: false,
+      fullscreenElement: null,
+      exitFullscreen: () => {},
     },
-    showToast: (msg, type) => { toasts.push({ msg, type }); },
-    openModal: () => {},
-    closeModal: () => {},
+    setInterval: () => 0,
+    clearInterval: () => {},
+    setTimeout: () => 0,
+    clearTimeout: () => {},
+    HydraApp: {
+      state: { stats: {}, target: {}, tracks: [] },
+      apiPost: async (url, body) => {
+        apiCalls.push({ url, body });
+        return apiResponse;
+      },
+      showToast: (msg, type) => { toasts.push({ msg, type }); },
+      openModal: () => {},
+      closeModal: () => {},
+    },
   };
+  context.globalThis = context;
+  context.global = context;
+  vm.createContext(context);
 
   const code = fs.readFileSync('hydra_detect/web/static/js/ops.js', 'utf8');
-  vm.runInThisContext(code, { filename: 'ops.js' });
+  vm.runInContext(`${code}\nglobalThis.__HydraOps = HydraOps;`, context, { filename: 'ops.js' });
 
   return {
-    HydraOps: global.HydraOps,
+    HydraOps: context.__HydraOps,
     elements,
     toasts,
     apiCalls,
@@ -110,6 +115,12 @@ test('updateApproachPanel hides section when approach.mode === "idle"', () => {
   assert.equal(h.getEl('ops-approach-section').style.display, 'none');
 });
 
+test('updateApproachPanel treats uppercase/whitespace IDLE mode as hidden', () => {
+  const h = loadOpsHarness();
+  h.HydraOps.updateApproachPanel({ approach: { mode: '  IDLE  ' } });
+  assert.equal(h.getEl('ops-approach-section').style.display, 'none');
+});
+
 test('updateApproachPanel with follow active shows section, hides arm sub-panel', () => {
   const h = loadOpsHarness();
   h.HydraOps.updateApproachPanel({
@@ -120,6 +131,21 @@ test('updateApproachPanel with follow active shows section, hides arm sub-panel'
   assert.equal(h.getEl('ops-approach-elapsed').textContent, '12s');
   assert.equal(h.getEl('ops-approach-wp').textContent, '3');
   assert.equal(h.getEl('ops-approach-arm-status').style.display, 'none');
+});
+
+test('updateApproachPanel normalizes mode text and strike state casing', () => {
+  const h = loadOpsHarness();
+  h.HydraOps.updateApproachPanel({
+    approach: {
+      mode: ' Strike ',
+      software_arm: false,
+      hardware_arm_status: false,
+    },
+  });
+  assert.equal(h.getEl('ops-approach-mode').textContent, 'STRIKE');
+  assert.equal(h.getEl('ops-approach-arm-status').style.display, 'block');
+  assert.equal(h.getEl('ops-approach-sw-arm').textContent, 'SAFE');
+  assert.equal(h.getEl('ops-approach-hw-arm').textContent, 'SAFE');
 });
 
 test('updateApproachPanel strike + SW armed + HW null → N/A with dim', () => {


### PR DESCRIPTION
### Motivation

- Make the approach status panel robust to `mode` strings that include extra whitespace or different casing so status visibility and comparisons behave predictably.
- Ensure displayed mode text is normalized for consistent UI presentation.
- Harden the test harness to run the ops module inside an isolated VM context to avoid polluting the real global environment.

### Description

- Normalize `approach.mode` by trimming and lowercasing into a `mode` variable and use it for visibility checks and comparisons instead of the raw value, and render the display as `mode.toUpperCase()` in `updateApproachPanel`.
- Use `mode === 'strike'` and normalized `mode` for arm-panel logic so mixed-case and whitespace variants like `' Strike '` are handled correctly.
- Refactor tests to create an isolated `context` and call `vm.createContext`/`vm.runInContext` to execute `ops.js` and expose `HydraOps` as `globalThis.__HydraOps` instead of running in the real global scope.
- Add unit tests `updateApproachPanel treats uppercase/whitespace IDLE mode as hidden` and `updateApproachPanel normalizes mode text and strike state casing` and adjust the harness setup (add `clearTimeout`/timeout stubs, etc.).

### Testing

- Ran the updated JS unit tests in `hydra_detect/web/static/js/tests/approach-panel.test.mjs` which exercise `updateApproachPanel` behavior for idle, follow, and strike modes and the new normalization cases, and they passed.
- The new harness successfully loads `ops.js` in a VM context and exposes `HydraOps` to the tests, with all assertions in the file succeeding.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e93861797483289b580e381b8e89e9)