### PR TITLE
feat(#157): Pixhawk prereq docs + pixhawk_preflight.py

### DIFF
--- a/docs/pixhawk-prereqs-drone_10in.md
+++ b/docs/pixhawk-prereqs-drone_10in.md
@@ -1,0 +1,122 @@
+# Pixhawk Prerequisites — 10-inch Quadcopter (ArduCopter)
+
+Platform: 10" FPV quadcopter running ArduCopter on Pixhawk 6C.
+
+Run `python scripts/pixhawk_preflight.py --profile drone_10in --conn /dev/ttyACM0` to
+validate these params live against your flight controller.
+
+---
+
+## Required Parameters
+
+These must be set correctly before running Hydra. The drone profile is the most
+safety-sensitive — a 10-inch airframe operating near personnel with wrong params is
+a serious hazard.
+
+| Parameter | Expected | Why |
+|---|---|---|
+| `FENCE_ENABLE` | `1` | Geofence required for any autonomous behavior (GUIDED mode approach, drop, strike). Without it the copter has no automatic altitude or radius boundary during Hydra-commanded sorties. |
+| `SERIAL2_PROTOCOL` | `2` | Companion computer port (TELEM2) must be MAVLink2 for Hydra connectivity. |
+| `SERIAL2_BAUD` | `921` | 921600 baud. Required for reliable heartbeat + telemetry + command throughput at CULEX tempo (multiple sorties, rapid turnaround). |
+| `ARMING_CHECK` | `1` | All arming checks enabled. Disabling checks (value 0) allows arming without GPS fix, healthy EKF, or RC calibration. Unacceptable for a 10-inch airframe near personnel. If a specific check must be bypassed (e.g., GPS not available indoors), use the bitmask to disable only that bit — not all checks. |
+
+---
+
+## Recommended Parameters
+
+| Parameter | Recommended | Why |
+|---|---|---|
+| `FS_GCS_ENABLE` | `1` | GCS heartbeat failsafe enabled. If Hydra's MAVLink connection drops mid-sortie the copter should RTL or land rather than continue flying autonomously. Value 1 = enabled. |
+| `BATT_FS_LOW_ACT` | `2` | RTL on low battery. Value 2 = RTL. Without this a copter with a failing battery continues flying until motors stop — crash risk. |
+| `FENCE_ACTION` | `1` | RTL when altitude or radius fence is breached. Value 0 = report only, which is not appropriate for operations near people. |
+| `FENCE_ALT_MAX` | `120` | **TODO: verify against your NOA/LAANC authorization.** 120m (400ft AGL) is the FAA Part 107 default ceiling. Adjust to your actual airspace authorization. |
+
+---
+
+## Stream Rates
+
+Minimum rates required on the companion port (SERIAL2). ArduCopter requires higher
+update rates than Rover for stable GUIDED mode tracking.
+
+| Parameter | Minimum Hz | Why |
+|---|---|---|
+| `SR1_POSITION` | `5` | GPS position for TAK markers, geo-tracking, and GUIDED mode waypoints. |
+| `SR1_EXTRA1` | `4` | Attitude/heading. Required for OSD orientation and approach mode pixel-lock. |
+| `SR1_EXTRA2` | `2` | Battery voltage. Required for battery warnings and failsafe monitoring. |
+| `SR1_RAW_SENS` | `2` | IMU data. Required if RF hunt mode is active. |
+
+---
+
+## GUIDED Mode — Flight Mode Channel
+
+Hydra's approach modes (follow, drop, strike, pixel-lock) all require the copter to be
+in GUIDED mode. ArduCopter uses `FLTMODE_CH` (default: channel 5) for mode switching via RC.
+
+**Verify before each sortie:**
+1. GUIDED is mapped to at least one switch position on your RC transmitter.
+2. The switch is reachable with one hand while operating the sticks.
+3. The instructor can override to LOITER or LAND from their transmitter.
+
+Hydra does not validate the flight mode map in the preflight — check manually in
+Mission Planner (Config → Flight Modes) or QGroundControl.
+
+---
+
+## Failsafe Expectations
+
+- **RC Loss:** `FS_THR_ENABLE = 1`. Copter should RTL or land on RC signal loss, not loiter indefinitely.
+- **GCS Loss:** `FS_GCS_ENABLE = 1` (see recommended). Fires when the Jetson or WiFi drops. Configure `FS_GCS_TIMEOUT` (default 5s) — do not set above 10s for field ops.
+- **Battery Low:** `BATT_FS_LOW_ACT = 2` (RTL). Configure `BATT_LOW_VOLT` to your battery's safe minimum. For 6S LiPo: typically 21.6V (3.6V/cell).
+- **Battery Critical:** `BATT_FS_CRT_ACT = 1` (Land immediately). At critical voltage, RTL may not complete before battery failure — land is safer.
+- **EKF Failsafe:** `FS_EKF_ACTION = 2` (Land). EKF failures in flight are a serious condition; landing in place is safer than trying to navigate.
+- **Geofence:** `FENCE_ACTION = 1` (RTL). `FENCE_RADIUS` and `FENCE_ALT_MAX` must match your operating area — confirm before each sortie.
+
+---
+
+## Arming Checks
+
+`ARMING_CHECK = 1` enables all checks. When a check blocks arming, ArduCopter sends a
+STATUSTEXT explaining which check failed. Common field-blocking checks and their
+bitmask values to temporarily disable (use sparingly, restore after):
+
+| Check | Bitmask bit | Notes |
+|---|---|---|
+| GPS lock | bit 3 (value 8) | Indoor ops only. Restore before outdoor sorties. |
+| Compass | bit 4 (value 16) | Only if using GPS-based heading fallback. |
+| RC calibration | bit 6 (value 64) | Only if RC is via MAVLink RC override (companion-only ops). |
+
+To disable only GPS check: `ARMING_CHECK = 1 + (1 << 3) - (1 << 3)` — better to
+compute the bitmask value in Mission Planner's arming check GUI rather than manually.
+
+**Do not set `ARMING_CHECK = 0` on a platform operating near students.**
+
+---
+
+## Servo / Relay Assignments
+
+Engagement actions (drop, arm) are operator-configured at mission time. Hydra reads
+these from `config.ini [drop]`. The preflight does not check servo assignments because
+they only apply during armed operation and vary by loadout.
+
+```
+# Example SORCC 10-inch engagement setup (not validated by preflight)
+SERVO9_FUNCTION = 0    # GPIO — Hydra relay (payload drop)
+RELAY_PIN       = 13   # AUX1 on Pixhawk 6C
+```
+
+Set `[drop] relay_pin` in `config.ini` to match.
+
+---
+
+## Notes
+
+- `SERIAL2_BAUD = 921` encodes 921600 baud in ArduPilot's compressed format.
+- `ARMING_CHECK = 1` is the integer value for "all checks enabled." The full bitmask is
+  `0xFFFF` but ArduPilot treats `1` as "default all enabled" in practice. Verify in
+  Mission Planner that the arming check screen shows all items checked.
+- `FENCE_ALT_MAX` defaults to 100m in ArduCopter. The 120m recommendation aligns with
+  FAA Part 107 but requires appropriate airspace authorization — this is a TODO, not a
+  hard requirement. Do not fly above your authorized ceiling.
+- The 5" drone profile (`drone_5in`) is not currently implemented. The 10-inch manifest
+  covers the SORCC primary quadcopter platform. If the 5" uses different params, create
+  a separate profile.

--- a/docs/pixhawk-prereqs-drone_10in.md
+++ b/docs/pixhawk-prereqs-drone_10in.md
@@ -1,4 +1,4 @@
-# Pixhawk Prerequisites — 10-inch Quadcopter (ArduCopter)
+# Pixhawk Prerequisites: 10-inch Quadcopter (ArduCopter)
 
 Platform: 10" FPV quadcopter running ArduCopter on Pixhawk 6C.
 
@@ -9,16 +9,14 @@ validate these params live against your flight controller.
 
 ## Required Parameters
 
-These must be set correctly before running Hydra. The drone profile is the most
-safety-sensitive — a 10-inch airframe operating near personnel with wrong params is
-a serious hazard.
+These must be set correctly before running Hydra. A 10-inch airframe operating near personnel with wrong params is a serious hazard.
 
 | Parameter | Expected | Why |
 |---|---|---|
 | `FENCE_ENABLE` | `1` | Geofence required for any autonomous behavior (GUIDED mode approach, drop, strike). Without it the copter has no automatic altitude or radius boundary during Hydra-commanded sorties. |
 | `SERIAL2_PROTOCOL` | `2` | Companion computer port (TELEM2) must be MAVLink2 for Hydra connectivity. |
 | `SERIAL2_BAUD` | `921` | 921600 baud. Required for reliable heartbeat + telemetry + command throughput at CULEX tempo (multiple sorties, rapid turnaround). |
-| `ARMING_CHECK` | `1` | All arming checks enabled. Disabling checks (value 0) allows arming without GPS fix, healthy EKF, or RC calibration. Unacceptable for a 10-inch airframe near personnel. If a specific check must be bypassed (e.g., GPS not available indoors), use the bitmask to disable only that bit — not all checks. |
+| `ARMING_CHECK` | `1` | All arming checks enabled. Disabling checks (value 0) allows arming without GPS fix, healthy EKF, or RC calibration. Unacceptable near personnel. To bypass a specific check (e.g., GPS unavailable indoors), use the bitmask to disable that bit only. |
 
 ---
 
@@ -27,7 +25,7 @@ a serious hazard.
 | Parameter | Recommended | Why |
 |---|---|---|
 | `FS_GCS_ENABLE` | `1` | GCS heartbeat failsafe enabled. If Hydra's MAVLink connection drops mid-sortie the copter should RTL or land rather than continue flying autonomously. Value 1 = enabled. |
-| `BATT_FS_LOW_ACT` | `2` | RTL on low battery. Value 2 = RTL. Without this a copter with a failing battery continues flying until motors stop — crash risk. |
+| `BATT_FS_LOW_ACT` | `2` | RTL on low battery. Value 2 = RTL. Without this, a copter with a failing battery flies until motors stop. |
 | `FENCE_ACTION` | `1` | RTL when altitude or radius fence is breached. Value 0 = report only, which is not appropriate for operations near people. |
 | `FENCE_ALT_MAX` | `120` | **TODO: verify against your NOA/LAANC authorization.** 120m (400ft AGL) is the FAA Part 107 default ceiling. Adjust to your actual airspace authorization. |
 
@@ -47,7 +45,7 @@ update rates than Rover for stable GUIDED mode tracking.
 
 ---
 
-## GUIDED Mode — Flight Mode Channel
+## GUIDED Mode: Flight Mode Channel
 
 Hydra's approach modes (follow, drop, strike, pixel-lock) all require the copter to be
 in GUIDED mode. ArduCopter uses `FLTMODE_CH` (default: channel 5) for mode switching via RC.
@@ -57,19 +55,19 @@ in GUIDED mode. ArduCopter uses `FLTMODE_CH` (default: channel 5) for mode switc
 2. The switch is reachable with one hand while operating the sticks.
 3. The instructor can override to LOITER or LAND from their transmitter.
 
-Hydra does not validate the flight mode map in the preflight — check manually in
-Mission Planner (Config → Flight Modes) or QGroundControl.
+Hydra does not validate the flight mode map in the preflight. Check manually in
+Mission Planner (Config > Flight Modes) or QGroundControl.
 
 ---
 
 ## Failsafe Expectations
 
 - **RC Loss:** `FS_THR_ENABLE = 1`. Copter should RTL or land on RC signal loss, not loiter indefinitely.
-- **GCS Loss:** `FS_GCS_ENABLE = 1` (see recommended). Fires when the Jetson or WiFi drops. Configure `FS_GCS_TIMEOUT` (default 5s) — do not set above 10s for field ops.
+- **GCS Loss:** `FS_GCS_ENABLE = 1` (see recommended). Fires when the Jetson or WiFi drops. Configure `FS_GCS_TIMEOUT` (default 5s). Do not set above 10s for field ops.
 - **Battery Low:** `BATT_FS_LOW_ACT = 2` (RTL). Configure `BATT_LOW_VOLT` to your battery's safe minimum. For 6S LiPo: typically 21.6V (3.6V/cell).
-- **Battery Critical:** `BATT_FS_CRT_ACT = 1` (Land immediately). At critical voltage, RTL may not complete before battery failure — land is safer.
+- **Battery Critical:** `BATT_FS_CRT_ACT = 1` (Land immediately). At critical voltage, RTL may not complete before battery failure. Land in place is safer.
 - **EKF Failsafe:** `FS_EKF_ACTION = 2` (Land). EKF failures in flight are a serious condition; landing in place is safer than trying to navigate.
-- **Geofence:** `FENCE_ACTION = 1` (RTL). `FENCE_RADIUS` and `FENCE_ALT_MAX` must match your operating area — confirm before each sortie.
+- **Geofence:** `FENCE_ACTION = 1` (RTL). `FENCE_RADIUS` and `FENCE_ALT_MAX` must match your operating area. Confirm before each sortie.
 
 ---
 
@@ -85,8 +83,7 @@ bitmask values to temporarily disable (use sparingly, restore after):
 | Compass | bit 4 (value 16) | Only if using GPS-based heading fallback. |
 | RC calibration | bit 6 (value 64) | Only if RC is via MAVLink RC override (companion-only ops). |
 
-To disable only GPS check: `ARMING_CHECK = 1 + (1 << 3) - (1 << 3)` — better to
-compute the bitmask value in Mission Planner's arming check GUI rather than manually.
+To disable only GPS check: compute the bitmask in Mission Planner's arming check GUI rather than manually.
 
 **Do not set `ARMING_CHECK = 0` on a platform operating near students.**
 
@@ -115,7 +112,7 @@ Set `[drop] relay_pin` in `config.ini` to match.
   `0xFFFF` but ArduPilot treats `1` as "default all enabled" in practice. Verify in
   Mission Planner that the arming check screen shows all items checked.
 - `FENCE_ALT_MAX` defaults to 100m in ArduCopter. The 120m recommendation aligns with
-  FAA Part 107 but requires appropriate airspace authorization — this is a TODO, not a
+  FAA Part 107 but requires appropriate airspace authorization. This is a TODO, not a
   hard requirement. Do not fly above your authorized ceiling.
 - The 5" drone profile (`drone_5in`) is not currently implemented. The 10-inch manifest
   covers the SORCC primary quadcopter platform. If the 5" uses different params, create

--- a/docs/pixhawk-prereqs-ugv.md
+++ b/docs/pixhawk-prereqs-ugv.md
@@ -1,0 +1,87 @@
+# Pixhawk Prerequisites — UGV (ArduRover)
+
+Platform: Traxxas Stampede running ArduRover on Pixhawk 6C.
+
+Run `python scripts/pixhawk_preflight.py --profile ugv --conn /dev/ttyACM0` to validate
+these params live against your flight controller.
+
+---
+
+## Required Parameters
+
+These must be set correctly before running Hydra. Wrong values here cause silent failures —
+the system will appear to work but autonomous behavior will not function safely.
+
+| Parameter | Expected | Why |
+|---|---|---|
+| `FENCE_ENABLE` | `1` | Geofence required for any autonomous behavior. Without it the rover can drive beyond the operating area with no automatic recovery. |
+| `SERIAL2_PROTOCOL` | `2` | Companion computer port (TELEM2) must be MAVLink2. MAVLink1 works but loses long-parameter and signed-message support. |
+| `SERIAL2_BAUD` | `921` | 921600 baud required for Hydra's heartbeat + param + command traffic. 57/115 are too slow under load. |
+
+---
+
+## Recommended Parameters
+
+Not required to start Hydra, but strongly recommended for field operations. A mismatch
+generates a `[WARN]` in the preflight report and does not block the run.
+
+| Parameter | Recommended | Why |
+|---|---|---|
+| `BATT_FS_LOW_ACT` | `2` | RTL on low battery. Without this, the rover continues until the battery dies and loses comms. Value 2 = RTL. |
+| `FENCE_ACTION` | `1` | RTL when fence is breached. Value 0 (report only) means the rover ignores the fence boundary. |
+| `FENCE_MARGIN` | `2` | 2-meter breach margin before escalation to LAND. Prevents hard stops exactly at the fence boundary. |
+| `FS_GCS_ENABLE` | `2` | GCS heartbeat failsafe enabled. If the Hydra companion loses MAVLink, the rover should RTL rather than freeze in place. |
+
+---
+
+## Stream Rates
+
+Minimum rates required on the companion port (SERIAL2). These affect how quickly Hydra
+receives GPS, telemetry, and attitude data from the autopilot.
+
+Set via `SRx_*` parameters where `x` maps to your connection port. If the companion is
+connected to SERIAL2 (TELEM2), use `SR2_*`. If using a MAVProxy router that maps to SR1,
+use `SR1_*`. Match these to whatever SRx index corresponds to the companion port in your setup.
+
+| Parameter | Minimum Hz | Why |
+|---|---|---|
+| `SR1_POSITION` | `5` | GPS position data for TAK markers and geo-tracking. Below 5 Hz, the map track lags noticeably. |
+| `SR1_EXTRA1` | `4` | Attitude/heading. Used for OSD orientation display. |
+| `SR1_EXTRA2` | `2` | Battery voltage and current. Used for battery warnings. |
+| `SR1_RAW_SENS` | `2` | IMU data. Required if RF hunt mode is active. |
+
+---
+
+## Failsafe Expectations
+
+- **RC Loss:** Set `FS_THR_ENABLE = 1`. The rover should return to launch (RTL) or hold in place — do not set to disabled.
+- **GCS Loss:** `FS_GCS_ENABLE = 2` (see recommended above). RTL after 5 seconds of missed heartbeats.
+- **Battery:** `BATT_FS_LOW_ACT = 2` triggers RTL at low voltage. `BATT_FS_CRT_ACT = 1` (Hold) or `2` (RTL) for critical.
+- **Geofence:** `FENCE_ACTION = 1` (RTL) on breach. Confirm `FENCE_RADIUS` and `FENCE_ALT_MAX` match your operating area.
+
+---
+
+## Servo / Relay Assignments
+
+Engagement actions (drop, arm) are operator-configured at mission time. Hydra reads
+these from `config.ini [drop]` — it does not require or validate specific servo assignments.
+
+The preflight does not check servo functions because they are valid only during armed
+operation and vary by loadout. Document your team's setup here for reference:
+
+```
+# Example SORCC UGV engagement setup (not validated by preflight)
+SERVO9_FUNCTION = 0    # GPIO — Hydra relay control
+RELAY_PIN       = 13   # AUX1 on Pixhawk 6C
+```
+
+Set `[drop] relay_pin` in `config.ini` to match.
+
+---
+
+## Notes
+
+- `SERIAL2_BAUD = 921` encodes 921600 baud in ArduPilot's compressed format (value `921` = 921600).
+- If using MAVProxy as a router, set baud on the MAVProxy master port, not on the ArduPilot serial port directly.
+- Stream rates set in Mission Planner apply immediately but do not persist across reboots unless saved. Run **Write Params** after adjusting.
+- The UGV profile does not check `FLTMODE_CH` because ArduRover does not use flight mode channels the same way ArduCopter does. Mode switching is done via `MODE_CH` (default CH 8 for Rover); verify GUIDED is reachable on your RC transmitter.

--- a/docs/pixhawk-prereqs-ugv.md
+++ b/docs/pixhawk-prereqs-ugv.md
@@ -1,4 +1,4 @@
-# Pixhawk Prerequisites — UGV (ArduRover)
+# Pixhawk Prerequisites: UGV (ArduRover)
 
 Platform: Traxxas Stampede running ArduRover on Pixhawk 6C.
 
@@ -9,8 +9,7 @@ these params live against your flight controller.
 
 ## Required Parameters
 
-These must be set correctly before running Hydra. Wrong values here cause silent failures —
-the system will appear to work but autonomous behavior will not function safely.
+These must be set correctly before running Hydra. Wrong values cause silent failures: the system starts but autonomous behavior will not work safely.
 
 | Parameter | Expected | Why |
 |---|---|---|
@@ -54,7 +53,7 @@ use `SR1_*`. Match these to whatever SRx index corresponds to the companion port
 
 ## Failsafe Expectations
 
-- **RC Loss:** Set `FS_THR_ENABLE = 1`. The rover should return to launch (RTL) or hold in place — do not set to disabled.
+- **RC Loss:** Set `FS_THR_ENABLE = 1`. RTL or hold on RC loss. Do not disable.
 - **GCS Loss:** `FS_GCS_ENABLE = 2` (see recommended above). RTL after 5 seconds of missed heartbeats.
 - **Battery:** `BATT_FS_LOW_ACT = 2` triggers RTL at low voltage. `BATT_FS_CRT_ACT = 1` (Hold) or `2` (RTL) for critical.
 - **Geofence:** `FENCE_ACTION = 1` (RTL) on breach. Confirm `FENCE_RADIUS` and `FENCE_ALT_MAX` match your operating area.
@@ -64,7 +63,7 @@ use `SR1_*`. Match these to whatever SRx index corresponds to the companion port
 ## Servo / Relay Assignments
 
 Engagement actions (drop, arm) are operator-configured at mission time. Hydra reads
-these from `config.ini [drop]` — it does not require or validate specific servo assignments.
+these from `config.ini [drop]`. The preflight does not require or validate specific servo assignments.
 
 The preflight does not check servo functions because they are valid only during armed
 operation and vary by loadout. Document your team's setup here for reference:

--- a/docs/pixhawk-prereqs-usv.md
+++ b/docs/pixhawk-prereqs-usv.md
@@ -1,0 +1,87 @@
+# Pixhawk Prerequisites — USV (ArduRover, Boat Mode)
+
+Platform: Bonzai Enforcer 48" running ArduRover in boat frame mode on Pixhawk 6C.
+
+Run `python scripts/pixhawk_preflight.py --profile usv --conn /dev/ttyACM0` to validate
+these params live against your flight controller.
+
+---
+
+## Required Parameters
+
+These must be set correctly before running Hydra. The USV profile is stricter than
+the UGV profile because a boat on water has no brakes — wrong params can result in
+an unrecoverable situation.
+
+| Parameter | Expected | Why |
+|---|---|---|
+| `FRAME_CLASS` | `2` | Value 2 = Boat frame. ArduRover defaults to wheeled skid-steer (value 1). Without this, steering geometry is wrong and failsafe behavior is incorrect for a single-thruster + rudder platform. |
+| `FENCE_ENABLE` | `1` | Geofence required for any autonomous behavior. Critical on water — a boat that exits the operating area cannot be physically stopped. |
+| `SERIAL2_PROTOCOL` | `2` | Companion computer port (TELEM2) must be MAVLink2 for Hydra connectivity. |
+| `SERIAL2_BAUD` | `921` | 921600 baud. The Enforcer's RF link is already a latency bottleneck — don't add serial lag from a slow baud rate. |
+
+---
+
+## Recommended Parameters
+
+| Parameter | Recommended | Why |
+|---|---|---|
+| `BATT_FS_LOW_ACT` | `2` | RTL on low battery. On water this is critical — a dead boat drifts. Value 2 = RTL. Value 1 = Hold (stays in place, still dangerous). |
+| `FENCE_ACTION` | `1` | RTL when fence is breached. Report-only (value 0) provides no recovery on water where there's no physical barrier to stop drift. |
+| `FENCE_MARGIN` | `2` | 2-meter breach margin. Boats have more momentum than rovers; the margin gives the autopilot time to arrest heading before hard-land escalation. |
+| `FS_GCS_ENABLE` | `2` | GCS heartbeat failsafe. Loss of Hydra MAVLink on water means the boat is operating without situational awareness — should RTL. |
+| `PILOT_STEER_TYPE` | `1` | Two-paddle steering (separate throttle + rudder channels). Ensures the RC pilot can override Hydra commands cleanly. Value 0 (skid steer) is incorrect for a single-thruster + rudder boat. |
+
+---
+
+## Stream Rates
+
+Minimum rates required on the companion port (SERIAL2). Match the `SRx_*` index to your
+actual companion port mapping (see UGV doc for indexing notes).
+
+| Parameter | Minimum Hz | Why |
+|---|---|---|
+| `SR1_POSITION` | `5` | GPS position for TAK markers and geo-tracking. Below 5 Hz the map track lags. |
+| `SR1_EXTRA1` | `4` | Attitude/heading. Required for OSD and approach mode orientation. |
+| `SR1_EXTRA2` | `2` | Battery voltage. Required for battery warnings and failsafe monitoring. |
+| `SR1_RAW_SENS` | `2` | IMU data. Required if RF hunt mode is active. |
+
+---
+
+## Failsafe Expectations
+
+- **RC Loss:** Confirm `FS_THR_ENABLE = 1`. On water, losing RC with no failsafe means the boat runs free until the battery dies.
+- **GCS Loss:** `FS_GCS_ENABLE = 2` triggers RTL after missed heartbeats. This fires if the Jetson or its WiFi drops.
+- **Battery:** `BATT_FS_LOW_ACT = 2`. On water, RTL is the only safe response to low battery — the boat cannot be walked back.
+- **Geofence:** `FENCE_ACTION = 1` (RTL). Set `FENCE_RADIUS` to the radius of the operating waterway. `FENCE_ALT_MAX` is not applicable for surface vehicles but should be set to a safe value (e.g. 10m) to prevent false triggers from GPS altitude noise.
+
+---
+
+## Servo / Relay Assignments
+
+Engagement actions (drop, arm) are operator-configured at mission time and not validated
+by the preflight check. Document your setup for reference:
+
+```
+# Example SORCC USV engagement setup (not validated by preflight)
+SERVO9_FUNCTION  = 0   # GPIO — Hydra relay (payload drop)
+SERVO10_FUNCTION = 0   # GPIO — Hydra relay (arm activation, if equipped)
+RELAY_PIN        = 13  # AUX1 on Pixhawk 6C
+```
+
+Set `[drop] relay_pin` in `config.ini` to match.
+
+---
+
+## Notes
+
+- `FRAME_CLASS = 2` is the most commonly missed param for USV setups. Mission Planner
+  sometimes shows the vehicle type as "Rover" even when FRAME_CLASS is wrong — verify
+  in the Full Parameter List, not the vehicle type selector.
+- Verify `FRAME_TYPE` as well. For the Enforcer (single thruster, rudder steering):
+  `FRAME_TYPE` should be the value appropriate for your propulsion layout. Check the
+  ArduPilot Rover FRAME_TYPE docs for your specific hull configuration.
+  **TODO: Confirm exact FRAME_TYPE value for Bonzai Enforcer with Hydra platform SME.**
+- `SERIAL2_BAUD = 921` encodes 921600 baud in ArduPilot's compressed format.
+- The `PILOT_STEER_TYPE = 1` recommendation assumes standard two-channel RC input
+  (throttle + rudder). If your Enforcer uses a mixer-based single-stick input, adjust accordingly.

--- a/docs/pixhawk-prereqs-usv.md
+++ b/docs/pixhawk-prereqs-usv.md
@@ -1,4 +1,4 @@
-# Pixhawk Prerequisites — USV (ArduRover, Boat Mode)
+# Pixhawk Prerequisites: USV (ArduRover, Boat Mode)
 
 Platform: Bonzai Enforcer 48" running ArduRover in boat frame mode on Pixhawk 6C.
 
@@ -10,15 +10,14 @@ these params live against your flight controller.
 ## Required Parameters
 
 These must be set correctly before running Hydra. The USV profile is stricter than
-the UGV profile because a boat on water has no brakes — wrong params can result in
-an unrecoverable situation.
+the UGV profile because a boat on water has no brakes. Wrong params can result in an unrecoverable situation.
 
 | Parameter | Expected | Why |
 |---|---|---|
 | `FRAME_CLASS` | `2` | Value 2 = Boat frame. ArduRover defaults to wheeled skid-steer (value 1). Without this, steering geometry is wrong and failsafe behavior is incorrect for a single-thruster + rudder platform. |
-| `FENCE_ENABLE` | `1` | Geofence required for any autonomous behavior. Critical on water — a boat that exits the operating area cannot be physically stopped. |
+| `FENCE_ENABLE` | `1` | Geofence required for any autonomous behavior. Critical on water: a boat that exits the operating area cannot be physically stopped. |
 | `SERIAL2_PROTOCOL` | `2` | Companion computer port (TELEM2) must be MAVLink2 for Hydra connectivity. |
-| `SERIAL2_BAUD` | `921` | 921600 baud. The Enforcer's RF link is already a latency bottleneck — don't add serial lag from a slow baud rate. |
+| `SERIAL2_BAUD` | `921` | 921600 baud. The Enforcer's RF link is already a latency bottleneck. Don't add serial lag from a slow baud rate. |
 
 ---
 
@@ -26,10 +25,10 @@ an unrecoverable situation.
 
 | Parameter | Recommended | Why |
 |---|---|---|
-| `BATT_FS_LOW_ACT` | `2` | RTL on low battery. On water this is critical — a dead boat drifts. Value 2 = RTL. Value 1 = Hold (stays in place, still dangerous). |
+| `BATT_FS_LOW_ACT` | `2` | RTL on low battery. On water a dead boat drifts. Value 2 = RTL. Value 1 = Hold (stays in place, still dangerous). |
 | `FENCE_ACTION` | `1` | RTL when fence is breached. Report-only (value 0) provides no recovery on water where there's no physical barrier to stop drift. |
 | `FENCE_MARGIN` | `2` | 2-meter breach margin. Boats have more momentum than rovers; the margin gives the autopilot time to arrest heading before hard-land escalation. |
-| `FS_GCS_ENABLE` | `2` | GCS heartbeat failsafe. Loss of Hydra MAVLink on water means the boat is operating without situational awareness — should RTL. |
+| `FS_GCS_ENABLE` | `2` | GCS heartbeat failsafe. Loss of Hydra MAVLink on water means the boat has no situational awareness. Should RTL. |
 | `PILOT_STEER_TYPE` | `1` | Two-paddle steering (separate throttle + rudder channels). Ensures the RC pilot can override Hydra commands cleanly. Value 0 (skid steer) is incorrect for a single-thruster + rudder boat. |
 
 ---
@@ -52,7 +51,7 @@ actual companion port mapping (see UGV doc for indexing notes).
 
 - **RC Loss:** Confirm `FS_THR_ENABLE = 1`. On water, losing RC with no failsafe means the boat runs free until the battery dies.
 - **GCS Loss:** `FS_GCS_ENABLE = 2` triggers RTL after missed heartbeats. This fires if the Jetson or its WiFi drops.
-- **Battery:** `BATT_FS_LOW_ACT = 2`. On water, RTL is the only safe response to low battery — the boat cannot be walked back.
+- **Battery:** `BATT_FS_LOW_ACT = 2`. RTL on low battery. On water the boat cannot be walked back.
 - **Geofence:** `FENCE_ACTION = 1` (RTL). Set `FENCE_RADIUS` to the radius of the operating waterway. `FENCE_ALT_MAX` is not applicable for surface vehicles but should be set to a safe value (e.g. 10m) to prevent false triggers from GPS altitude noise.
 
 ---
@@ -76,7 +75,7 @@ Set `[drop] relay_pin` in `config.ini` to match.
 ## Notes
 
 - `FRAME_CLASS = 2` is the most commonly missed param for USV setups. Mission Planner
-  sometimes shows the vehicle type as "Rover" even when FRAME_CLASS is wrong — verify
+  sometimes shows the vehicle type as "Rover" even when FRAME_CLASS is wrong. Verify
   in the Full Parameter List, not the vehicle type selector.
 - Verify `FRAME_TYPE` as well. For the Enforcer (single thruster, rudder steering):
   `FRAME_TYPE` should be the value appropriate for your propulsion layout. Check the

--- a/hydra_detect/profiles/drone_10in/pixhawk_prereqs.yaml
+++ b/hydra_detect/profiles/drone_10in/pixhawk_prereqs.yaml
@@ -1,0 +1,79 @@
+profile: drone_10in
+firmware: ArduCopter
+
+# ArduCopter 10" FPV quadcopter Pixhawk prerequisites for Hydra Detect.
+# Required = Hydra will not function correctly without these.
+# Recommended = strong operational best practice.
+
+required:
+  - name: FENCE_ENABLE
+    expected: 1
+    reason: >
+      Geofence required for any autonomous behavior (GUIDED mode approach,
+      drop, strike). Without it the copter has no automatic altitude or
+      radius boundary during Hydra-commanded sorties.
+
+  - name: SERIAL2_PROTOCOL
+    expected: 2
+    reason: >
+      Companion computer port (TELEM2) must be MAVLink2 for Hydra connectivity.
+
+  - name: SERIAL2_BAUD
+    expected: 921
+    reason: >
+      921600 baud. Required for reliable heartbeat + telemetry + command
+      throughput at CULEX tempo (multiple sorties, rapid turnaround).
+
+  - name: ARMING_CHECK
+    expected: 1
+    reason: >
+      Value 1 = all arming checks enabled. Disabling checks (value 0) allows
+      arming without GPS fix, healthy EKF, or RC calibration — unacceptable
+      on a 10-inch airframe operating near personnel. If GPS-check interference
+      is needed in a specific environment, use the bitmask to disable only
+      that bit rather than disabling all checks (see ArduPilot docs).
+
+# Stream rates — minimum Hz on companion port (SERIAL2).
+stream_rates:
+  SR1_POSITION: 5
+  SR1_EXTRA1: 4
+  SR1_EXTRA2: 2
+  SR1_RAW_SENS: 2
+
+recommended:
+  - name: FS_GCS_ENABLE
+    expected: 1
+    reason: >
+      Enable GCS heartbeat failsafe. If Hydra's MAVLink connection drops
+      mid-sortie the copter should RTL or land rather than continue flying
+      autonomously without situational awareness. Value 1 = enabled.
+
+  - name: BATT_FS_LOW_ACT
+    expected: 2
+    reason: >
+      RTL on low battery. Value 2 = RTL. Without this a copter with a failing
+      battery will continue flying until motors stop — crash risk.
+
+  - name: FENCE_ACTION
+    expected: 1
+    reason: >
+      RTL when altitude or radius fence is breached. Value 0 = report only
+      (no recovery action), which is not appropriate for operations near people.
+
+  - name: FENCE_ALT_MAX
+    expected: 120
+    reason: >
+      TODO: verify local airspace altitude limit. 120m (400ft AGL) is the
+      FAA Part 107 default ceiling. Adjust to your NOA/LAANC authorization.
+      This is a recommended cap — Hydra does not validate altitude limits.
+
+# Flight mode channel — ArduCopter uses FLTMODE_CH (default 5).
+# GUIDED must be reachable on this channel for Hydra approach modes.
+# Verify your RC transmitter has GUIDED mapped to a switch position.
+# Hydra does not validate the flight mode map — check manually in Mission Planner.
+#
+# Servo/relay function assignments for engagement modes.
+# Operator-configurable at mission time — not validated by preflight.
+# Typical 10-inch setup:
+#   SERVO9_FUNCTION = 0  (GPIO relay — Hydra-controlled payload drop)
+# Set in config.ini [drop] section.

--- a/hydra_detect/profiles/ugv/pixhawk_prereqs.yaml
+++ b/hydra_detect/profiles/ugv/pixhawk_prereqs.yaml
@@ -1,0 +1,68 @@
+profile: ugv
+firmware: ArduRover
+
+# ArduRover UGV (Traxxas Stampede) Pixhawk prerequisites for Hydra Detect.
+# Required = Hydra will not function correctly without these.
+# Recommended = strong operational best practice, but Hydra will still run.
+
+required:
+  - name: FENCE_ENABLE
+    expected: 1
+    reason: >
+      Geofence required for any autonomous behavior. Without it the rover can
+      drive beyond the operating area with no automatic recovery.
+
+  - name: SERIAL2_PROTOCOL
+    expected: 2
+    reason: >
+      Companion computer port (TELEM2) must be set to MAVLink2. MAVLink1
+      (value 1) works but loses long-parameter and signed-message support.
+
+  - name: SERIAL2_BAUD
+    expected: 921
+    reason: >
+      921600 baud required for Hydra's heartbeat + param + command traffic.
+      Lower rates cause message drops under load (57 and 115 are too slow).
+
+# Stream rates — values are minimum Hz on SERIAL2 (companion computer port).
+# SR1 maps to TELEM2 when the companion is on SERIAL2 with SRx overrides.
+# If your setup uses SR2 instead (SERIAL2 with no SRx remap), adjust accordingly.
+stream_rates:
+  SR1_POSITION: 5
+  SR1_EXTRA1: 4
+  SR1_EXTRA2: 2
+  SR1_RAW_SENS: 2
+
+recommended:
+  - name: BATT_FS_LOW_ACT
+    expected: 2
+    reason: >
+      RTL on low battery. Without this, the rover will continue running until
+      the battery dies and loses comms with no automatic recovery.
+
+  - name: FENCE_ACTION
+    expected: 1
+    reason: >
+      RTL when fence breached. Value 0 (report only) means the rover ignores
+      the fence boundary — defeat the purpose of having a fence.
+
+  - name: FENCE_MARGIN
+    expected: 2
+    reason: >
+      2-meter breach margin before escalation to LAND. Prevents hard stops at
+      the exact fence boundary; gives the mission controller time to respond.
+
+  - name: FS_GCS_ENABLE
+    expected: 2
+    reason: >
+      Enable GCS heartbeat failsafe. If the Hydra companion loses MAVLink
+      the rover should RTL rather than freeze in place.
+
+# Servo/relay function assignments for engagement modes.
+# These are operator-set at mission time; Hydra reads them but does not
+# require specific values for DROP/ARM/STRIKE actions.
+# Document your setup in config.ini [drop] section.
+#
+# Typical SORCC UGV setup (not validated by preflight):
+#   SERVO9_FUNCTION = 0  (GPIO — controlled by Hydra relay)
+#   RELAY_PIN = 13       (matches Pixhawk 6C AUX1)

--- a/hydra_detect/profiles/usv/pixhawk_prereqs.yaml
+++ b/hydra_detect/profiles/usv/pixhawk_prereqs.yaml
@@ -1,0 +1,79 @@
+profile: usv
+firmware: ArduRover
+
+# ArduRover USV (Bonzai Enforcer 48") Pixhawk prerequisites for Hydra Detect.
+# ArduRover runs both ground and surface vehicles; FRAME_CLASS=2 selects boat mode.
+# Required = Hydra will not function correctly without these.
+# Recommended = strong operational best practice.
+
+required:
+  - name: FRAME_CLASS
+    expected: 2
+    reason: >
+      Value 2 = Boat frame. Without this, ArduRover treats the platform as a
+      wheeled skid-steer rover and applies incorrect steering geometry and
+      failsafe behavior. The Enforcer will not track correctly in any mode.
+
+  - name: FENCE_ENABLE
+    expected: 1
+    reason: >
+      Geofence required for any autonomous behavior. Critical on water — a
+      boat that exits the operating area cannot be physically stopped the way
+      a rover can. RTL on breach is the only recovery.
+
+  - name: SERIAL2_PROTOCOL
+    expected: 2
+    reason: >
+      Companion computer port (TELEM2) must be MAVLink2 for Hydra connectivity.
+
+  - name: SERIAL2_BAUD
+    expected: 921
+    reason: >
+      921600 baud. Lower rates cause message drops; the Enforcer's RF link
+      is already a latency bottleneck — don't add serial lag.
+
+# Stream rates — minimum Hz on companion port (SERIAL2).
+stream_rates:
+  SR1_POSITION: 5
+  SR1_EXTRA1: 4
+  SR1_EXTRA2: 2
+  SR1_RAW_SENS: 2
+
+recommended:
+  - name: BATT_FS_LOW_ACT
+    expected: 2
+    reason: >
+      RTL on low battery. On water this is critical — a dead boat drifts.
+      Value 2 = RTL. Value 1 = Hold (stays in place, still dangerous).
+
+  - name: FENCE_ACTION
+    expected: 1
+    reason: >
+      RTL when fence breached. Report-only (value 0) provides no recovery
+      on water where there's no physical barrier to stop drift.
+
+  - name: FENCE_MARGIN
+    expected: 2
+    reason: >
+      2-meter breach margin. Boats have more momentum than rovers; the margin
+      gives the autopilot time to arrest heading before hard-land escalation.
+
+  - name: FS_GCS_ENABLE
+    expected: 2
+    reason: >
+      Enable GCS heartbeat failsafe. Loss of Hydra MAVLink on water means
+      the boat is operating without situational awareness — should RTL.
+
+  - name: PILOT_STEER_TYPE
+    expected: 1
+    reason: >
+      Value 1 = two-paddle steering (separate throttle + rudder channels).
+      Ensures the RC pilot can override Hydra commands cleanly. Value 0
+      (skid steer) is incorrect for a single-thruster + rudder boat.
+
+# Servo/relay function assignments for engagement modes.
+# Operator-configurable at mission time — not validated by preflight.
+# On the Enforcer, AUX channels are typically used for:
+#   SERVO9_FUNCTION = 0  (GPIO relay — Hydra-controlled payload drop)
+#   SERVO10_FUNCTION = 0 (GPIO relay — arm activation, if equipped)
+# Set these in config.ini [drop] section.

--- a/scripts/pixhawk_preflight.py
+++ b/scripts/pixhawk_preflight.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-pixhawk_preflight.py — Validate live ArduPilot params against a profile manifest.
+pixhawk_preflight.py: Validate live ArduPilot params against a profile manifest.
 
 Usage:
     python scripts/pixhawk_preflight.py --profile ugv --conn /dev/ttyACM0
@@ -242,7 +242,7 @@ def _fmt(value: float | None) -> str:
 def format_report(profile: str, firmware: str, results: list[PreflightResult]) -> str:
     """Format a human-readable preflight report string."""
     lines = []
-    lines.append(f"PIXHAWK PREFLIGHT — profile={profile} firmware={firmware}")
+    lines.append(f"PIXHAWK PREFLIGHT  profile={profile}  firmware={firmware}")
     lines.append("-" * 48)
     for r in results:
         lines.append(f"[{r.status:<4}] {r.message}")

--- a/scripts/pixhawk_preflight.py
+++ b/scripts/pixhawk_preflight.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""
+pixhawk_preflight.py — Validate live ArduPilot params against a profile manifest.
+
+Usage:
+    python scripts/pixhawk_preflight.py --profile ugv --conn /dev/ttyACM0
+    python scripts/pixhawk_preflight.py --profile drone_10in --conn udp:127.0.0.1:14550
+
+Exit codes:
+    0  All required params pass (warnings allowed).
+    1  One or more required params fail.
+    2  Connection failure or timeout before params collected.
+
+Read-only — never writes params to the flight controller.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).parent.parent
+_PROFILES_DIR = _REPO_ROOT / "hydra_detect" / "profiles"
+
+
+# ---------------------------------------------------------------------------
+# Data types
+# ---------------------------------------------------------------------------
+
+class PreflightResult:
+    """Single parameter check result."""
+
+    __slots__ = ("name", "status", "actual", "expected", "message")
+
+    def __init__(
+        self,
+        name: str,
+        status: str,
+        actual: float | None,
+        expected: Any,
+        message: str,
+    ) -> None:
+        self.name = name
+        self.status = status        # "PASS", "FAIL", or "WARN"
+        self.actual = actual
+        self.expected = expected
+        self.message = message
+
+    def __repr__(self) -> str:
+        return (
+            f"PreflightResult(name={self.name!r}, status={self.status!r}, "
+            f"actual={self.actual!r}, expected={self.expected!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Manifest loading
+# ---------------------------------------------------------------------------
+
+def _parse_manifest_yaml(path: Path) -> dict:
+    """Load YAML from path. Raises yaml.YAMLError on parse failure."""
+    with open(path, "r") as fh:
+        return yaml.safe_load(fh)
+
+
+def _validate_manifest_schema(data: dict, path: Path) -> None:
+    """Raise ValueError if required top-level keys are missing."""
+    for key in ("profile", "firmware"):
+        if key not in data:
+            raise ValueError(
+                f"Manifest {path} missing required key '{key}'"
+            )
+
+
+def load_manifest(profile: str) -> dict:
+    """Load and validate a profile manifest from hydra_detect/profiles/<profile>/pixhawk_prereqs.yaml.
+
+    Raises:
+        FileNotFoundError: Profile directory or manifest file does not exist.
+        ValueError: Manifest is missing required schema keys.
+        yaml.YAMLError: YAML parse failure.
+    """
+    manifest_path = _PROFILES_DIR / profile / "pixhawk_prereqs.yaml"
+    if not manifest_path.exists():
+        raise FileNotFoundError(
+            f"No manifest for profile '{profile}' at {manifest_path}"
+        )
+    data = _parse_manifest_yaml(manifest_path)
+    _validate_manifest_schema(data, manifest_path)
+    # Ensure expected list keys exist
+    data.setdefault("required", [])
+    data.setdefault("recommended", [])
+    data.setdefault("stream_rates", {})
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Validation logic
+# ---------------------------------------------------------------------------
+
+def validate_params(manifest: dict, live_params: dict[str, float]) -> list[PreflightResult]:
+    """Compare live ArduPilot params against a manifest.
+
+    Required params: PASS if value matches expected exactly; FAIL otherwise.
+    Recommended params: PASS if matches; WARN if not.
+    Stream rates: PASS if live_value >= expected; FAIL if below or missing.
+
+    Args:
+        manifest:    Loaded manifest dict (from load_manifest()).
+        live_params: Dict of {param_name: float_value} from the flight controller.
+
+    Returns:
+        List of PreflightResult, one per checked param.
+    """
+    results: list[PreflightResult] = []
+
+    # Required params — exact match
+    for entry in manifest.get("required", []):
+        name = entry["name"]
+        expected = entry["expected"]
+        if name not in live_params:
+            results.append(PreflightResult(
+                name=name,
+                status="FAIL",
+                actual=None,
+                expected=expected,
+                message=f"{name} missing from flight controller params",
+            ))
+        else:
+            actual = live_params[name]
+            if _values_match(actual, expected):
+                results.append(PreflightResult(
+                    name=name,
+                    status="PASS",
+                    actual=actual,
+                    expected=expected,
+                    message=f"{name} = {_fmt(actual)}",
+                ))
+            else:
+                results.append(PreflightResult(
+                    name=name,
+                    status="FAIL",
+                    actual=actual,
+                    expected=expected,
+                    message=f"{name} = {_fmt(actual)} (expected {expected})",
+                ))
+
+    # Recommended params — mismatch becomes WARN, not FAIL
+    for entry in manifest.get("recommended", []):
+        name = entry["name"]
+        expected = entry["expected"]
+        if name not in live_params:
+            results.append(PreflightResult(
+                name=name,
+                status="WARN",
+                actual=None,
+                expected=expected,
+                message=f"{name} missing (recommended {expected})",
+            ))
+        else:
+            actual = live_params[name]
+            if _values_match(actual, expected):
+                results.append(PreflightResult(
+                    name=name,
+                    status="PASS",
+                    actual=actual,
+                    expected=expected,
+                    message=f"{name} = {_fmt(actual)}",
+                ))
+            else:
+                results.append(PreflightResult(
+                    name=name,
+                    status="WARN",
+                    actual=actual,
+                    expected=expected,
+                    message=f"{name} = {_fmt(actual)} (recommended {expected})",
+                ))
+
+    # Stream rates — minimum threshold check (live >= expected)
+    for rate_name, min_hz in manifest.get("stream_rates", {}).items():
+        if rate_name not in live_params:
+            results.append(PreflightResult(
+                name=rate_name,
+                status="FAIL",
+                actual=None,
+                expected=min_hz,
+                message=f"{rate_name} missing (expected ≥ {min_hz})",
+            ))
+        else:
+            actual = live_params[rate_name]
+            if actual >= min_hz:
+                results.append(PreflightResult(
+                    name=rate_name,
+                    status="PASS",
+                    actual=actual,
+                    expected=min_hz,
+                    message=f"{rate_name} = {_fmt(actual)}",
+                ))
+            else:
+                results.append(PreflightResult(
+                    name=rate_name,
+                    status="FAIL",
+                    actual=actual,
+                    expected=min_hz,
+                    message=f"{rate_name} = {_fmt(actual)} (expected ≥ {min_hz})",
+                ))
+
+    return results
+
+
+def _values_match(actual: float, expected: Any) -> bool:
+    """Return True if actual float matches expected value within tolerance."""
+    try:
+        return abs(actual - float(expected)) < 0.01
+    except (TypeError, ValueError):
+        return False
+
+
+def _fmt(value: float | None) -> str:
+    """Format a param value for display. Integers shown as int, floats with 1 decimal."""
+    if value is None:
+        return "None"
+    if value == int(value):
+        return str(int(value))
+    return f"{value:.1f}"
+
+
+# ---------------------------------------------------------------------------
+# Report formatting
+# ---------------------------------------------------------------------------
+
+def format_report(profile: str, firmware: str, results: list[PreflightResult]) -> str:
+    """Format a human-readable preflight report string."""
+    lines = []
+    lines.append(f"PIXHAWK PREFLIGHT — profile={profile} firmware={firmware}")
+    lines.append("-" * 48)
+    for r in results:
+        lines.append(f"[{r.status:<4}] {r.message}")
+    lines.append("-" * 48)
+    pass_count = sum(1 for r in results if r.status == "PASS")
+    fail_count = sum(1 for r in results if r.status == "FAIL")
+    warn_count = sum(1 for r in results if r.status == "WARN")
+    lines.append(f"Summary: {pass_count} PASS, {fail_count} FAIL, {warn_count} WARN")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Exit code
+# ---------------------------------------------------------------------------
+
+def compute_exit_code(results: list[PreflightResult]) -> int:
+    """Return 0 if all PASS/WARN, 1 if any FAIL."""
+    if any(r.status == "FAIL" for r in results):
+        return 1
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# MAVLink param collection
+# ---------------------------------------------------------------------------
+
+def collect_params(
+    conn: Any,
+    timeout: float = 30.0,
+    quiescent: float = 3.0,
+) -> dict[str, float]:
+    """Request and collect all parameters from a MAVLink connection.
+
+    Sends PARAM_REQUEST_LIST, then collects PARAM_VALUE messages until no new
+    params arrive for `quiescent` seconds or `timeout` seconds total.
+
+    Args:
+        conn:      pymavlink connection (mavutil.mavlink_connection result).
+        timeout:   Hard timeout in seconds before giving up.
+        quiescent: Seconds of silence that signals collection is complete.
+
+    Returns:
+        Dict of {param_name: float_value}.
+    """
+    params: dict[str, float] = {}
+    conn.mav.param_request_list_send(conn.target_system, conn.target_component)
+
+    deadline = time.monotonic() + timeout
+    last_new = time.monotonic()
+
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        # Use a short recv window so we can check quiescent condition
+        msg = conn.recv_match(type="PARAM_VALUE", blocking=True, timeout=min(0.5, remaining))
+        if msg is None:
+            # No message in window — check quiescent
+            if time.monotonic() - last_new >= quiescent:
+                break
+            continue
+        # Strip null bytes from MAVLink fixed-length param_id strings
+        param_name = msg.param_id.rstrip("\x00").strip()
+        if param_name and param_name not in params:
+            params[param_name] = float(msg.param_value)
+            last_new = time.monotonic()
+
+    return params
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Validate Pixhawk params against a Hydra profile manifest.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--profile",
+        required=True,
+        choices=["ugv", "usv", "drone_10in"],
+        help="Vehicle profile to validate against.",
+    )
+    parser.add_argument(
+        "--conn",
+        default="/dev/ttyACM0",
+        help="MAVLink connection string (default: /dev/ttyACM0).",
+    )
+    parser.add_argument(
+        "--baud",
+        type=int,
+        default=115200,
+        help="Serial baud rate (default: 115200, ignored for UDP/TCP connections).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=30,
+        help="Seconds to wait for param collection (default: 30).",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI main — returns exit code."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    # Load manifest before connecting so a bad profile arg fails fast
+    try:
+        manifest = load_manifest(args.profile)
+    except (FileNotFoundError, ValueError, yaml.YAMLError) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
+    # Import pymavlink here so the rest of the module is importable without it
+    try:
+        from pymavlink import mavutil
+    except ImportError:
+        print("ERROR: pymavlink not installed. Run: pip install pymavlink", file=sys.stderr)
+        return 2
+
+    # Connect
+    try:
+        conn = mavutil.mavlink_connection(args.conn, baud=args.baud)
+        print(f"Connecting to {args.conn} ...", flush=True)
+        conn.wait_heartbeat(timeout=args.timeout)
+    except Exception as exc:
+        print(f"ERROR: Connection failed: {exc}", file=sys.stderr)
+        return 2
+
+    print(f"Connected: system {conn.target_system} component {conn.target_component}")
+    print("Requesting params ...", flush=True)
+
+    try:
+        live_params = collect_params(conn, timeout=args.timeout)
+    except Exception as exc:
+        print(f"ERROR: Param collection failed: {exc}", file=sys.stderr)
+        return 2
+
+    if not live_params:
+        print("ERROR: No params received (timeout).", file=sys.stderr)
+        return 2
+
+    print(f"Received {len(live_params)} params.")
+
+    results = validate_params(manifest, live_params)
+    report = format_report(manifest["profile"], manifest["firmware"], results)
+    print(report)
+
+    return compute_exit_code(results)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_pixhawk_preflight.py
+++ b/tests/test_pixhawk_preflight.py
@@ -1,0 +1,535 @@
+"""Tests for scripts/pixhawk_preflight.py — Pixhawk prerequisite validation."""
+
+from __future__ import annotations
+
+import sys
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Helpers to import the script under test without a MAVLink connection
+# ---------------------------------------------------------------------------
+
+SCRIPT_PATH = Path(__file__).parent.parent / "scripts" / "pixhawk_preflight.py"
+MANIFEST_DIR = Path(__file__).parent.parent / "hydra_detect" / "profiles"
+
+
+def _load_preflight_module():
+    """Import pixhawk_preflight.py as a module (not __main__).
+
+    Registers under 'pixhawk_preflight' in sys.modules so any module-level
+    machinery that does module lookups finds it correctly.
+    """
+    module_name = "pixhawk_preflight"
+    if module_name in sys.modules:
+        return sys.modules[module_name]
+    spec = importlib.util.spec_from_file_location(module_name, SCRIPT_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Manifest loader tests
+# ---------------------------------------------------------------------------
+
+class TestManifestLoader:
+    """Tests for load_manifest()."""
+
+    def test_loads_ugv_manifest(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("ugv")
+        assert manifest["profile"] == "ugv"
+        assert manifest["firmware"] == "ArduRover"
+        assert "required" in manifest
+        assert "recommended" in manifest
+        assert "stream_rates" in manifest
+
+    def test_loads_usv_manifest(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("usv")
+        assert manifest["profile"] == "usv"
+        assert manifest["firmware"] == "ArduRover"
+
+    def test_loads_drone_10in_manifest(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("drone_10in")
+        assert manifest["profile"] == "drone_10in"
+        assert manifest["firmware"] == "ArduCopter"
+
+    def test_missing_profile_raises(self):
+        mod = _load_preflight_module()
+        with pytest.raises(FileNotFoundError):
+            mod.load_manifest("nonexistent_profile")
+
+    def test_manifest_required_entries_have_name_expected_reason(self):
+        mod = _load_preflight_module()
+        for profile in ("ugv", "usv", "drone_10in"):
+            manifest = mod.load_manifest(profile)
+            for entry in manifest.get("required", []):
+                assert "name" in entry, f"{profile}: required entry missing 'name'"
+                assert "expected" in entry, f"{profile}: required entry missing 'expected'"
+                assert "reason" in entry, f"{profile}: required entry missing 'reason'"
+
+    def test_manifest_recommended_entries_have_name_expected_reason(self):
+        mod = _load_preflight_module()
+        for profile in ("ugv", "usv", "drone_10in"):
+            manifest = mod.load_manifest(profile)
+            for entry in manifest.get("recommended", []):
+                assert "name" in entry
+                assert "expected" in entry
+                assert "reason" in entry
+
+    def test_invalid_yaml_raises(self, tmp_path):
+        mod = _load_preflight_module()
+        bad_yaml = tmp_path / "bad.yaml"
+        bad_yaml.write_text("{ not: valid: yaml: [}")
+        with pytest.raises(Exception):
+            mod._parse_manifest_yaml(bad_yaml)
+
+    def test_manifest_schema_missing_profile_key_raises(self, tmp_path):
+        mod = _load_preflight_module()
+        data = {"firmware": "ArduRover", "required": [], "recommended": [], "stream_rates": {}}
+        yaml_file = tmp_path / "manifest.yaml"
+        yaml_file.write_text(yaml.dump(data))
+        with pytest.raises(ValueError, match="profile"):
+            mod._validate_manifest_schema(data, yaml_file)
+
+    def test_manifest_schema_missing_firmware_key_raises(self, tmp_path):
+        mod = _load_preflight_module()
+        data = {"profile": "ugv", "required": [], "recommended": [], "stream_rates": {}}
+        yaml_file = tmp_path / "manifest.yaml"
+        yaml_file.write_text(yaml.dump(data))
+        with pytest.raises(ValueError, match="firmware"):
+            mod._validate_manifest_schema(data, yaml_file)
+
+
+# ---------------------------------------------------------------------------
+# Validator tests — synthetic param dicts
+# ---------------------------------------------------------------------------
+
+class TestValidateParams:
+    """Tests for validate_params(manifest, live_params) -> list[Result]."""
+
+    def _make_manifest(self, required=None, recommended=None, stream_rates=None):
+        return {
+            "profile": "ugv",
+            "firmware": "ArduRover",
+            "required": required or [],
+            "recommended": recommended or [],
+            "stream_rates": stream_rates or {},
+        }
+
+    def test_all_pass_required(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            required=[{"name": "FENCE_ENABLE", "expected": 1, "reason": "Geofence required"}]
+        )
+        results = mod.validate_params(manifest, {"FENCE_ENABLE": 1.0})
+        assert len(results) == 1
+        assert results[0].status == "PASS"
+        assert results[0].name == "FENCE_ENABLE"
+
+    def test_fail_wrong_required_value(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            required=[{"name": "FENCE_ENABLE", "expected": 1, "reason": "Geofence required"}]
+        )
+        results = mod.validate_params(manifest, {"FENCE_ENABLE": 0.0})
+        assert results[0].status == "FAIL"
+
+    def test_fail_missing_required_param(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            required=[{"name": "FENCE_ENABLE", "expected": 1, "reason": "Geofence required"}]
+        )
+        results = mod.validate_params(manifest, {})
+        assert results[0].status == "FAIL"
+        assert "missing" in results[0].message.lower() or results[0].actual is None
+
+    def test_warn_wrong_recommended_value(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            recommended=[{"name": "BATT_FS_LOW_ACT", "expected": 2, "reason": "RTL on low battery"}]
+        )
+        results = mod.validate_params(manifest, {"BATT_FS_LOW_ACT": 0.0})
+        assert results[0].status == "WARN"
+
+    def test_pass_correct_recommended_value(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            recommended=[{"name": "BATT_FS_LOW_ACT", "expected": 2, "reason": "RTL on low battery"}]
+        )
+        results = mod.validate_params(manifest, {"BATT_FS_LOW_ACT": 2.0})
+        assert results[0].status == "PASS"
+
+    def test_stream_rate_min_check_pass(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(stream_rates={"SR1_POSITION": 5})
+        results = mod.validate_params(manifest, {"SR1_POSITION": 5.0})
+        assert results[0].status == "PASS"
+
+    def test_stream_rate_min_check_fail_below_minimum(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(stream_rates={"SR1_POSITION": 5})
+        results = mod.validate_params(manifest, {"SR1_POSITION": 2.0})
+        assert results[0].status == "FAIL"
+        assert "≥" in results[0].message or ">=" in results[0].message
+
+    def test_stream_rate_missing_is_fail(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(stream_rates={"SR1_POSITION": 5})
+        results = mod.validate_params(manifest, {})
+        assert results[0].status == "FAIL"
+
+    def test_stream_rate_above_minimum_passes(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(stream_rates={"SR1_POSITION": 5})
+        results = mod.validate_params(manifest, {"SR1_POSITION": 10.0})
+        assert results[0].status == "PASS"
+
+    def test_multiple_results_summary_counts(self):
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            required=[
+                {"name": "FENCE_ENABLE", "expected": 1, "reason": ""},
+                {"name": "MISSING_PARAM", "expected": 1, "reason": ""},
+            ],
+            recommended=[
+                {"name": "BATT_FS_LOW_ACT", "expected": 2, "reason": ""},
+            ],
+            stream_rates={"SR1_POSITION": 5},
+        )
+        live_params = {"FENCE_ENABLE": 1.0, "BATT_FS_LOW_ACT": 0.0, "SR1_POSITION": 5.0}
+        results = mod.validate_params(manifest, live_params)
+        statuses = [r.status for r in results]
+        assert statuses.count("PASS") >= 2
+        assert statuses.count("FAIL") == 1
+        assert statuses.count("WARN") == 1
+
+
+# ---------------------------------------------------------------------------
+# Report formatting tests
+# ---------------------------------------------------------------------------
+
+class TestFormatReport:
+    """Tests for format_report(profile, firmware, results) -> str."""
+
+    def test_report_header_contains_profile_and_firmware(self):
+        mod = _load_preflight_module()
+        results = []
+        report = mod.format_report("ugv", "ArduRover", results)
+        assert "ugv" in report
+        assert "ArduRover" in report
+
+    def test_report_contains_pass_fail_warn_lines(self):
+        mod = _load_preflight_module()
+        Result = mod.PreflightResult
+        results = [
+            Result(name="FENCE_ENABLE", status="PASS", actual=1.0, expected=1, message="FENCE_ENABLE = 1"),
+            Result(name="SR1_POSITION", status="FAIL", actual=2.0, expected=5, message="SR1_POSITION = 2 (expected ≥ 5)"),
+            Result(name="BATT_FS_LOW_ACT", status="WARN", actual=0.0, expected=2, message="BATT_FS_LOW_ACT = 0 (recommended 2)"),
+        ]
+        report = mod.format_report("ugv", "ArduRover", results)
+        assert "[PASS]" in report
+        assert "[FAIL]" in report
+        assert "[WARN]" in report
+
+    def test_report_summary_line_correct(self):
+        mod = _load_preflight_module()
+        Result = mod.PreflightResult
+        results = [
+            Result(name="A", status="PASS", actual=1.0, expected=1, message="A = 1"),
+            Result(name="B", status="FAIL", actual=0.0, expected=1, message="B = 0"),
+            Result(name="C", status="WARN", actual=0.0, expected=2, message="C = 0"),
+        ]
+        report = mod.format_report("ugv", "ArduRover", results)
+        assert "1 PASS" in report
+        assert "1 FAIL" in report
+        assert "1 WARN" in report
+
+    def test_empty_results_shows_zero_summary(self):
+        mod = _load_preflight_module()
+        report = mod.format_report("usv", "ArduRover", [])
+        assert "0 PASS" in report or "Summary" in report
+
+
+# ---------------------------------------------------------------------------
+# Exit code tests (mocking the MAVLink connection)
+# ---------------------------------------------------------------------------
+
+class TestCLIExitCodes:
+    """Tests for CLI exit codes via compute_exit_code()."""
+
+    def _make_manifest(self, required=None, recommended=None, stream_rates=None):
+        return {
+            "profile": "ugv",
+            "firmware": "ArduRover",
+            "required": required or [],
+            "recommended": recommended or [],
+            "stream_rates": stream_rates or {},
+        }
+
+    def test_exit_0_all_pass(self):
+        """Exit 0 when all required params pass (warnings allowed)."""
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            required=[{"name": "FENCE_ENABLE", "expected": 1, "reason": ""}],
+            recommended=[{"name": "BATT_FS_LOW_ACT", "expected": 2, "reason": ""}],
+        )
+        live_params = {"FENCE_ENABLE": 1.0, "BATT_FS_LOW_ACT": 0.0}  # WARN allowed
+        code = mod.compute_exit_code(mod.validate_params(manifest, live_params))
+        assert code == 0
+
+    def test_exit_1_any_fail(self):
+        """Exit 1 when any required param fails."""
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            required=[{"name": "FENCE_ENABLE", "expected": 1, "reason": ""}]
+        )
+        live_params = {"FENCE_ENABLE": 0.0}
+        code = mod.compute_exit_code(mod.validate_params(manifest, live_params))
+        assert code == 1
+
+    def test_exit_1_stream_rate_fail(self):
+        """Exit 1 when stream rate is below minimum."""
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(stream_rates={"SR1_POSITION": 5})
+        live_params = {"SR1_POSITION": 2.0}
+        code = mod.compute_exit_code(mod.validate_params(manifest, live_params))
+        assert code == 1
+
+    def test_exit_0_warns_only(self):
+        """Exit 0 when only warnings (no failures)."""
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            recommended=[{"name": "BATT_FS_LOW_ACT", "expected": 2, "reason": ""}]
+        )
+        live_params = {"BATT_FS_LOW_ACT": 0.0}
+        code = mod.compute_exit_code(mod.validate_params(manifest, live_params))
+        assert code == 0
+
+    def test_exit_0_all_pass_no_warns(self):
+        """Exit 0 with all required + recommended passing."""
+        mod = _load_preflight_module()
+        manifest = self._make_manifest(
+            required=[{"name": "FENCE_ENABLE", "expected": 1, "reason": ""}],
+            recommended=[{"name": "BATT_FS_LOW_ACT", "expected": 2, "reason": ""}],
+        )
+        live_params = {"FENCE_ENABLE": 1.0, "BATT_FS_LOW_ACT": 2.0}
+        code = mod.compute_exit_code(mod.validate_params(manifest, live_params))
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# Per-profile all-pass / one-fail / one-warn / missing-required scenarios
+# ---------------------------------------------------------------------------
+
+class TestProfileScenarios:
+    """End-to-end validation scenarios using real manifests."""
+
+    @pytest.mark.parametrize("profile", ["ugv", "usv", "drone_10in"])
+    def test_all_pass_scenario(self, profile):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest(profile)
+        # Build live_params that satisfy all required + recommended + stream_rates
+        live_params = {}
+        for entry in manifest.get("required", []):
+            live_params[entry["name"]] = float(entry["expected"])
+        for entry in manifest.get("recommended", []):
+            live_params[entry["name"]] = float(entry["expected"])
+        for name, val in manifest.get("stream_rates", {}).items():
+            live_params[name] = float(val)
+        results = mod.validate_params(manifest, live_params)
+        statuses = {r.status for r in results}
+        assert "FAIL" not in statuses
+        assert "WARN" not in statuses
+        assert mod.compute_exit_code(results) == 0
+
+    @pytest.mark.parametrize("profile", ["ugv", "usv", "drone_10in"])
+    def test_one_fail_scenario(self, profile):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest(profile)
+        if not manifest.get("required"):
+            pytest.skip(f"No required params in {profile} manifest")
+        entry = manifest["required"][0]
+        live_params = {entry["name"]: float(entry["expected"]) + 99.0}  # wrong value
+        results = mod.validate_params(manifest, live_params)
+        fail_results = [r for r in results if r.status == "FAIL"]
+        assert len(fail_results) >= 1
+        assert mod.compute_exit_code(results) == 1
+
+    @pytest.mark.parametrize("profile", ["ugv", "usv", "drone_10in"])
+    def test_one_warn_scenario(self, profile):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest(profile)
+        if not manifest.get("recommended"):
+            pytest.skip(f"No recommended params in {profile} manifest")
+        # Satisfy all required and stream_rates, satisfy all recommended first,
+        # then break only the first recommended entry
+        live_params = {}
+        for entry in manifest.get("required", []):
+            live_params[entry["name"]] = float(entry["expected"])
+        for name, val in manifest.get("stream_rates", {}).items():
+            live_params[name] = float(val)
+        for entry in manifest.get("recommended", []):
+            live_params[entry["name"]] = float(entry["expected"])
+        bad_entry = manifest["recommended"][0]
+        live_params[bad_entry["name"]] = float(bad_entry["expected"]) + 99.0
+        results = mod.validate_params(manifest, live_params)
+        warn_results = [r for r in results if r.status == "WARN"]
+        assert len(warn_results) >= 1
+        assert mod.compute_exit_code(results) == 0  # WARN doesn't fail
+
+    @pytest.mark.parametrize("profile", ["ugv", "usv", "drone_10in"])
+    def test_missing_required_is_fail(self, profile):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest(profile)
+        if not manifest.get("required"):
+            pytest.skip(f"No required params in {profile} manifest")
+        # Provide nothing — all required and stream_rates should fail
+        results = mod.validate_params(manifest, {})
+        fail_results = [r for r in results if r.status == "FAIL"]
+        assert len(fail_results) >= 1
+        assert mod.compute_exit_code(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# collect_params mock tests (MAVLink connection is mocked)
+# ---------------------------------------------------------------------------
+
+class TestCollectParams:
+    """Tests for collect_params() with a mocked MAVLink connection."""
+
+    def test_returns_dict_of_params(self):
+        mod = _load_preflight_module()
+
+        mock_conn = MagicMock()
+        mock_conn.target_system = 1
+        mock_conn.target_component = 1
+
+        param1 = MagicMock()
+        param1.param_id = "FENCE_ENABLE"
+        param1.param_value = 1.0
+        param1.param_count = 2
+        param1.param_index = 0
+
+        param2 = MagicMock()
+        param2.param_id = "SR1_POSITION"
+        param2.param_value = 5.0
+        param2.param_count = 2
+        param2.param_index = 1
+
+        # After draining the list, return None indefinitely (triggers quiescent exit)
+        call_returns = [param1, param2]
+
+        def _recv(**kwargs):
+            return call_returns.pop(0) if call_returns else None
+
+        mock_conn.recv_match.side_effect = _recv
+
+        params = mod.collect_params(mock_conn, timeout=5, quiescent=0.1)
+        assert "FENCE_ENABLE" in params
+        assert params["FENCE_ENABLE"] == pytest.approx(1.0)
+        assert "SR1_POSITION" in params
+        assert params["SR1_POSITION"] == pytest.approx(5.0)
+
+    def test_empty_params_on_immediate_timeout(self):
+        mod = _load_preflight_module()
+        mock_conn = MagicMock()
+        mock_conn.target_system = 1
+        mock_conn.target_component = 1
+        mock_conn.recv_match.return_value = None
+
+        # With a very short timeout, collect_params should return empty or few params
+        params = mod.collect_params(mock_conn, timeout=0.05, quiescent=0.05)
+        assert isinstance(params, dict)
+
+    def test_param_id_whitespace_stripped(self):
+        mod = _load_preflight_module()
+        mock_conn = MagicMock()
+        mock_conn.target_system = 1
+        mock_conn.target_component = 1
+
+        param1 = MagicMock()
+        param1.param_id = "FENCE_ENABLE\x00\x00"  # null-padded as MAVLink sends
+        param1.param_value = 1.0
+        param1.param_count = 1
+        param1.param_index = 0
+
+        call_returns = [param1]
+
+        def _recv(**kwargs):
+            return call_returns.pop(0) if call_returns else None
+
+        mock_conn.recv_match.side_effect = _recv
+        params = mod.collect_params(mock_conn, timeout=5, quiescent=0.1)
+        # Key must be clean string, not null-padded
+        assert "FENCE_ENABLE" in params
+
+
+# ---------------------------------------------------------------------------
+# Manifest content spot-checks for parameter correctness
+# ---------------------------------------------------------------------------
+
+class TestManifestContent:
+    """Spot-check key parameters exist in manifests with correct values."""
+
+    def test_ugv_requires_fence_enable(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("ugv")
+        required_names = [e["name"] for e in manifest["required"]]
+        assert "FENCE_ENABLE" in required_names
+        entry = next(e for e in manifest["required"] if e["name"] == "FENCE_ENABLE")
+        assert entry["expected"] == 1
+
+    def test_ugv_has_stream_rate_sr1_position(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("ugv")
+        assert "SR1_POSITION" in manifest["stream_rates"]
+        assert manifest["stream_rates"]["SR1_POSITION"] >= 5
+
+    def test_usv_requires_fence_enable(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("usv")
+        required_names = [e["name"] for e in manifest["required"]]
+        assert "FENCE_ENABLE" in required_names
+
+    def test_usv_requires_frame_class(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("usv")
+        required_names = [e["name"] for e in manifest["required"]]
+        assert "FRAME_CLASS" in required_names
+        entry = next(e for e in manifest["required"] if e["name"] == "FRAME_CLASS")
+        assert entry["expected"] == 2  # Boat frame class in ArduRover
+
+    def test_drone_requires_fence_enable(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("drone_10in")
+        required_names = [e["name"] for e in manifest["required"]]
+        assert "FENCE_ENABLE" in required_names
+
+    def test_drone_has_stream_rate_sr1_position(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("drone_10in")
+        assert "SR1_POSITION" in manifest["stream_rates"]
+        assert manifest["stream_rates"]["SR1_POSITION"] >= 5
+
+    def test_ugv_recommends_battery_failsafe(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("ugv")
+        rec_names = [e["name"] for e in manifest["recommended"]]
+        assert "BATT_FS_LOW_ACT" in rec_names
+        entry = next(e for e in manifest["recommended"] if e["name"] == "BATT_FS_LOW_ACT")
+        assert entry["expected"] == 2  # RTL
+
+    def test_drone_recommends_gcs_failsafe(self):
+        mod = _load_preflight_module()
+        manifest = mod.load_manifest("drone_10in")
+        rec_names = [e["name"] for e in manifest["recommended"]]
+        assert "FS_GCS_ENABLE" in rec_names


### PR DESCRIPTION
## Summary

- Adds per-profile Pixhawk prerequisite manifests (`hydra_detect/profiles/<profile>/pixhawk_prereqs.yaml`) for UGV, USV, and 10-inch drone profiles. Each covers required params, recommended params, and stream rate minimums with reasons.
- Adds `scripts/pixhawk_preflight.py`: reads live ArduPilot params over MAVLink, compares against the manifest, emits a `[PASS]/[FAIL]/[WARN]` report, exits 0/1/2 per spec.
- Adds per-profile operator docs (`docs/pixhawk-prereqs-*.md`) with param tables, failsafe expectations, servo/relay notes, and GUIDED mode guidance.
- Adds `tests/test_pixhawk_preflight.py`: 51 tests, TDD-first (all 51 confirmed failing before implementation).

## Acceptance criteria

- [x] Per-profile docs: `docs/pixhawk-prereqs-ugv.md`, `docs/pixhawk-prereqs-usv.md`, `docs/pixhawk-prereqs-drone_10in.md`
- [x] Machine-readable manifests at `hydra_detect/profiles/<profile>/pixhawk_prereqs.yaml` with required/recommended/stream_rates structure
- [x] `scripts/pixhawk_preflight.py` with `--profile`, `--conn`, `--baud`, `--timeout` args
- [x] Connects via pymavlink, requests PARAM_REQUEST_LIST, collects params until quiescent (3s) or timeout
- [x] Emits `[PASS]/[FAIL]/[WARN]` report with summary line
- [x] Exit codes: 0 = all PASS (WARN allowed), 1 = any FAIL, 2 = connection failure/timeout
- [x] Read-only; never writes params

## Test plan

- `python -m pytest tests/test_pixhawk_preflight.py -v` → 51 passed
- 316 tests pass on the collectable subset; 38 pre-existing collection errors (optional deps missing in worktree environment, not caused by this PR)

## Judgment calls

- **`ARMING_CHECK = 1` for drone**: preflight requires all checks enabled for field ops near personnel. Manifest documents the bitmask approach for specific bypasses.
- **`FRAME_CLASS = 2` for USV**: confirmed ArduRover boat frame class. `FRAME_TYPE` for the Bonzai Enforcer is a TODO in the USV doc — hull-specific, platform SME to verify.
- **`FS_GCS_ENABLE = 1` for drone vs `= 2` for USV/UGV**: different semantics across firmware variants. Each manifest uses the correct value per firmware.
- **Stream rate `SRx` index**: manifests use `SR1_*` as the reference index. The script doc explains that the actual index depends on MAVProxy routing.
- **`FENCE_ALT_MAX` for drone**: recommended (not required), marked TODO. Requires LAANC/NOA verification per deployment.
- **Servo function assignments**: excluded from required checks per spec.

## Scope

Additive only. No edits to existing pipeline, mavlink_io, config_schema, web/server.py, or setup scripts.

Closes #157