### PR TITLE
feat(#147): operating mode system (SIM/BENCH/OBSERVE/FIELD/ARMED/MAINTENANCE)

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,3 +1,9 @@
+[system]
+; Operating mode — environment the unit is running in.
+; Values: SIM | BENCH | OBSERVE | FIELD | ARMED | MAINTENANCE
+; Default OBSERVE. ARMED transitions require double-confirmation via API.
+mode = OBSERVE
+
 [camera]
 source_type = auto
 source = auto

--- a/config.ini.factory
+++ b/config.ini.factory
@@ -1,3 +1,9 @@
+[system]
+; Operating mode — environment the unit is running in.
+; Values: SIM | BENCH | OBSERVE | FIELD | ARMED | MAINTENANCE
+; Default OBSERVE. ARMED transitions require double-confirmation via API.
+mode = OBSERVE
+
 [camera]
 source_type = auto
 source = auto

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1202,6 +1202,17 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             description="Minimum consecutive track frames before autonomous action (fixed-wing)",
         ),
     },
+    "system": {
+        "mode": FieldSpec(
+            FieldType.ENUM,
+            choices=["SIM", "BENCH", "OBSERVE", "FIELD", "ARMED", "MAINTENANCE"],
+            default="OBSERVE",
+            description=(
+                "Operating environment. Orthogonal to vehicle/mission profile. "
+                "ARMED transitions require double-confirmation via API."
+            ),
+        ),
+    },
     "audit": {
         "enabled": FieldSpec(
             FieldType.BOOL,

--- a/hydra_detect/operating_mode.py
+++ b/hydra_detect/operating_mode.py
@@ -1,0 +1,178 @@
+"""Operating mode — system environment descriptor.
+
+Modes are orthogonal to vehicle profile and mission profile. They describe
+the environment Hydra is operating in, not what the platform is doing.
+
+Modes: SIM | BENCH | OBSERVE | FIELD | ARMED | MAINTENANCE
+Default: OBSERVE (on fresh install or factory reset)
+
+ARMED is the only mode that requires a double-confirmation (confirmed_twice=True).
+All mode transitions are written atomically to config.ini via the existing
+file-lock pattern and emit one event-timeline entry.
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+import os
+import shutil
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Optional event logger reference — injected by pipeline at startup.
+# None when running in tests or before pipeline initialises.
+_event_logger: Any = None
+
+
+def register_event_logger(event_logger: Any) -> None:
+    """Inject the EventLogger instance so mode transitions are recorded."""
+    global _event_logger
+    _event_logger = event_logger
+
+
+def _get_event_logger() -> Any | None:
+    """Return the registered EventLogger, or None."""
+    return _event_logger
+
+
+class OperatingMode(str, Enum):
+    """Operating environment for Hydra Detect.
+
+    Values equal their names so round-tripping through config strings is
+    unambiguous: OperatingMode("FIELD") == OperatingMode.FIELD.
+    """
+    SIM = "SIM"
+    BENCH = "BENCH"
+    OBSERVE = "OBSERVE"
+    FIELD = "FIELD"
+    ARMED = "ARMED"
+    MAINTENANCE = "MAINTENANCE"
+
+
+class ModeTransitionError(Exception):
+    """Raised when a mode transition is rejected."""
+
+
+_DEFAULT_MODE = OperatingMode.OBSERVE
+
+
+def get_config_path() -> Path:
+    """Return the current config.ini path (delegates to config_api)."""
+    from hydra_detect.web.config_api import get_config_path as _gcp
+    return _gcp()
+
+
+def current_mode(cfg: configparser.ConfigParser) -> OperatingMode:
+    """Read the current operating mode from a parsed config.
+
+    Returns OBSERVE if the key or section is missing, or if the stored
+    value is not a recognised mode name.
+    """
+    try:
+        raw = cfg.get("system", "mode").strip().upper()
+        return OperatingMode(raw)
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        return _DEFAULT_MODE
+    except ValueError:
+        logger.warning("Unknown operating mode in config; defaulting to OBSERVE")
+        return _DEFAULT_MODE
+
+
+def _write_mode_atomic(path: Path, new_mode: OperatingMode) -> None:
+    """Write mode value atomically to config.ini.
+
+    Uses file-lock + os.replace to match config_api's write_config() pattern.
+    fcntl is imported lazily so this module can be imported on Windows;
+    the call will fail on Windows (production targets Linux/Jetson only).
+    """
+    import fcntl  # Linux-only — production Jetson; tests mock get_config_path
+
+    cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    cfg.read(path)
+
+    if not cfg.has_section("system"):
+        cfg.add_section("system")
+    cfg.set("system", "mode", new_mode.value)
+
+    bak_path = Path(str(path) + ".bak")
+    if path.exists():
+        shutil.copy2(path, bak_path)
+
+    tmp_path = Path(str(path) + ".tmp")
+    lock_fd = os.open(str(path), os.O_RDWR | os.O_CREAT)
+    try:
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        with open(tmp_path, "w") as f:
+            cfg.write(f)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, path)
+    finally:
+        fcntl.flock(lock_fd, fcntl.LOCK_UN)
+        os.close(lock_fd)
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+
+
+def set_mode(
+    cfg: configparser.ConfigParser,
+    new_mode: OperatingMode,
+    reason: str = "",
+    confirmed_twice: bool = False,
+    actor: str = "api",
+) -> None:
+    """Transition to new_mode and persist to config.ini.
+
+    ARMED transitions require confirmed_twice=True, otherwise
+    ModeTransitionError is raised. All other modes accept confirmed_twice
+    in any state (it's ignored for non-ARMED transitions).
+
+    The transition is written atomically via file-lock + os.replace.
+    An event-timeline entry is emitted if an EventLogger has been registered.
+
+    Args:
+        cfg: Parsed ConfigParser (used to read current mode for the event).
+        new_mode: Target OperatingMode.
+        reason: Human-readable reason for the transition.
+        confirmed_twice: Must be True when transitioning to ARMED.
+        actor: "api" | "boot" | other attribution string for the event log.
+
+    Raises:
+        ModeTransitionError: ARMED transition without confirmed_twice=True.
+    """
+    if new_mode is OperatingMode.ARMED and not confirmed_twice:
+        raise ModeTransitionError(
+            "Transition to ARMED requires confirmed_twice=True. "
+            "Send the request twice with confirm=true."
+        )
+
+    from_mode = current_mode(cfg)
+
+    # Resolve config path (patchable in tests).
+    path = get_config_path()
+    _write_mode_atomic(path, new_mode)
+
+    logger.info(
+        "Mode: %s → %s (reason=%r actor=%s)",
+        from_mode.value, new_mode.value, reason, actor,
+    )
+
+    # Emit event-timeline entry.
+    el = _get_event_logger()
+    if el is not None:
+        try:
+            el.log_action("mode.transition", {
+                "from": from_mode.value,
+                "to": new_mode.value,
+                "reason": reason,
+                "actor": actor,
+            })
+        except Exception as exc:  # never let event logging crash the caller
+            logger.debug("Mode event log error: %s", exc)

--- a/hydra_detect/web/mode_api.py
+++ b/hydra_detect/web/mode_api.py
@@ -1,0 +1,130 @@
+"""Operating mode API — GET/POST /api/mode.
+
+New APIRouter included in server.py via a single include_router() call.
+Auth pattern matches existing control endpoints: _check_auth() for POST,
+no auth for GET (read-only, needed by dashboard poll).
+"""
+
+from __future__ import annotations
+
+import configparser
+import logging
+from typing import Optional
+
+from fastapi import APIRouter, Header, Request
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, field_validator
+
+from hydra_detect.operating_mode import (
+    ModeTransitionError,
+    OperatingMode,
+    current_mode,
+    set_mode,
+)
+from hydra_detect.web.config_api import get_config_path
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class ModeRequest(BaseModel):
+    """Body for POST /api/mode."""
+    mode: OperatingMode
+    reason: str = ""
+    confirm: bool = False
+
+    @field_validator("mode", mode="before")
+    @classmethod
+    def normalise_mode(cls, v: str) -> str:
+        if isinstance(v, str):
+            return v.upper()
+        return v
+
+
+def _read_current_mode() -> OperatingMode:
+    """Read mode from config.ini on disk."""
+    path = get_config_path()
+    cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    cfg.read(path)
+    return current_mode(cfg)
+
+
+@router.get("/api/mode")
+async def api_get_mode():
+    """Return the current operating mode.
+
+    No auth required — read-only, polled by the dashboard on the same
+    cadence as /api/stats.
+    """
+    mode = _read_current_mode()
+    return {"mode": mode.value}
+
+
+@router.post("/api/mode")
+async def api_set_mode(
+    request: Request,
+    authorization: Optional[str] = Header(None),
+):
+    """Transition to a new operating mode.
+
+    Body: {"mode": "FIELD", "reason": "pre-sortie", "confirm": true}
+
+    ARMED requires confirm=true AND a non-empty reason string.
+    All other modes accept confirm in any state.
+
+    Auth: same-origin requests (dashboard) bypass Bearer token.
+    External callers (curl/scripts) require Authorization: Bearer <token>.
+    """
+    # Lazy import to avoid circular dependency at module level.
+    from hydra_detect.web.server import _check_auth, _audit, _parse_json
+
+    auth_err = _check_auth(authorization, request)
+    if auth_err:
+        return auth_err
+
+    raw = await _parse_json(request)
+    if raw is None:
+        return JSONResponse({"error": "Invalid or missing JSON body"}, status_code=400)
+
+    # Validate body via Pydantic — unknown mode → 422
+    try:
+        body = ModeRequest(**raw)
+    except Exception as exc:
+        return JSONResponse({"error": str(exc)}, status_code=422)
+
+    target_mode = body.mode
+
+    # ARMED needs confirm=True + non-empty reason.
+    if target_mode is OperatingMode.ARMED:
+        if not body.confirm:
+            return JSONResponse(
+                {"error": "Mode: ARMED requires confirm=true."},
+                status_code=400,
+            )
+        if not body.reason.strip():
+            return JSONResponse(
+                {"error": "Mode: ARMED requires a reason."},
+                status_code=400,
+            )
+
+    path = get_config_path()
+    cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    cfg.read(path)
+
+    try:
+        set_mode(
+            cfg,
+            target_mode,
+            reason=body.reason,
+            confirmed_twice=body.confirm,
+            actor="api",
+        )
+    except ModeTransitionError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except Exception as exc:
+        logger.error("Mode transition failed: %s", exc)
+        return JSONResponse({"error": "Mode transition failed."}, status_code=500)
+
+    _audit(request, "mode_set", target=target_mode.value)
+    return {"mode": target_mode.value, "reason": body.reason}

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -337,6 +337,7 @@ _PUBLIC_PATH_PREFIXES = (
     "/api/health", "/api/preflight", "/api/abort",
     "/api/stats",      # instructor page polls peers cross-origin
     "/api/tracks",     # read-only dashboard data
+    "/api/mode",       # operating mode — dashboard polls; POST still auth-checked
     "/api/metrics",    # Prometheus scrape
     "/api/client_error",  # frontend error sink (same-origin, rate-limited)
     "/stream.jpg",     # snapshot polling (img.src, no cookie in some contexts)
@@ -3215,6 +3216,9 @@ async def api_setup_save(request: Request, authorization: Optional[str] = Header
 
     return {"status": "saved", "callsign": callsign, **result}
 
+
+# ── Operating mode router ────────────────────────────────────────────
+from hydra_detect.web.mode_api import router as _mode_router; app.include_router(_mode_router)  # noqa: E402,E501
 
 # ── Server launcher ──────────────────────────────────────────────────
 

--- a/hydra_detect/web/static/css/base.css
+++ b/hydra_detect/web/static/css/base.css
@@ -855,3 +855,47 @@ body[data-emerg="1"] #emergency-flash {
     .topbar[data-mock="1"] .tb-wordmark { font-size: 18px; }
     .topbar[data-mock="1"] .tb-shield { width: 36px; height: 36px; }
 }
+
+/* ── Operating Mode Badge ── */
+.topbar[data-mock="1"] .tb-mode-badge {
+    font-family: 'Barlow Condensed', sans-serif;
+    font-weight: 700;
+    font-size: 9px;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border-radius: var(--radius);
+    border: 1px solid currentColor;
+    white-space: nowrap;
+    /* default / OBSERVE */
+    color: var(--ogt-muted);
+    background: rgba(166, 188, 146, 0.08);
+}
+
+/* Per-mode accent colours */
+.topbar[data-mock="1"] .tb-mode-badge[data-mode="SIM"] {
+    color: var(--info);
+    background: rgba(147, 197, 253, 0.10);
+}
+.topbar[data-mock="1"] .tb-mode-badge[data-mode="BENCH"] {
+    color: #d1d5db;
+    background: rgba(255, 255, 255, 0.06);
+}
+.topbar[data-mock="1"] .tb-mode-badge[data-mode="FIELD"] {
+    color: var(--ogt-muted);
+    background: rgba(166, 188, 146, 0.12);
+}
+.topbar[data-mock="1"] .tb-mode-badge[data-mode="ARMED"] {
+    color: #fca5a5;
+    background: rgba(197, 48, 48, 0.18);
+    border-color: var(--danger);
+}
+.topbar[data-mock="1"] .tb-mode-badge[data-mode="MAINTENANCE"] {
+    color: var(--warning);
+    background: rgba(234, 179, 8, 0.10);
+}
+
+/* Hide mode badge on very narrow viewports */
+@media (max-width: 899px) {
+    .topbar[data-mock="1"] .tb-mode-badge { display: none; }
+}

--- a/hydra_detect/web/static/js/main.js
+++ b/hydra_detect/web/static/js/main.js
@@ -269,12 +269,38 @@
         });
     }
 
+    // ── Operating mode badge ─────────────────────────────────────────
+    // Polls /api/mode every 5 s (same cadence as slow stats).
+    // Badge element: #tb-mode-badge with data-mode attribute.
+    let _modePollTimer = null;
+
+    function updateModeBadge(mode) {
+        const el = document.getElementById('tb-mode-badge');
+        if (!el) return;
+        el.textContent = mode;
+        el.setAttribute('data-mode', mode);
+        el.setAttribute('title', 'Mode: ' + mode);
+    }
+
+    function pollMode() {
+        fetch('/api/mode')
+            .then(r => r.ok ? r.json() : null)
+            .then(data => { if (data && data.mode) updateModeBadge(data.mode); })
+            .catch(() => {})
+            .finally(() => { _modePollTimer = setTimeout(pollMode, 5000); });
+    }
+
+    function initModeBadge() {
+        pollMode();
+    }
+
     function init() {
         preflight.runPreflight();
         modal.initEscapeAndTrap();
         stream.initStreamWatcher();
         router.initRouter();
         initClientErrorReporter();
+        initModeBadge();
         // Defer initial view enter until all scripts are loaded
         setTimeout(function() {
             var v = store.getState().currentView;

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -58,6 +58,7 @@
         <div class="tb-chips" aria-label="Platform and callsign">
             <span class="tb-chip"><span class="tb-chip-label">PLT </span><span class="tb-chip-value" id="tb-plt-value">USV</span></span>
             <span class="tb-chip"><span class="tb-chip-label">CS </span><span class="tb-chip-value tb-chip-value-cs" id="tb-cs-value">HYDRA-1</span></span>
+            <span class="tb-mode-badge" id="tb-mode-badge" data-mode="OBSERVE" title="Operating mode">OBSERVE</span>
         </div>
 
         <span class="tb-divider" aria-hidden="true"></span>

--- a/tests/test_operating_mode.py
+++ b/tests/test_operating_mode.py
@@ -1,0 +1,400 @@
+"""Tests for operating mode system — issue #147.
+
+Covers:
+- OperatingMode enum round-trip
+- current_mode() reads from config
+- set_mode() persists and reads back
+- ARMED transition requires confirmed_twice=True
+- Event timeline entry written on transition
+- Invalid mode raises
+- API: GET returns current mode
+- API: POST transitions mode
+- API: POST to ARMED without confirm=True returns 400
+- API: POST with bad mode returns 422
+- Factory reset → OBSERVE
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hydra_detect.operating_mode import (
+    ModeTransitionError,
+    OperatingMode,
+    current_mode,
+    set_mode,
+)
+from hydra_detect.web.server import app, configure_auth, stream_state
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_server_state():
+    configure_auth(None)
+    stream_state._callbacks.clear()
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def tmp_config(tmp_path: Path) -> Path:
+    """Minimal config.ini with [system] section."""
+    cfg = configparser.ConfigParser()
+    cfg["system"] = {"mode": "OBSERVE"}
+    cfg["web"] = {
+        "host": "0.0.0.0",
+        "port": "8080",
+        "api_token": "",
+        "web_password": "",
+        "session_timeout_min": "480",
+        "tls_enabled": "false",
+        "tls_cert": "",
+        "tls_key": "",
+        "require_auth_for_control": "false",
+        "mjpeg_quality": "70",
+        "hud_layout": "classic",
+        "theme": "lattice",
+    }
+    path = tmp_path / "config.ini"
+    with open(path, "w") as f:
+        cfg.write(f)
+    return path
+
+
+@pytest.fixture
+def tmp_factory(tmp_path: Path) -> Path:
+    """config.ini.factory with mode=OBSERVE."""
+    cfg = configparser.ConfigParser()
+    cfg["system"] = {"mode": "OBSERVE"}
+    cfg["web"] = {
+        "host": "0.0.0.0", "port": "8080", "api_token": "",
+        "web_password": "", "session_timeout_min": "480",
+        "tls_enabled": "false", "tls_cert": "", "tls_key": "",
+        "require_auth_for_control": "false", "mjpeg_quality": "70",
+        "hud_layout": "classic", "theme": "lattice",
+    }
+    path = tmp_path / "config.ini"
+    factory = tmp_path / "config.ini.factory"
+    with open(path, "w") as f:
+        cfg.write(f)
+    with open(factory, "w") as f:
+        cfg.write(f)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Enum round-trip
+# ---------------------------------------------------------------------------
+
+class TestOperatingModeEnum:
+    def test_all_six_values_exist(self):
+        names = {m.name for m in OperatingMode}
+        assert names == {"SIM", "BENCH", "OBSERVE", "FIELD", "ARMED", "MAINTENANCE"}
+
+    def test_enum_is_str_subclass(self):
+        assert isinstance(OperatingMode.OBSERVE, str)
+
+    def test_round_trip_from_string(self):
+        for mode in OperatingMode:
+            assert OperatingMode(mode.value) == mode
+
+    def test_value_equals_name(self):
+        for mode in OperatingMode:
+            assert mode.value == mode.name
+
+
+# ---------------------------------------------------------------------------
+# current_mode()
+# ---------------------------------------------------------------------------
+
+class TestCurrentMode:
+    def test_reads_observe_from_config(self, tmp_config: Path):
+        cfg = configparser.ConfigParser()
+        cfg.read(tmp_config)
+        assert current_mode(cfg) == OperatingMode.OBSERVE
+
+    def test_reads_field_from_config(self, tmp_config: Path):
+        # Manually set mode to FIELD
+        cfg = configparser.ConfigParser()
+        cfg.read(tmp_config)
+        cfg.set("system", "mode", "FIELD")
+        with open(tmp_config, "w") as f:
+            cfg.write(f)
+
+        cfg2 = configparser.ConfigParser()
+        cfg2.read(tmp_config)
+        assert current_mode(cfg2) == OperatingMode.FIELD
+
+    def test_missing_section_defaults_to_observe(self):
+        cfg = configparser.ConfigParser()
+        # No [system] section
+        assert current_mode(cfg) == OperatingMode.OBSERVE
+
+    def test_invalid_value_defaults_to_observe(self):
+        cfg = configparser.ConfigParser()
+        cfg["system"] = {"mode": "BOGUS"}
+        assert current_mode(cfg) == OperatingMode.OBSERVE
+
+
+# ---------------------------------------------------------------------------
+# set_mode()
+# ---------------------------------------------------------------------------
+
+class TestSetMode:
+    def test_set_mode_persists_to_config(self, tmp_config: Path):
+        with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+            cfg = configparser.ConfigParser()
+            cfg.read(tmp_config)
+            set_mode(cfg, OperatingMode.FIELD, reason="field sortie", confirmed_twice=False)
+
+        cfg2 = configparser.ConfigParser()
+        cfg2.read(tmp_config)
+        assert cfg2.get("system", "mode") == "FIELD"
+
+    def test_set_mode_reads_back_correctly(self, tmp_config: Path):
+        with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+            cfg = configparser.ConfigParser()
+            cfg.read(tmp_config)
+            set_mode(cfg, OperatingMode.SIM, reason="simulation start", confirmed_twice=False)
+
+        cfg2 = configparser.ConfigParser()
+        cfg2.read(tmp_config)
+        assert current_mode(cfg2) == OperatingMode.SIM
+
+    def test_armed_requires_confirmed_twice_true(self, tmp_config: Path):
+        with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+            cfg = configparser.ConfigParser()
+            cfg.read(tmp_config)
+            with pytest.raises(ModeTransitionError, match="ARMED"):
+                set_mode(cfg, OperatingMode.ARMED, reason="hot range", confirmed_twice=False)
+
+    def test_armed_succeeds_with_confirmed_twice_true(self, tmp_config: Path):
+        with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+            cfg = configparser.ConfigParser()
+            cfg.read(tmp_config)
+            set_mode(cfg, OperatingMode.ARMED, reason="hot range", confirmed_twice=True)
+
+        cfg2 = configparser.ConfigParser()
+        cfg2.read(tmp_config)
+        assert cfg2.get("system", "mode") == "ARMED"
+
+    def test_other_modes_do_not_require_confirmed_twice(self, tmp_config: Path):
+        for mode in [OperatingMode.BENCH, OperatingMode.MAINTENANCE, OperatingMode.SIM]:
+            with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+                cfg = configparser.ConfigParser()
+                cfg.read(tmp_config)
+                # Should not raise
+                set_mode(cfg, mode, reason="test", confirmed_twice=False)
+
+
+# ---------------------------------------------------------------------------
+# Event timeline entry on transition
+# ---------------------------------------------------------------------------
+
+class TestModeTransitionEvent:
+    def test_event_written_on_transition(self, tmp_config: Path):
+        mock_logger = MagicMock()
+        with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+            with patch("hydra_detect.operating_mode._get_event_logger", return_value=mock_logger):
+                cfg = configparser.ConfigParser()
+                cfg.read(tmp_config)
+                set_mode(cfg, OperatingMode.FIELD, reason="pre-sortie", confirmed_twice=False)
+
+        mock_logger.log_action.assert_called_once()
+        call_kwargs = mock_logger.log_action.call_args
+        # First positional arg is the action name
+        action = call_kwargs[0][0]
+        assert action == "mode.transition"
+        # Details dict
+        details = call_kwargs[0][1] if len(call_kwargs[0]) > 1 else call_kwargs[1].get("details", {})
+        assert details["to"] == "FIELD"
+        assert details["reason"] == "pre-sortie"
+
+    def test_event_includes_from_and_to(self, tmp_config: Path):
+        mock_logger = MagicMock()
+        with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+            with patch("hydra_detect.operating_mode._get_event_logger", return_value=mock_logger):
+                cfg = configparser.ConfigParser()
+                cfg.read(tmp_config)
+                set_mode(cfg, OperatingMode.BENCH, reason="bench test", confirmed_twice=False)
+
+        call_kwargs = mock_logger.log_action.call_args
+        details = call_kwargs[0][1] if len(call_kwargs[0]) > 1 else call_kwargs[1].get("details", {})
+        assert details["from"] == "OBSERVE"
+        assert details["to"] == "BENCH"
+
+    def test_event_includes_actor(self, tmp_config: Path):
+        mock_logger = MagicMock()
+        with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+            with patch("hydra_detect.operating_mode._get_event_logger", return_value=mock_logger):
+                cfg = configparser.ConfigParser()
+                cfg.read(tmp_config)
+                set_mode(cfg, OperatingMode.FIELD, reason="test", actor="api")
+
+        call_kwargs = mock_logger.log_action.call_args
+        details = call_kwargs[0][1] if len(call_kwargs[0]) > 1 else call_kwargs[1].get("details", {})
+        assert "actor" in details
+
+    def test_no_event_when_no_logger(self, tmp_config: Path):
+        """set_mode works even when no event logger is registered."""
+        with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+            with patch("hydra_detect.operating_mode._get_event_logger", return_value=None):
+                cfg = configparser.ConfigParser()
+                cfg.read(tmp_config)
+                # Should not raise
+                set_mode(cfg, OperatingMode.MAINTENANCE, reason="maintenance window")
+
+        cfg2 = configparser.ConfigParser()
+        cfg2.read(tmp_config)
+        assert cfg2.get("system", "mode") == "MAINTENANCE"
+
+
+# ---------------------------------------------------------------------------
+# API — GET /api/mode
+# ---------------------------------------------------------------------------
+
+class TestModeGetEndpoint:
+    def test_get_returns_current_mode(self, client, tmp_config: Path):
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            resp = client.get("/api/mode")
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "OBSERVE"
+
+    def test_get_returns_updated_mode(self, client, tmp_config: Path):
+        # Write FIELD into config
+        cfg = configparser.ConfigParser()
+        cfg.read(tmp_config)
+        cfg.set("system", "mode", "FIELD")
+        with open(tmp_config, "w") as f:
+            cfg.write(f)
+
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            resp = client.get("/api/mode")
+        assert resp.status_code == 200
+        assert resp.json()["mode"] == "FIELD"
+
+    def test_get_requires_no_auth(self, client, tmp_config: Path):
+        """GET /api/mode is read-only — no token required."""
+        configure_auth("test-token")
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            resp = client.get("/api/mode")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# API — POST /api/mode
+# ---------------------------------------------------------------------------
+
+class TestModePostEndpoint:
+    def test_post_transitions_mode(self, client, tmp_config: Path):
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+                resp = client.post("/api/mode", json={
+                    "mode": "FIELD",
+                    "reason": "pre-sortie check",
+                    "confirm": True,
+                })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["mode"] == "FIELD"
+
+    def test_post_armed_without_confirm_returns_400(self, client, tmp_config: Path):
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+                resp = client.post("/api/mode", json={
+                    "mode": "ARMED",
+                    "reason": "hot range",
+                    "confirm": False,
+                })
+        assert resp.status_code == 400
+
+    def test_post_armed_without_reason_returns_400(self, client, tmp_config: Path):
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+                resp = client.post("/api/mode", json={
+                    "mode": "ARMED",
+                    "confirm": True,
+                })
+        assert resp.status_code == 400
+
+    def test_post_armed_with_confirm_and_reason_succeeds(self, client, tmp_config: Path):
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+                resp = client.post("/api/mode", json={
+                    "mode": "ARMED",
+                    "reason": "confirmed hot range",
+                    "confirm": True,
+                })
+        assert resp.status_code == 200
+
+    def test_post_bad_mode_returns_422(self, client, tmp_config: Path):
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/mode", json={
+                "mode": "BOGUS_MODE",
+                "reason": "test",
+                "confirm": True,
+            })
+        assert resp.status_code == 422
+
+    def test_post_missing_body_returns_400(self, client, tmp_config: Path):
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            resp = client.post("/api/mode", content=b"not json",
+                               headers={"content-type": "application/json"})
+        assert resp.status_code == 400
+
+    def test_post_persists_across_get(self, client, tmp_config: Path):
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
+                client.post("/api/mode", json={
+                    "mode": "BENCH",
+                    "reason": "bench test session",
+                    "confirm": True,
+                })
+        with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
+            resp = client.get("/api/mode")
+        assert resp.json()["mode"] == "BENCH"
+
+
+# ---------------------------------------------------------------------------
+# Factory reset → OBSERVE
+# ---------------------------------------------------------------------------
+
+class TestFactoryResetMode:
+    def test_factory_config_has_observe(self, tmp_factory: Path):
+        """Factory file must default to OBSERVE."""
+        factory = Path(str(tmp_factory) + ".factory")
+        cfg = configparser.ConfigParser()
+        cfg.read(factory)
+        assert cfg.get("system", "mode") == "OBSERVE"
+
+    def test_restore_factory_resets_mode_to_observe(self, tmp_factory: Path):
+        """After factory restore, mode reads as OBSERVE."""
+        # First set mode to FIELD
+        cfg = configparser.ConfigParser()
+        cfg.read(tmp_factory)
+        cfg.set("system", "mode", "FIELD")
+        with open(tmp_factory, "w") as f:
+            cfg.write(f)
+
+        # Restore factory
+        from hydra_detect.web.config_api import restore_factory
+        with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_factory):
+            result = restore_factory()
+
+        assert result is True
+        cfg2 = configparser.ConfigParser()
+        cfg2.read(tmp_factory)
+        assert cfg2.get("system", "mode") == "OBSERVE"


