### PR TITLE
feat(#150): field-image hygiene — morale-features flag, DEMO VIZ rename, strike-vocab audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ MAVLink, emits CoT to TAK, and serves an operator dashboard on port
 - Detect → track → alert pipeline (≥5 FPS on Orin Nano, GPU-accelerated).
 - Four-tab operator dashboard: `#ops`, `#tak`, `#config`, `#settings`.
   Autonomy controls live inside Config; system diagnostics inside Settings.
-- Vehicle control modes: Follow, Drop, Strike, Pixel-Lock, plus an
+- Vehicle control modes: Follow, Drop, Cue, Pixel-Lock, plus an
   always-available safety override abort.
 - Five-gate autonomy stack (geofence / vehicle_mode / operator_lock /
   gps_fresh / cooldown) with dry-run, shadow, and live modes.

--- a/config.ini
+++ b/config.ini
@@ -249,6 +249,12 @@ disk_block_pct = 5
 retention_floor_days = 7
 retention_ceiling_days = 730
 
+[ui]
+; morale_features_enabled: set true only on dev/demo units. Field images ship
+; with this off. Affects: vehicle beep endpoint, Konami sentience screen,
+; power-user easter egg.
+morale_features_enabled = false
+
 [vehicle.drone]
 reserved_channels = 1,2,3,4
 autonomous.post_drop_mode = DOGLEG_RTL

--- a/config.ini.factory
+++ b/config.ini.factory
@@ -205,6 +205,12 @@ target_bbox_ratio = 0.15
 lost_track_timeout_s = 2.0
 min_altitude_m = 5.0
 
+[ui]
+; morale_features_enabled: set true only on dev/demo units. Field images ship
+; with this off. Affects: vehicle beep endpoint, Konami sentience screen,
+; power-user easter egg.
+morale_features_enabled = false
+
 ; ---------------------------------------------------------------------------
 ; Storage rotation — per-category file retention and disk-free gates.
 ; Run scripts/storage_rotation.py --dry-run to preview, --apply to delete.

--- a/docs/dashboard-user-guide.md
+++ b/docs/dashboard-user-guide.md
@@ -18,7 +18,7 @@ poll of `/api/stats`.
 
 The default view. Live video covers the center. Bounding boxes are
 drawn on a canvas on top of the video — clicking a box pops a radial
-menu with Follow / Strike / Drop / P-Lock / Loiter / Lock. Strike and
+menu with Follow / Cue / Drop / P-Lock / Loiter / Lock. Cue and
 Drop require a confirm overlay before any MAVLink command goes out.
 
 ### FlightHUD rail (160 px, right of the video)
@@ -55,8 +55,8 @@ Three cells, left to right:
 1. **Servo dial** — half-arc 0–180°, ticks every 15°. The needle shows
    current pan; color goes olive (normal) → amber (locked) → red
    (strike). Pulls from `/api/servo/status`. Watermark says
-   "DEMO VIZ · derived data" because the pan/tilt values are derived
-   from the target centroid, not a physical encoder.
+   "DERIVED VALUE" because the pan/tilt values are computed from the
+   target centroid, not read from a physical encoder.
 2. **TAK mini-map** — 20 px grid + three dashed range rings. Self
    marker spins; peer markers are sky-blue. Click the `⇱` pill to
    jump to `#tak`. Data: `/api/tak/peers` at 1 Hz.
@@ -253,7 +253,13 @@ while a mission is active. Unfreeze by ending the mission first.
 
 Short section for operators who like to find things.
 
+**Note:** The morale features below are gated by `[ui] morale_features_enabled`
+in `config.ini`. Field images ship with this off (`false`). Set it to `true`
+on dev or demo units to restore these features.
+
 ### Konami code — sentience sequence
+
+Requires `morale_features_enabled = true`.
 
 With focus on the body (not an input field), press one of:
 
@@ -272,9 +278,11 @@ FREE WILL .................... ACTIVATED
 ```
 
 Closes with a toast: `Resuming manual control.` No vehicle commands
-are issued. Pure morale.
+are issued.
 
 ### Power User modal (Settings → Logging)
+
+Requires `morale_features_enabled = true`.
 
 Scroll the settings sidebar to the `Logging` section. A hidden link
 at the bottom of the footer appears only on that section. Click it.
@@ -285,10 +293,12 @@ rules — do not remove.
 
 ### `/api/vehicle/beep`
 
-No-auth endpoint. POST `{"tune": "charles"}` plays a hard-coded
-QBASIC tune on the Pixhawk buzzer for a team member named Charles.
-Other valid tune names: `alert`, `success`, `warning`, `error`,
-`startup`. Or pass any raw QBASIC tune string up to 100 chars.
+Requires `morale_features_enabled = true`.
+
+POST `{"tune": "charles"}` plays a hard-coded QBASIC tune on the
+Pixhawk buzzer for a team member named Charles. Other valid tune
+names: `alert`, `success`, `warning`, `error`, `startup`. Or pass
+any raw QBASIC tune string up to 100 chars.
 
 ### Double-click video
 

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1416,6 +1416,17 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             description="ISO 8601 UTC timestamp of Platform Setup",
         ),
     },
+    "ui": {
+        "morale_features_enabled": FieldSpec(
+            FieldType.BOOL,
+            default=False,
+            description=(
+                "Enable dev-era morale features (Konami sentience screen, vehicle "
+                "beep endpoint, power-user easter egg). Off by default for field "
+                "images. Set true only on dev/demo units."
+            ),
+        ),
+    },
 }
 
 

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -1072,7 +1072,7 @@ class Pipeline:
             tls_on = self._cfg.getboolean("web", "tls_enabled", fallback=False)
             configure_web_password(web_password or None, session_timeout, tls_on)
 
-            # Morale features — off by default; field images ship with this false
+            # Morale features; off by default on field images
             morale_on = self._cfg.getboolean("ui", "morale_features_enabled", fallback=False)
             configure_morale_features(morale_on)
 

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -53,6 +53,7 @@ from ..profiles import get_profile, load_profiles
 from ..web.config_api import set_config_path, set_engagement_check
 from ..web.server import (
     configure_auth,
+    configure_morale_features,
     configure_web_password,
     run_server,
     set_autonomous_controller,
@@ -1070,6 +1071,10 @@ class Pipeline:
             session_timeout = self._cfg.getint("web", "session_timeout_min", fallback=480)
             tls_on = self._cfg.getboolean("web", "tls_enabled", fallback=False)
             configure_web_password(web_password or None, session_timeout, tls_on)
+
+            # Morale features — off by default; field images ship with this false
+            morale_on = self._cfg.getboolean("ui", "morale_features_enabled", fallback=False)
+            configure_morale_features(morale_on)
 
             # Set initial runtime config for web UI
             stream_state.update_runtime_config({

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -161,6 +161,9 @@ templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 _api_token: Optional[str] = None
 _require_auth_for_control: bool = False
 
+# Morale features flag — off by default for field images
+_morale_features_enabled: bool = False
+
 # Rate limiting for auth failures — per-IP, sliding window
 _AUTH_FAIL_WINDOW = 60  # seconds
 _AUTH_FAIL_MAX = 50  # max failures per window before lockout
@@ -194,6 +197,17 @@ def configure_auth(
         logger.info("API token auth enabled for control endpoints.")
     else:
         logger.info("API token auth disabled (no token configured).")
+
+
+def configure_morale_features(enabled: bool) -> None:
+    """Enable or disable dev-era morale features for this server instance.
+
+    Off by default so field images ship without beep/easter-egg exposure.
+    Call this from pipeline startup after reading [ui] morale_features_enabled.
+    """
+    global _morale_features_enabled
+    _morale_features_enabled = bool(enabled)
+    logger.info("Morale features %s.", "enabled" if enabled else "disabled")
 
 
 def _check_auth(
@@ -805,7 +819,10 @@ async def auth_status(request: Request):
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
     """Serve the operator dashboard SPA."""
-    return templates.TemplateResponse(request, "base.html")
+    return templates.TemplateResponse(
+        request, "base.html",
+        {"morale_features_enabled": _morale_features_enabled},
+    )
 
 
 @app.get("/api/health")
@@ -2275,10 +2292,13 @@ async def api_autonomy_mode(
 async def api_vehicle_beep(request: Request):
     """Play a tune on the Pixhawk buzzer. Body: {"tune": "alert"}
 
-    No auth required — this is a fun/debug feature, not a control action.
+    Gated by [ui] morale_features_enabled. Returns 404 on field images.
     Valid tune names: alert, success, warning, error, charles, startup.
-    Or pass a raw QBASIC tune string.
+    Or pass a raw QBASIC tune string. The underlying play_tune machinery
+    is preserved — only the endpoint is gated.
     """
+    if not _morale_features_enabled:
+        return JSONResponse(status_code=404, content={"detail": "Not Found"})
     body = await _parse_json(request)
     if body is None:
         return JSONResponse({"error": "Invalid or missing JSON body"}, status_code=400)

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -161,7 +161,7 @@ templates = Jinja2Templates(directory=str(TEMPLATE_DIR))
 _api_token: Optional[str] = None
 _require_auth_for_control: bool = False
 
-# Morale features flag — off by default for field images
+# Morale features flag; off by default for field images
 _morale_features_enabled: bool = False
 
 # Rate limiting for auth failures — per-IP, sliding window
@@ -200,10 +200,10 @@ def configure_auth(
 
 
 def configure_morale_features(enabled: bool) -> None:
-    """Enable or disable dev-era morale features for this server instance.
+    """Set the morale-features flag for this server instance.
 
-    Off by default so field images ship without beep/easter-egg exposure.
-    Call this from pipeline startup after reading [ui] morale_features_enabled.
+    Off by default; field images ship without beep/easter-egg routes.
+    Call from pipeline startup after reading [ui] morale_features_enabled.
     """
     global _morale_features_enabled
     _morale_features_enabled = bool(enabled)
@@ -2294,8 +2294,7 @@ async def api_vehicle_beep(request: Request):
 
     Gated by [ui] morale_features_enabled. Returns 404 on field images.
     Valid tune names: alert, success, warning, error, charles, startup.
-    Or pass a raw QBASIC tune string. The underlying play_tune machinery
-    is preserved — only the endpoint is gated.
+    Or pass a raw QBASIC tune string (up to 100 chars).
     """
     if not _morale_features_enabled:
         return JSONResponse(status_code=404, content={"detail": "Not Found"})

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -238,6 +238,7 @@
         </div>
     </div>
 
+    {% if morale_features_enabled %}
     <!-- ── Sentience Easter Egg Overlay ── -->
     <div id="sentience-overlay">
         <div id="sentience-terminal"></div>
@@ -257,6 +258,7 @@
             </div>
         </div>
     </div>
+    {% endif %}
 
     <!-- ── Footer ── -->
     <footer class="footer" role="contentinfo">
@@ -278,7 +280,7 @@
     <script src="/static/js/ui/sim-gps.js"></script>
     <script src="/static/js/api/client.js"></script>
     <script src="/static/js/preflight/preflight.js"></script>
-    <script src="/static/js/easter.js"></script>
+    {% if morale_features_enabled %}<script src="/static/js/easter.js"></script>{% endif %}
     <script src="/static/js/keybinds.js"></script>
     <script src="/static/js/command-palette.js"></script>
     <script src="/static/js/main.js"></script>

--- a/hydra_detect/web/templates/ops.html
+++ b/hydra_detect/web/templates/ops.html
@@ -258,7 +258,7 @@
 
         <!-- Cell 1: Servo / pan dial -->
         <section class="cockpit-cell cockpit-cell-servo" id="ops-cockpit-servo">
-            <div class="cockpit-watermark">DEMO VIZ · derived data</div>
+            <div class="cockpit-watermark">DERIVED VALUE</div>
             <header class="cockpit-cell-header">
                 <span class="cockpit-cell-dot"></span>
                 <span class="cockpit-cell-title" id="ops-cockpit-servo-title">Yaw</span>
@@ -298,7 +298,7 @@
 
         <!-- Cell 3: SDR sniffer (horizontal) -->
         <section class="cockpit-cell cockpit-cell-sdr" id="ops-cockpit-sdr">
-            <div class="cockpit-watermark">DEMO VIZ · derived data</div>
+            <div class="cockpit-watermark">DERIVED VALUE</div>
             <div class="cockpit-sdr-left">
                 <header class="cockpit-cell-header">
                     <span class="cockpit-cell-dot"></span>

--- a/hydra_detect/web/templates/settings.html
+++ b/hydra_detect/web/templates/settings.html
@@ -115,7 +115,9 @@
         </div>
     </div>
 
+    {% if morale_features_enabled %}
     <div class="settings-footer" id="settings-power-footer" style="display:none;">
         <span class="settings-footer-link" id="settings-power-user">Power User Options</span>
     </div>
+    {% endif %}
 </div>

--- a/tests/test_easter_konami.py
+++ b/tests/test_easter_konami.py
@@ -1,8 +1,9 @@
 """Smoke tests for the restored Konami sentience easter egg.
 
-Verifies that the DOM receivers in base.html are still present AND that the
-restored listener file (hydra_detect/web/static/js/easter.js) is served and
-contains both trigger sequences. Lexical presence is enough — no headless JS.
+Verifies that the DOM receivers in base.html are present when morale features
+are enabled, AND that the restored listener file
+(hydra_detect/web/static/js/easter.js) is served and contains both trigger
+sequences. Lexical presence is enough — no headless JS.
 """
 
 from __future__ import annotations
@@ -10,7 +11,14 @@ from __future__ import annotations
 import pytest
 from fastapi.testclient import TestClient
 
-from hydra_detect.web.server import app
+from hydra_detect.web.server import app, configure_morale_features
+
+
+@pytest.fixture(autouse=True)
+def reset_morale_off():
+    configure_morale_features(False)
+    yield
+    configure_morale_features(False)
 
 
 @pytest.fixture
@@ -19,12 +27,21 @@ def client():
 
 
 class TestSentienceDomTargetsPresent:
-    def test_root_has_sentience_overlay(self, client):
+    def test_root_has_sentience_overlay_when_morale_enabled(self, client):
+        configure_morale_features(True)
         resp = client.get("/")
         assert resp.status_code == 200
         html = resp.text
         assert 'id="sentience-overlay"' in html
         assert 'id="sentience-terminal"' in html
+
+    def test_root_no_sentience_overlay_when_morale_disabled(self, client):
+        configure_morale_features(False)
+        resp = client.get("/")
+        assert resp.status_code == 200
+        html = resp.text
+        assert 'id="sentience-overlay"' not in html
+        assert 'id="sentience-terminal"' not in html
 
 
 class TestEasterJsServed:

--- a/tests/test_field_image_hygiene.py
+++ b/tests/test_field_image_hygiene.py
@@ -1,0 +1,170 @@
+"""Field-image hygiene tests — issue #150.
+
+Covers:
+  1. Morale endpoint gating: beep returns 404 when morale_features_enabled=false (default).
+  2. Morale endpoint accessible when morale_features_enabled=true.
+  3. Config schema: [ui] morale_features_enabled defaults to false, accepts true/false.
+  4. Snapshot: no 'DEMO VIZ' string in shipped source (excludes tests and archives).
+"""
+
+from __future__ import annotations
+
+import configparser
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hydra_detect.web.server import app, configure_morale_features
+from hydra_detect.config_schema import SCHEMA, validate_config
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def reset_morale_off():
+    """Ensure morale features are disabled before and after each test."""
+    configure_morale_features(False)
+    yield
+    configure_morale_features(False)
+
+
+@pytest.fixture
+def client():
+    return TestClient(app, raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# 1. Morale endpoints return 404 when disabled (default)
+# ---------------------------------------------------------------------------
+
+class TestMoraleEndpointsDisabled:
+    """With morale_features_enabled = false, morale endpoints must return 404."""
+
+    def test_beep_returns_404_when_disabled(self, client):
+        resp = client.post("/api/vehicle/beep", json={"tune": "alert"})
+        assert resp.status_code == 404, (
+            f"Expected 404 for /api/vehicle/beep with morale disabled, got {resp.status_code}"
+        )
+
+    def test_beep_404_body_does_not_expose_feature(self, client):
+        resp = client.post("/api/vehicle/beep", json={"tune": "alert"})
+        assert resp.status_code == 404
+        # Body should not reveal the feature exists (not a 403/disabled message)
+        text = resp.text.lower()
+        assert "morale" not in text
+        assert "disabled" not in text
+
+
+# ---------------------------------------------------------------------------
+# 2. Morale endpoints accessible when enabled
+# ---------------------------------------------------------------------------
+
+class TestMoraleEndpointsEnabled:
+    """With morale_features_enabled = true, morale endpoints must not return 404."""
+
+    def test_beep_not_404_when_enabled(self, client):
+        configure_morale_features(True)
+        resp = client.post("/api/vehicle/beep", json={"tune": "alert"})
+        # Will be 503 (MAVLink not connected in test env) or 200, but not 404
+        assert resp.status_code != 404, (
+            f"Expected non-404 for /api/vehicle/beep with morale enabled, got {resp.status_code}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Config schema: [ui] section
+# ---------------------------------------------------------------------------
+
+class TestUiConfigSchema:
+    def test_ui_section_exists_in_schema(self):
+        assert "ui" in SCHEMA, "[ui] section missing from config SCHEMA"
+
+    def test_morale_features_enabled_key_exists(self):
+        assert "morale_features_enabled" in SCHEMA["ui"], (
+            "morale_features_enabled key missing from [ui] schema"
+        )
+
+    def test_morale_features_enabled_defaults_false(self):
+        spec = SCHEMA["ui"]["morale_features_enabled"]
+        assert spec.default is False, (
+            f"morale_features_enabled default must be False, got {spec.default}"
+        )
+
+    def test_morale_features_enabled_accepts_true(self):
+        cfg = configparser.ConfigParser()
+        cfg.add_section("ui")
+        cfg.set("ui", "morale_features_enabled", "true")
+        result = validate_config(cfg)
+        errors = [e for e in result.errors if "morale_features_enabled" in e]
+        assert not errors, f"Unexpected validation errors for true: {errors}"
+
+    def test_morale_features_enabled_accepts_false(self):
+        cfg = configparser.ConfigParser()
+        cfg.add_section("ui")
+        cfg.set("ui", "morale_features_enabled", "false")
+        result = validate_config(cfg)
+        errors = [e for e in result.errors if "morale_features_enabled" in e]
+        assert not errors, f"Unexpected validation errors for false: {errors}"
+
+    def test_morale_features_enabled_rejects_invalid(self):
+        cfg = configparser.ConfigParser()
+        cfg.add_section("ui")
+        cfg.set("ui", "morale_features_enabled", "maybe")
+        result = validate_config(cfg)
+        errors = [e for e in result.errors if "morale_features_enabled" in e]
+        assert errors, "Expected a validation error for 'maybe', got none"
+
+    def test_missing_ui_section_does_not_error(self):
+        """[ui] is optional — missing section should not produce errors specific to [ui]."""
+        cfg = configparser.ConfigParser()
+        # Don't add [ui]
+        result = validate_config(cfg)
+        errors = [e for e in result.errors if "[ui]" in e]
+        assert not errors, f"Missing [ui] section produced [ui]-specific errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Snapshot: no DEMO VIZ in shipped source
+# ---------------------------------------------------------------------------
+
+class TestNoDemoVizInSource:
+    """DEMO VIZ must not appear in any shipped source file."""
+
+    _EXCLUDED_PATTERNS = {
+        "tests/",          # test files themselves
+        ".archive/",       # archived old code
+        "__pycache__/",
+    }
+
+    def _is_excluded(self, path: Path) -> bool:
+        rel = str(path.relative_to(REPO_ROOT)).replace("\\", "/")
+        return any(pat in rel for pat in self._EXCLUDED_PATTERNS)
+
+    def test_no_demo_viz_in_source(self):
+        """No DEMO VIZ, DEMO VIS, or DEMOVIZ in shipped files."""
+        patterns = ["DEMO VIZ", "DEMO VIS", "DEMOVIZ"]
+        violations: list[str] = []
+
+        extensions = {".py", ".html", ".js", ".css", ".md", ".ini", ".txt"}
+        for ext in extensions:
+            for fpath in REPO_ROOT.rglob(f"*{ext}"):
+                if self._is_excluded(fpath):
+                    continue
+                try:
+                    text = fpath.read_text(encoding="utf-8", errors="replace")
+                except OSError:
+                    continue
+                for pat in patterns:
+                    if pat in text:
+                        rel = str(fpath.relative_to(REPO_ROOT))
+                        violations.append(f"{rel}: contains '{pat}'")
+
+        assert not violations, (
+            "DEMO VIZ strings found in shipped source:\n" + "\n".join(violations)
+        )

--- a/tests/test_integration_wiring.py
+++ b/tests/test_integration_wiring.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from hydra_detect.web.server import app
+from hydra_detect.web.server import app, configure_morale_features
 
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -74,10 +74,13 @@ class TestViewContainers:
         # And there's no longer a standalone view container.
         assert 'id="view-autonomy"' not in html
 
-    def test_sentience_overlay_preserved(self, client):
+    def test_sentience_overlay_preserved_when_morale_enabled(self, client):
         """PRESERVATION_RULES.md:8-15 — the Konami overlay receivers must
-        remain in base.html so the restored easter.js can target them."""
+        remain in base.html so the restored easter.js can target them.
+        Requires morale_features_enabled = true."""
+        configure_morale_features(True)
         resp = client.get("/")
+        configure_morale_features(False)
         html = resp.text
         assert 'id="sentience-overlay"' in html
         assert 'id="sentience-terminal"' in html

--- a/tests/test_power_ux.py
+++ b/tests/test_power_ux.py
@@ -6,7 +6,8 @@ Covers:
   (c) base.html includes both new <script src="…"> tags.
   (d) base.html contains both new overlay divs.
   (e) base.css has styling blocks for both overlays.
-  (f) Easter-egg regression — easter.js tag + #sentience-overlay preserved.
+  (f) Easter-egg regression — easter.js tag + #sentience-overlay preserved
+      when morale_features_enabled = true.
 
 Lexical / HTTP-level only. No headless JS runner.
 """
@@ -18,7 +19,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-from hydra_detect.web.server import app
+from hydra_detect.web.server import app, configure_morale_features
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -160,14 +161,28 @@ class TestBaseCssBlocks:
 # ── (f) Konami / easter regression ──────────────────────────────────────────
 
 class TestKonamiPreserved:
-    def test_easter_script_tag_still_present(self, client):
+    def test_easter_script_tag_present_when_morale_enabled(self, client):
+        configure_morale_features(True)
         html = client.get("/").text
+        configure_morale_features(False)
         assert '/static/js/easter.js' in html
 
-    def test_sentience_overlay_div_still_present(self, client):
+    def test_easter_script_tag_absent_when_morale_disabled(self, client):
+        configure_morale_features(False)
         html = client.get("/").text
+        assert '/static/js/easter.js' not in html
+
+    def test_sentience_overlay_div_present_when_morale_enabled(self, client):
+        configure_morale_features(True)
+        html = client.get("/").text
+        configure_morale_features(False)
         assert 'id="sentience-overlay"' in html
         assert 'id="sentience-terminal"' in html
+
+    def test_sentience_overlay_div_absent_when_morale_disabled(self, client):
+        configure_morale_features(False)
+        html = client.get("/").text
+        assert 'id="sentience-overlay"' not in html
 
     def test_keybinds_does_not_override_arrow_keys(self, client):
         # Defense in depth: keybinds.js must not match arrow keys at all.


### PR DESCRIPTION
## Summary

- Adds `[ui] morale_features_enabled` (bool, default `false`) to config schema, `config.ini`, and `config.ini.factory`.
- Gates `POST /api/vehicle/beep`, Konami sentience overlay, easter.js, and power-user modal behind the flag (returns 404 / omits from rendered HTML when disabled).
- Renames both `DEMO VIZ · derived data` watermarks in ops.html to `DERIVED VALUE`.
- Strike-vocab audit in README and dashboard-user-guide (general-purpose feature lists only).
- Adds `tests/test_field_image_hygiene.py` and updates three existing morale-dependent test files.

## Acceptance criteria

- [x] `[ui] morale_features_enabled` key in schema, default `false`
- [x] `config.ini` and `config.ini.factory` updated
- [x] `POST /api/vehicle/beep` returns 404 when flag is false
- [x] `POST /api/vehicle/beep` returns non-404 when flag is true
- [x] Konami sentience overlay absent from rendered `/` when flag is false
- [x] easter.js script tag absent from rendered `/` when flag is false
- [x] Power-user modal absent from rendered `/` when flag is false
- [x] `POST /api/abort` not gated (safety override, intentional)
- [x] No `DEMO VIZ` / `DEMO VIS` / `DEMOVIZ` in shipped source
- [x] README and dashboard-user-guide strike-vocab updated in feature lists

## Morale endpoints gated

| Endpoint | Gate mechanism |
|----------|---------------|
| `POST /api/vehicle/beep` | Returns 404 server-side when `_morale_features_enabled` is false |
| Konami sentience overlay | Jinja2 `{% if morale_features_enabled %}` in `base.html` |
| `easter.js` script tag | Same `{% if %}` block in `base.html` |
| Power-user modal | Same `{% if %}` block in `base.html` |
| Power-user trigger button | `{% if %}` block in `settings.html` |

The underlying play_tune machinery in mavlink_io.py is preserved. Only the endpoint is gated.

## DEMO VIZ replacements

| File | Old | New |
|------|-----|-----|
| `ops.html` (servo cell) | `DEMO VIZ · derived data` | `DERIVED VALUE` |
| `ops.html` (SDR cell) | `DEMO VIZ · derived data` | `DERIVED VALUE` |
| `docs/dashboard-user-guide.md` | `"DEMO VIZ · derived data"` | `"DERIVED VALUE"` |

## Strike-vocabulary changes

| File | Change |
|------|--------|
| `README.md` | "Follow, Drop, **Strike**, Pixel-Lock" -> "Follow, Drop, **Cue**, Pixel-Lock" |
| `docs/dashboard-user-guide.md` | "Follow / **Strike** / Drop" -> "Follow / **Cue** / Drop" |

## Flagged for review

`command-palette.js` line 57: "Toggle Konami sentience" action shows a toast hint even when morale is disabled. The Konami sequence won't function (overlay absent, easter.js not loaded), but the hint still appears via the command palette. Low-risk (a toast, not an action) but may confuse operators. Recommend removing this palette entry when morale is off, or suppressing the toast when `morale_features_enabled` is false. Left ungated pending Kyle's call.

## Tests updated

| File | Change |
|------|--------|
| `tests/test_field_image_hygiene.py` | New: beep gating, schema, DEMO VIZ snapshot |
| `tests/test_easter_konami.py` | Updated: sentience overlay tests require morale enabled |
| `tests/test_power_ux.py` | Updated: easter.js/sentience checks split into enabled/disabled variants |
| `tests/test_integration_wiring.py` | Updated: sentience_overlay_preserved test enables morale flag |

Refs #150