### PR DESCRIPTION
## Summary

- Adds `OperatingMode` enum: SIM, BENCH, OBSERVE, FIELD, ARMED, MAINTENANCE. Default: OBSERVE.
- `hydra_detect/operating_mode.py`: `current_mode(cfg)`, `set_mode(cfg, mode, reason, confirmed_twice, actor)`. ARMED transitions require `confirmed_twice=True`, else `ModeTransitionError`. Atomic write via file-lock + `os.replace` (matches `config_api` pattern). Emits `mode.transition` event-timeline entry on every transition.
- `hydra_detect/web/mode_api.py`: new `APIRouter`. `GET /api/mode` (auth-free, dashboard-safe). `POST /api/mode` body `{mode, reason, confirm}`. ARMED requires `confirm=true` + non-empty reason (400 otherwise). Bad mode name → Pydantic 422. Auth matches existing control endpoints.
- `[system] mode` added to `config_schema.py` (ENUM, choices=six values, default=OBSERVE), `config.ini`, and `config.ini.factory`.
- `server.py`: one-line `include_router` import of mode router. `/api/mode` added to public path prefixes (GET is read-only).
- Dashboard: mode badge in topbar near callsign chip. Per-mode accent colours (ARMED = red). Polls `/api/mode` every 5s. Updates `data-mode` attribute for CSS targeting.
- 35 tests in `tests/test_operating_mode.py`: enum round-trip, current_mode, set_mode persistence, ARMED guard, event timeline entry, all API cases, factory reset.

## Voice check

Mode labels are uppercase abbreviations (SIM, FIELD, ARMED). Error messages are direct: "Mode: ARMED requires confirm=true." No AI-generated prose in error strings or comments.

## Test plan

- [ ] `python -m pytest tests/test_operating_mode.py -v` — all 35 pass on CI (Linux; fcntl required)
- [ ] `python -m pytest tests/ -v` — no regressions vs. main baseline
- [ ] `GET /api/mode` returns `{"mode": "OBSERVE"}` on fresh config
- [ ] `POST /api/mode {"mode": "FIELD", "reason": "sortie", "confirm": true}` transitions and persists
- [ ] `POST /api/mode {"mode": "ARMED", "confirm": false}` returns 400
- [ ] `POST /api/mode {"mode": "ARMED", "confirm": true}` with no reason returns 400
- [ ] `POST /api/mode {"mode": "BOGUS"}` returns 422
- [ ] Dashboard topbar shows mode badge; updates on poll
- [ ] Factory reset (restore config.ini.factory) restores mode to OBSERVE

## Orthogonality note

Mode is independent of vehicle profile and mission profile. No existing endpoints were modified. Placeholders for mode-gated capability logic (#146) can reference `OperatingMode` from `hydra_detect.operating_mode`.

Closes #147