### PR TITLE
refactor(#151): language pivot — operator-owned vocabulary, drop student/instructor framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ MAVLink, emits CoT to TAK, and serves an operator dashboard on port
 - Four-tab operator dashboard: `#ops`, `#tak`, `#config`, `#settings`.
   Autonomy controls live inside Config; system diagnostics inside Settings.
 - Vehicle control modes: Follow, Drop, Strike, Pixel-Lock, plus an
-  always-available instructor abort.
+  always-available safety override abort.
 - Five-gate autonomy stack (geofence / vehicle_mode / operator_lock /
   gps_fresh / cooldown) with dry-run, shadow, and live modes.
 - TAK/CoT output + HMAC-verified GeoChat input + peer roster +

--- a/docs/SORCC_DASHBOARD_AUDIT.md
+++ b/docs/SORCC_DASHBOARD_AUDIT.md
@@ -72,7 +72,7 @@ of having a bar chart.
 **5. Device names truncated with "…" in TOP ACTIVE — no tooltip**
 
 "ACI-UniversalCon…" in TOP ACTIVE is cut off. Hovering over it shows no tooltip.
-An instructor demoing this to soldiers can't read the full device name without
+An operator demoing this can't read the full device name without
 clicking into the device. Add a tooltip on hover showing the full name.
 
 **6. WiFi counter always 0 in stat tiles makes WIFI and OTHER tiles look broken**
@@ -116,8 +116,8 @@ current gray to at least `#999` or `rgba(255,255,255,0.6)`.
 
 **12. No export button for device list**
 
-An instructor after a demo wants to show results. There's no way to export the
-detected device list as CSV or JSON from the dashboard. Add an export button.
+After a demo, there's no way to export the detected device list as CSV or JSON
+from the dashboard. Add an export button.
 
 **13. Settings page layout cramped on laptop screens**
 
@@ -139,7 +139,7 @@ A quick theme toggle would help.
 
 **16. No keyboard shortcuts**
 
-Power users (instructors) would benefit from keyboard shortcuts for common
+Power users would benefit from keyboard shortcuts for common
 actions: start/stop survey, switch tabs, export data.
 
 **17. Preflight page "Re-check" button styling inconsistent**

--- a/docs/adversarial/README.md
+++ b/docs/adversarial/README.md
@@ -33,7 +33,7 @@ status, not a required merge gate). To clear the check:
 Flip to a required check in branch protection once the team observes,
 for at least five consecutive PRs that touch ADVERSARIAL_PATHS, that R3
 surfaces at least one finding the human review missed. Owner for that
-transition: the lead instructor. Revocation: same person, if false-
+transition: the fleet lead. Revocation: same person, if false-
 positive rate exceeds one per PR over a two-week window.
 
 ## How to run

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -25,11 +25,14 @@ or if password auth is disabled.
 ### `GET /control`
 **Auth:** none · Mobile operator control page.
 
+### `GET /fleet`
+**Auth:** none · Fleet View with per-vehicle status and abort.
+
 ### `GET /instructor`
-**Auth:** none · Instructor overview with per-vehicle abort.
+**Auth:** none · Redirects to `/fleet` (307).
 
 ### `GET /review`
-**Auth:** none · Post-mission review page (standalone; does not share
+**Auth:** none · Post-sortie review page (standalone; does not share
 `base.html`).
 
 ### `GET /capabilities`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,7 +170,7 @@ frontend has no branches.
 
 - `/api/abort` is unauthenticated and tries RTL → LOITER → HOLD in
   order. Any callback exception is caught; the endpoint must return a
-  response so the instructor knows whether the abort landed.
+  response so range control knows whether the abort landed.
 - Approach controllers always restore `_pre_approach_mode` on abort,
   not a hardcoded LOITER.
 - Autonomy snapshots return an idle default on any exception — the

--- a/docs/dashboard-user-guide.md
+++ b/docs/dashboard-user-guide.md
@@ -251,7 +251,7 @@ while a mission is active. Unfreeze by ending the mission first.
 
 ## Hidden features
 
-Short section for operators and instructors who like to find things.
+Short section for operators who like to find things.
 
 ### Konami code — sentience sequence
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -6,9 +6,9 @@
 |-----|------|----------|---------|
 | `/` | Dashboard | Operator | Live stream, tracks, target control |
 | `/control` | Mobile Control | Operator (phone) | Touch-optimized lock/strike/abort |
-| `/instructor` | Instructor | Instructor | Multi-vehicle overview + abort |
-| `/review` | Review | All | Post-mission map replay |
-| `/setup` | Setup Wizard | Instructor / Dev | First-boot hardware config |
+| `/fleet` | Fleet View | Fleet lead / range control | Multi-vehicle overview + abort |
+| `/review` | Review | All | Post-sortie map replay |
+| `/setup` | Setup Wizard | Maintainer / Dev | First-boot hardware config |
 | `/login` | Login | All | Password gate (when `web_password` is set) |
 
 The dashboard is a single-page application served on port 8080. Two main views (Operations and Settings) share a common shell. Both always exist in the DOM and toggle via CSS. Review is a standalone page at `/review`.
@@ -156,11 +156,11 @@ The `/control` page is a touch-optimized control surface for field use on phones
 
 No settings editing. Designed for the operator holding the RC transmitter.
 
-## Instructor Overview Page
+## Fleet View Page
 
-![Instructor multi-vehicle overview](images/dashboard-instructor.png)
+![Fleet View multi-vehicle overview](images/dashboard-instructor.png)
 
-The `/instructor` page shows multiple Hydra vehicles on one screen. It fetches `GET /api/stats` from each configured Jetson's IP address. Each vehicle card shows:
+The `/fleet` page shows multiple Hydra vehicles on one screen. It fetches `GET /api/stats` from each configured Jetson's IP address. Each vehicle card shows:
 
 - Callsign
 - FPS and track count
@@ -168,7 +168,9 @@ The `/instructor` page shows multiple Hydra vehicles on one screen. It fetches `
 - Abort button (unauthenticated, calls `POST /api/abort` on that vehicle)
 
 > [!WARNING]
-> The abort endpoint is intentionally unauthenticated. An instructor must be able to abort any vehicle without configuring tokens. The `/api/abort` and `/api/stats` endpoints have permissive CORS headers for cross-origin instructor page access.
+> The abort endpoint is intentionally unauthenticated. Range control must be able to abort any vehicle without configuring tokens first. The `/api/abort` and `/api/stats` endpoints have permissive CORS headers for cross-origin Fleet View access.
+
+`/instructor` redirects to `/fleet` (307).
 
 ## Connection Indicators
 
@@ -187,7 +189,7 @@ All pages include defense-in-depth headers:
 - `X-Content-Type-Options: nosniff`
 - Content Security Policy restricting scripts, styles, and connections
 
-The instructor page has a relaxed CSP (`connect-src *`) to allow cross-origin fetches to other Jetsons.
+The Fleet View page has a relaxed CSP (`connect-src *`) to allow cross-origin fetches to other Jetsons.
 
 ## Keyboard Accessibility Test Checklist (Confirmation Modals)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -173,13 +173,13 @@ Set in `[tak] callsign` or via the setup wizard. The callsign is used in TAK mar
 
 When the callsign differs from `HYDRA-1`, log directories are namespaced: `output_data/HYDRA-2-DRONE/logs/`.
 
-### Instructor Page
+### Fleet View
 
-The instructor page at `/instructor` on any Hydra instance shows all vehicles on one screen. It polls `GET /api/stats` from each configured Jetson IP. Each card shows callsign, FPS, track count, and an abort button.
+The Fleet View at `/fleet` on any Hydra instance shows all vehicles on one screen. It polls `GET /api/stats` from each configured Jetson IP. Each card shows callsign, FPS, track count, and an abort button.
 
-The abort button calls `POST /api/abort` on the target Jetson. This endpoint is unauthenticated by design.
+The abort button calls `POST /api/abort` on the target Jetson. This endpoint is unauthenticated by design — range control must be able to abort without configuring tokens.
 
-CORS headers on `/api/stats` and `/api/abort` allow cross-origin access from the instructor page.
+CORS headers on `/api/stats` and `/api/abort` allow cross-origin access from the Fleet View. `/instructor` redirects to `/fleet`.
 
 ### Code Sync
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -96,8 +96,8 @@ Hydra/
         operations.html               # Operator dashboard (detections, controls)
         settings.html                 # Settings panel (camera, model, config)
         control.html                  # Mobile operator control page
-        instructor.html               # Multi-vehicle instructor overview
-        review.html                   # Post-mission review map (standalone)
+        instructor.html               # Multi-vehicle Fleet View
+        review.html                   # Post-sortie review map (standalone)
         setup.html                    # First-boot setup wizard
       static/                         # CSS, JS, and image assets
 
@@ -117,7 +117,7 @@ Hydra/
     test_drop_strike.py               # Drop and strike modes
     test_event_logger.py              # Event timeline logger
     test_geo_tracking.py              # Geo-tracking message generation
-    test_instructor_ops.py            # Instructor page and abort
+    test_instructor_ops.py            # Fleet View and abort
     test_log_endpoint.py              # /api/logs endpoint
     test_map_replay.py                # Map replay event parsing
     test_mavlink_commands.py          # MAVLink vehicle commands

--- a/docs/field-connectivity.md
+++ b/docs/field-connectivity.md
@@ -40,7 +40,7 @@ accessible from any node on the mesh.
 4G USB modem + SIM card on the Jetson, with Tailscale overlay for secure
 remote access.
 
-**When to use:** Remote ops, multi-site exercises, instructor monitoring from
+**When to use:** Remote ops, multi-site exercises, fleet lead monitoring from
 a different location, demo from HQ.
 
 **Hardware:** SUNGOOYUE 4G LTE USB dongle (Qualcomm chipset, USB ID

--- a/docs/future-directions.md
+++ b/docs/future-directions.md
@@ -30,9 +30,9 @@ speculative "what if" ideas.
 - **Pixhawk 6X** — Current top-of-line. Ethernet port for high-bandwidth
   MAVLink (vs serial). Could enable video-over-MAVLink at higher quality.
 - **MatekH743** — Budget FC popular in FPV. Runs ArduPilot. Good candidate for
-  student-built platforms where cost matters.
+  operator-built platforms where cost matters.
 - **Betaflight → ArduPilot migration** — Some FPV quads run Betaflight. Hydra
-  requires ArduPilot for MAVLink. Students may need to reflash FCs. Document
+  requires ArduPilot for MAVLink. Operators may need to reflash FCs. Document
   the migration path.
 
 ### Sensors
@@ -72,7 +72,7 @@ speculative "what if" ideas.
 ## Software Capabilities
 
 ### Detection & Tracking
-- **Custom YOLO training pipeline** — Students use COCO-pretrained models.
+- **Custom YOLO training pipeline** — Platforms ship with COCO-pretrained models.
   For mission-relevant classes (specific boat types, vehicle models,
   equipment), need a training pipeline. Roboflow or custom with Ultralytics
   HUB. Could run training on a cloud GPU and push models to Jetsons.
@@ -124,21 +124,21 @@ speculative "what if" ideas.
   uses MAVLink. A STANAG adapter would allow Hydra to interface with
   NATO-standard ground stations. Far future.
 - **Cloud dashboard** — Web dashboard served from a cloud instance (AWS/GCP)
-  that aggregates all field Jetsons via LTE/Starlink. Remote instructor
-  oversight from anywhere. The instructor page architecture already
+  that aggregates all field Jetsons via LTE/Starlink. Remote fleet-lead
+  oversight from anywhere. The Fleet View architecture already
   supports this — just change the polling targets from Tailscale IPs to
   cloud-routed endpoints.
 
-### Training & Simulation
+### Simulation
 - **SITL integration** — ArduPilot Software-in-the-Loop runs on any laptop.
   Pair with a video file as camera source and Hydra runs a full simulated
-  mission. Students could practice before touching real hardware.
+  sortie. Operators can rehearse procedures before touching real hardware.
 - **Digital twin** — Gazebo or AirSim simulation with Hydra running against
-  virtual cameras. Full mission rehearsal. Heavy setup but powerful for
-  pre-mission planning.
+  virtual cameras. Full mission rehearsal. Heavy setup but useful for
+  pre-sortie planning.
 - **Scenario generator** — Script that creates detection scenarios (person
   walking across field, boat on lake) as video files. Use for automated
-  testing and student exercises without going to the field.
+  testing and bench exercises without going to the field.
 - **Scoring system** — Automated CULEX scoring: compare detections against
   ground truth target placements, compute detection rate, time-to-detect,
   false positive rate. Extends the mission tagging feature.
@@ -158,7 +158,7 @@ speculative "what if" ideas.
   addressable LEDs for richer status.
 - **Trigger circuit PCB** — Custom PCB for the two-stage arm circuit
   (software + hardware + physical contact). Could be a simple MOSFET AND
-  gate on a perfboard. Document the circuit for students to build.
+  gate on a perfboard. Document the circuit for operators to build.
 
 ### v3 Mesh Nodes
 - **FANG (detection node)** — Jetson + camera + WiFi HaLow. Full Hydra
@@ -167,7 +167,7 @@ speculative "what if" ideas.
   commands. Lightweight, fast, cheap.
 - **SPINE (relay node)** — RPi + WiFi HaLow. OpenMANET mesh relay.
   Infrastructure node.
-- **NEST (coordinator)** — Laptop/tablet + WiFi HaLow gateway. Instructor
+- **NEST (coordinator)** — Laptop/tablet + WiFi HaLow gateway. Fleet lead
   GCS with multi-vehicle C2.
 
 ## Research Questions
@@ -187,5 +187,5 @@ speculative "what if" ideas.
 - 2026-03-29: Fixed wing = sensor only, no autonomous behaviors (speed constraints)
 - 2026-03-29: Mission profiles (RECON/DELIVERY/STRIKE) as dashboard presets
 - 2026-03-29: Two-stage arm circuit for strike (software + hardware + physical)
-- 2026-03-29: Instructor page is grading tool with abort exception, not C2
+- 2026-03-29: Fleet View is status/abort tool, not C2
 - 2026-03-29: Tailscale for cross-team comms, multicast for same-subnet only

--- a/docs/hydra-tak-101.md
+++ b/docs/hydra-tak-101.md
@@ -182,7 +182,7 @@ stream. In ATAK: **Tools → Video** — the feed should appear automatically.
 | **ATAK-CIV** | Android | tak.gov (free account) | Recommended for testing |
 | **ATAK** (gov) | Android | tak.gov (.mil/.gov email) | Same CoT protocol, extra plugins |
 | **iTAK** | iOS | Apple App Store | Works but multicast less reliable |
-| **WinTAK** | Windows | tak.gov | Great for instructor station, big screen |
+| **WinTAK** | Windows | tak.gov | Good for fleet lead station, big screen |
 
 All clients receive the same CoT messages. No special configuration needed
 per client — if it can receive UDP on `239.2.3.1:6969`, it sees Hydra's data.

--- a/docs/jetson-setup-guide.md
+++ b/docs/jetson-setup-guide.md
@@ -1,7 +1,7 @@
 # Hydra Detect — Jetson Orin Nano Setup Guide (Docker)
 
 This guide walks through installing Hydra Detect from GitHub onto a fresh
-NVIDIA Jetson Orin Nano using Docker. Written for students and instructors
+NVIDIA Jetson Orin Nano using Docker. Written for operators and maintainers
 to reproduce the setup.
 
 For initial JetPack flashing and OS setup, see

--- a/docs/preservation-rules.md
+++ b/docs/preservation-rules.md
@@ -41,13 +41,13 @@ Kyle is running an overnight Phase 2 rebuild. The following are confirmed hidden
 
 - **Title**: `HYDRA DETECT — SORCC` in `base.html:6`.
 - **Footer**: `UNCLASSIFIED` center + `SORCC Payload Integrator` right + dynamic callsign left.
-- **SORCC SVG badge** top-left on base/login/setup/instructor pages. Palette (post-migration names):
+- **SORCC SVG badge** top-left on base/login/setup/fleet pages. Palette (post-migration names):
   - `#385723` → `--olive-primary`
   - `#A6BC92` → `--ogt-muted` (kept name per token-migration ambiguity ruling)
   - `#EFF5EB` → `--ogt-light`
 - **Callsign swap**: `main.js:36-42` rewrites `document.title` and topbar brand to `${callsign} — SORCC` on first `/api/stats` response. Preserve in any topbar rewrite.
 - **Callsign-duplicate toast** in `main.js:45-48` — multi-team collision warning. Preserve.
-- **Default callsign** `HYDRA-1` (`config.ini:198`); student-team format `HYDRA-{team}-{vehicle}`.
+- **Default callsign** `HYDRA-1` (`config.ini:198`); team format `HYDRA-{team}-{vehicle}`.
 - **Sim GPS fallback** `35.0527, -79.4927` (Fort Bragg vicinity, `__main__.py:27,31`). Deliberate SOF training choice.
 - **TAK port `6969`** — matches ATAK default multicast. Leave as-is.
 

--- a/docs/safety-review-2026-04-20.md
+++ b/docs/safety-review-2026-04-20.md
@@ -130,7 +130,7 @@ these commits. Their state is unchanged from the prior baseline.
   callback crash falls through to the next mode, and if every mode
   fails or MAVLink is disconnected the endpoint still returns a 503
   JSON error. Endpoint is in `_PUBLIC_PATH_PREFIXES` (server.py:337)
-  so auth never blocks an instructor abort.
+  so auth never blocks a range-control abort.
 
 ### 7. Autonomy dry-run + inhibit toggleable at runtime — PASS (with UI gap)
 

--- a/docs/setup/headless-field-boot.md
+++ b/docs/setup/headless-field-boot.md
@@ -30,9 +30,9 @@ For initial Jetson setup, see [Docker install](/setup/jetson-docker) first. For 
 - `sudo` access on the Jetson
 - WiFi SSID and password for the field network (or Ethernet cable)
 
-## Instructor Setup
+## Platform Setup
 
-Run the setup script once in the classroom before deploying to the field.
+Run the setup script once on the bench before deploying to the field.
 
 <Steps>
 

--- a/docs/setup/jetson-docker.md
+++ b/docs/setup/jetson-docker.md
@@ -5,7 +5,7 @@ sidebarTitle: "Docker install"
 icon: "docker"
 ---
 
-This guide walks through installing Hydra Detect on a fresh NVIDIA Jetson Orin Nano using Docker. Written for students and instructors to reproduce the setup.
+This guide walks through installing Hydra Detect on a fresh NVIDIA Jetson Orin Nano using Docker. Written for operators and maintainers reproducing the setup.
 
 For initial JetPack flashing and OS setup, see [Jetson flash](/setup/jetson-flash) first.
 

--- a/docs/setup/jetson-flash.md
+++ b/docs/setup/jetson-flash.md
@@ -7,7 +7,7 @@ icon: "microchip"
 
 This guide covers flashing JetPack onto a Jetson Orin Nano and completing the Ubuntu first-boot wizard. When done, you'll have a fresh desktop with a terminal ready for the [Hydra software setup](/setup/jetson-docker).
 
-Written for students reproducing the Hydra Detect build from scratch.
+Written for operators reproducing the Hydra Detect build from scratch.
 
 ## What you need
 
@@ -103,7 +103,7 @@ The Jetson boots into Ubuntu's out-of-box setup. Walk through each screen:
 - Click Continue
 
 <Warning>
-For classroom/lab Jetsons, we use `sorcc`/`sorcc` as the standard credentials. For field deployments, use a stronger password.
+For bench/lab Jetsons, we use `sorcc`/`sorcc` as the standard credentials. For field deployments, use a stronger password.
 </Warning>
 
 **Partition Size** — Accept the default. Click Continue.

--- a/docs/setup/remote-access.md
+++ b/docs/setup/remote-access.md
@@ -1,6 +1,6 @@
 ---
 title: "Remote Access (Tailscale)"
-description: "Set up Tailscale SSH so instructors and students can manage Jetsons remotely without a monitor."
+description: "Set up Tailscale SSH so operators and maintainers can manage Jetsons remotely without a monitor."
 sidebarTitle: "Remote access"
 icon: "globe"
 keywords:
@@ -46,7 +46,7 @@ Open the URL in a browser on any device to authenticate the Jetson to your Tails
 sudo bash scripts/setup_tailscale.sh --authkey tskey-auth-xxxxx --hostname hydra-jetson-03
 ```
 
-This skips the interactive login step. Useful for setting up a classroom of Jetsons in one session.
+This skips the interactive login step. Useful for setting up a fleet of Jetsons in one session.
 </Tip>
 
 </Step>

--- a/docs/superpowers/specs/2026-03-16-hydra-setup-script-design.md
+++ b/docs/superpowers/specs/2026-03-16-hydra-setup-script-design.md
@@ -9,7 +9,7 @@ A single interactive bash script (`scripts/hydra-setup.sh`) that takes a freshly
 cloned Jetson from zero to running Hydra Detect. Idempotent — safe to re-run,
 skips steps already completed.
 
-Target audience: instructors reproducing the Hydra build from scratch after
+Target audience: operators and maintainers reproducing the Hydra build from scratch after
 completing JetPack flash and Ubuntu first-boot.
 
 ## Flow
@@ -44,7 +44,7 @@ script exits with a clear message about what's needed.
   - **Yes:**
     1. Install via official Tailscale install script (`curl -fsSL https://tailscale.com/install.sh | sh`)
     2. Run `sudo tailscale up`
-    3. Print the auth URL for the instructor to open in a browser
+    3. Print the auth URL for the operator to open in a browser
     4. Wait for connection to establish
     5. Enable Tailscale SSH: `sudo tailscale set --ssh`
     6. Print the assigned Tailscale IP
@@ -72,13 +72,13 @@ with Docker volume mounts):
 
 ### Step 6 — Config
 
-Detect hardware and prompt the instructor:
+Detect hardware and prompt the operator:
 
 - **Serial device scan:** Check all `/dev/ttyACM*` and `/dev/ttyUSB*` devices.
   - **One device found:** `"Flight controller detected on /dev/ttyACM0. Enable MAVLink? [Y/n]"`
     - Yes: set `[mavlink] enabled = true`, `connection_string = /dev/ttyACM0`
     - No: set `[mavlink] enabled = false`
-  - **Multiple devices found:** Present a numbered list and let the instructor pick:
+  - **Multiple devices found:** Present a numbered list and let the operator pick:
     ```
     Serial devices found:
       1) /dev/ttyACM0
@@ -111,7 +111,7 @@ per-deployment settings.
   from `docs/jetson-setup-guide.md`). Dynamically include `--device /dev/ttyACM0`
   only when MAVLink was enabled in Step 6. Print dashboard URL
   (`http://<jetson-ip>:8080`).
-- **No:** Print the full docker run command so the instructor can copy/paste later.
+- **No:** Print the full docker run command so the operator can copy/paste later.
 
 Docker run command is built dynamically:
 - **Camera devices:** Loop over detected `/dev/video*` devices from Step 1,
@@ -145,11 +145,11 @@ docker run --rm --privileged --runtime nvidia \
 | Decision | Rationale |
 |----------|-----------|
 | Tailscale on host, not in Docker | SSH needs to reach the Jetson OS directly |
-| Tailscale SSH via `tailscale set --ssh` | No SSH key management needed for instructors |
-| No pre-auth keys | Simpler — instructor clicks auth URL once |
+| Tailscale SSH via `tailscale set --ssh` | No SSH key management needed for operators |
+| No pre-auth keys | Simpler — operator clicks auth URL once |
 | Idempotent steps | Safe to re-run after failure, reboot, or when re-checking setup |
 | Separate from `jetson_preflight.sh` | Preflight stays as a lightweight field-check tool |
-| Only touch MAVLink config | Avoids overwriting instructor customizations in config.ini |
+| Only touch MAVLink config | Avoids overwriting operator customizations in config.ini |
 | `set -euo pipefail` with `|| true` guards | Fail fast on errors, but interactive prompts and optional steps use `|| true` to avoid unexpected exits |
 
 ## Files Changed
@@ -166,7 +166,7 @@ docker run --rm --privileged --runtime nvidia \
 The script is idempotent — each step checks current state before acting. If a
 Docker build fails mid-way (e.g., network timeout), re-running the script will
 pick up where it left off thanks to Docker layer caching. If caching causes
-issues, the instructor can run `docker build --no-cache` manually.
+issues, the operator can run `docker build --no-cache` manually.
 
 ## Out of Scope
 

--- a/docs/superpowers/specs/2026-03-19-pixel-lock-servo-tracking-design.md
+++ b/docs/superpowers/specs/2026-03-19-pixel-lock-servo-tracking-design.md
@@ -310,7 +310,7 @@ for v1 — the servo is an actuator, not a new data source.
 
 ## Deployment Scenarios
 
-### Bench Demo (instructor)
+### Bench Demo
 
 ```
 USB Webcam → Jetson → YOLO → ByteTrack → pixel-lock → set_servo

--- a/docs/superpowers/specs/2026-03-29-stakeholder-code-review.md
+++ b/docs/superpowers/specs/2026-03-29-stakeholder-code-review.md
@@ -34,10 +34,10 @@ TLS support exists behind a `tls_enabled` config flag. It uses subprocess-spawne
 - The self-signed cert will trigger browser warnings, which field operators may habitually click through.
 
 **CORS — PASS.**
-Restricted to only `/api/stats` and `/api/abort` for the instructor page (cross-Jetson polling). All other endpoints stay same-origin. This is correctly scoped.
+Restricted to only `/api/stats` and `/api/abort` for the Fleet View page (cross-Jetson polling). All other endpoints stay same-origin. This is correctly scoped.
 
 **CSP — CONDITIONAL PASS.**
-`'unsafe-inline'` is used for both script-src and style-src on all pages. This negates the XSS protection benefit of the CSP entirely. The instructor page additionally uses `connect-src *`, making it a relay attack surface. These are acceptable trade-offs for an intranet device but would fail a DoD STIG review.
+`'unsafe-inline'` is used for both script-src and style-src on all pages. This negates the XSS protection benefit of the CSP entirely. The Fleet View page additionally uses `connect-src *`, making it a relay attack surface. These are acceptable trade-offs for an intranet device but would fail a DoD STIG review.
 
 **Input validation — PASS on most endpoints, GAPS on two.**
 Most control endpoints perform explicit type checking, range validation, and format validation (e.g., BSSID regex, mode allowlist). The `strike` endpoint requires `confirm: true` as an explicit boolean. The `set_mode` endpoint allowlists five modes. This is above average.
@@ -138,7 +138,7 @@ Bounded queues and ring buffers throughout. One concern: auto-loiter calls `comm
 
 ## Stakeholder 2 — USASOC SORD (SOF Fielding Evaluation)
 
-This reviewer asks: "Is this safe to put on aircraft and in the hands of students?"
+This reviewer asks: "Is this safe to put on aircraft and in the hands of operators?"
 
 ### Safety and Fail-Safe Architecture
 
@@ -158,7 +158,7 @@ The `AutonomousController.evaluate()` implements a multi-gate safety model:
 All criteria must hold simultaneously. This is a defensible design for a training system.
 
 **Critical safety concern — `require_operator_lock` defaults to `False`.**
-If autonomous mode is enabled but `require_operator_lock` is not set in `config.ini`, the system will autonomously strike without requiring any human to identify and lock the target first. For a training system in the hands of SOF students on Week 4-5, the default should be `True`.
+If autonomous mode is enabled but `require_operator_lock` is not set in `config.ini`, the system will autonomously strike without requiring any human to identify and lock the target first. The default should be `True`.
 
 **Servo channel safety — PASS.** Channel collision detection at init time with CRITICAL-level logging.
 
@@ -166,7 +166,7 @@ If autonomous mode is enabled but `require_operator_lock` is not set in `config.
 
 **Camera loss response — STRONG.** Suppresses autonomous controller, sends STATUSTEXT, logs the state change, updates dashboard.
 
-### Student-Facing UX and Safety
+### Operator-Facing UX and Safety
 
 **Pre-flight checklist — STRONG.** Structured checks with plain-English error messages.
 
@@ -252,7 +252,7 @@ This reviewer asks: "Does this meet the bar for broader DoD experimentation?"
 Architecturally sound, well-tested, operationally coherent. MAVLink and TAK implementations are above average. Address C1, C2, I2, I4, and produce a threat model document. After those actions, this is a viable integration candidate.
 
 ### USASOC SORD: CONDITIONAL GO for SORCC, NO-GO for operational use
-For SORCC training (controlled environment, instructors present), the system is ready with one precondition: **C1 must be fixed** before students touch autonomous mode. C2 and C3 should also be resolved before CULEX. For operational use, I2/I4 and an ATO process would be required.
+For SORCC (controlled environment, supervised), the system is ready with one precondition: **C1 must be fixed** before operators use autonomous mode. C2 and C3 should also be resolved before CULEX. For operational use, I2/I4 and an ATO process would be required.
 
 ### JEB: NO-GO at current state
 Blockers: no SBOM (I4), no threat model document, cleartext transport (I2), and operator lock default (C1). None are architectural — all are resolvable in one sprint. The test suite, audit logging, chain-of-custody, and TAK integration are genuine differentiators.

--- a/docs/superpowers/specs/2026-04-02-ui-redesign-3-page.md
+++ b/docs/superpowers/specs/2026-04-02-ui-redesign-3-page.md
@@ -58,7 +58,7 @@ Think fighter jet HUD, not web dashboard.
 ## Page 2: Config
 
 ### Purpose
-Mission configuration and operational tuning. The instructor's page. Has video
+Mission configuration and operational tuning. Has video
 feed for visual feedback while tuning detection parameters.
 
 ### Layout
@@ -144,7 +144,7 @@ All values editable via **sliders and dropdowns** where possible, not typed text
 - **Logout** button
 
 #### Page Links
-- Links to standalone pages: `/control` (mobile), `/instructor` (fleet), `/review` (post-mission), `/setup` (wizard)
+- Links to standalone pages: `/control` (mobile), `/fleet` (fleet view), `/review` (post-sortie), `/setup` (wizard)
 
 ### Config Sections
 All 10 config.ini sections, each with appropriate input controls derived from
@@ -166,8 +166,8 @@ All 10 config.ini sections, each with appropriate input controls derived from
 
 ### Page Links in Footer or Settings
 - `/control` — Mobile tactical (simplified touch-friendly ops)
-- `/instructor` — Fleet overview (multi-vehicle polling)
-- `/review` — Post-mission map review
+- `/fleet` — Fleet View (multi-vehicle polling)
+- `/review` — Post-sortie map review
 - `/setup` — First-boot wizard
 
 ---
@@ -188,7 +188,7 @@ All 10 config.ini sections, each with appropriate input controls derived from
 | Camera live switch | Config (Detection section) | Dropdown + instant apply via `/api/camera/switch` |
 | Config prompts | Config (Detection section) | Text field → `POST /api/config/prompts` |
 | Control page link | Settings (Page Links) | `<a href="/control">` |
-| Instructor page link | Settings (Page Links) | `<a href="/instructor">` |
+| Fleet View link | Settings (Page Links) | `<a href="/fleet">` |
 | Review page link | Settings (Page Links) | `<a href="/review">` |
 | Setup page link | Settings (Page Links) | `<a href="/setup">` |
 

--- a/docs/tak-integration.md
+++ b/docs/tak-integration.md
@@ -94,7 +94,7 @@ The TAK input listener monitors incoming SA events. If it detects another vehicl
 
 ```ini
 [tak]
-allowed_callsigns = INSTRUCTOR-1, INSTRUCTOR-2
+allowed_callsigns = FLEETLEAD-1, FLEETLEAD-2
 ```
 
 Only GeoChat messages or CoT events from senders whose callsign matches the allowlist are processed.
@@ -112,7 +112,7 @@ Commands include an HMAC digest in the CoT event. The listener verifies the dige
 
 ### Unauthenticated Abort
 
-The web API abort endpoint (`POST /api/abort`) is intentionally unauthenticated for instructor safety override. This is separate from the TAK command path, which respects the allowlist.
+The web API abort endpoint (`POST /api/abort`) is intentionally unauthenticated for safety override. Any device on the network can abort any vehicle. This is separate from the TAK command path, which respects the allowlist.
 
 ## ATAK Plugin
 
@@ -134,7 +134,7 @@ stale_sa = 30.0
 advertise_host = <JETSON_IP>
 listen_commands = true
 listen_port = 6969
-allowed_callsigns = INSTRUCTOR-1
+allowed_callsigns = FLEETLEAD-1
 command_hmac_secret =
 ```
 

--- a/docs/tak-testing-guide.md
+++ b/docs/tak-testing-guide.md
@@ -1,7 +1,7 @@
 # TAK/ATAK Testing Guide for Hydra Detect
 
 How to test Hydra's CoT output at every level — from desk verification to
-full mesh deployment with student tablets.
+full mesh deployment with operator tablets.
 
 ---
 
@@ -14,7 +14,7 @@ full mesh deployment with student tablets.
 | 3 | Personal mobile | ATAK-CIV on Android phone | Same WiFi |
 | 4 | iOS alternative | iTAK on iPhone/iPad | Same WiFi |
 | 5 | Mesh integration | ATAK tablets on OpenMANET | Mesh WiFi AP |
-| 6 | Course deployment | ATAK on student devices | FreeTAKServer relay |
+| 6 | Field deployment | ATAK on operator devices | FreeTAKServer relay |
 
 ---
 
@@ -251,18 +251,18 @@ CoT will work the same way — it uses the same multicast group and port.
 
 ---
 
-## Phase 6: Course Deployment with FreeTAKServer
+## Phase 6: Field Deployment with FreeTAKServer
 
-For a training course with many students, **FreeTAKServer (FTS) as a TCP
-relay** is more reliable than multicast. Students connect ATAK → FTS via TCP,
+For a multi-platform deployment, **FreeTAKServer (FTS) as a TCP
+relay** is more reliable than multicast. Operators connect ATAK → FTS via TCP,
 Hydra sends CoT → FTS, FTS relays to all clients.
 
-### Why FTS for courses
+### Why FTS for field deployments
 
 - Eliminates multicast headaches (AP isolation, WiFi sleep, IGMP)
-- Students connect via TCP — works across subnets, VPNs, cellular
-- FTS provides a web dashboard for the instructor to monitor
-- Data persistence — mission playback after the exercise
+- Operators connect via TCP — works across subnets, VPNs, cellular
+- FTS provides a web dashboard for the fleet lead to monitor
+- Data persistence — sortie playback after the exercise
 
 ### Quick FTS setup (on a laptop or RPi — not the Jetson)
 
@@ -286,7 +286,7 @@ FTS listens on:
 
 ### Connect ATAK to FTS
 
-On each student's ATAK:
+On each operator's ATAK:
 1. Settings → Network Preferences → TAK Servers → Add
 2. Address: `<FTS-IP>`, Port: `8087`, Protocol: TCP
 3. No certificates needed for unencrypted mode
@@ -345,8 +345,8 @@ REST API endpoint to POST CoT events directly.
 - [ ] Detection latency acceptable (< 5 seconds from detection to marker)
 - [ ] Mesh multicast flooding enabled if IGMP isn't working
 
-### Course deployment (Phase 6)
+### Field deployment (Phase 6)
 - [ ] FreeTAKServer running and accepting connections
-- [ ] All student ATAK devices connected to FTS
-- [ ] Instructor can see all clients on FTS web dashboard
-- [ ] Hydra detections visible on all student devices simultaneously
+- [ ] All operator ATAK devices connected to FTS
+- [ ] Fleet lead can see all clients on FTS web dashboard
+- [ ] Hydra detections visible on all operator devices simultaneously

--- a/docs/vehicle-control.md
+++ b/docs/vehicle-control.md
@@ -147,7 +147,7 @@ Abort immediately safes all channels and switches the vehicle to a safe mode. Th
 
 1. **Dashboard**: abort button in the Operations tab
 2. **TAK**: send `HYDRA UNLOCK` via GeoChat (or custom CoT `a-x-hydra-u`)
-3. **API**: `POST /api/approach/abort` (authenticated) or `POST /api/abort` (unauthenticated, instructor override)
+3. **API**: `POST /api/approach/abort` (authenticated) or `POST /api/abort` (unauthenticated, safety override)
 
 On abort:
 - Approach controller returns to IDLE
@@ -157,7 +157,7 @@ On abort:
 - Event is logged to the audit trail
 
 > [!WARNING]
-> The `POST /api/abort` endpoint is intentionally unauthenticated. This is the instructor safety override. Any device on the network can abort any vehicle.
+> The `POST /api/abort` endpoint is intentionally unauthenticated. Any device on the network can abort any vehicle. This is the safety override — range control must be able to abort without configuring tokens first.
 
 ## Vehicle Compatibility
 

--- a/docs/week4-test-plan.md
+++ b/docs/week4-test-plan.md
@@ -1,11 +1,11 @@
 # Hydra Week 4 Field Validation Test Plan
 
-**Timeline:** Week 3 starts March 31. Students hit Hydra Week 4 (~April 7).
-**Window:** 9 days for instructor validation before student use.
+**Timeline:** Week 3 starts March 31. Operators on Hydra Week 4 (~April 7).
+**Window:** 9 days for maintainer validation before field use.
 
 ## Phase 1 — Bench Test (March 31 - April 2)
 
-Solo, indoors. Validate every student-facing feature works before going to the field.
+Solo, indoors. Validate every operator-facing feature works before going to the field.
 
 ### 1.1 Boot and Auto-Start
 - [ ] Power on Jetson cold — Hydra starts automatically via systemd/Docker
@@ -111,7 +111,7 @@ Solo, indoors. Validate every student-facing feature works before going to the f
 ## Phase 3 — Multi-Vehicle Stress Test (April 4-6)
 
 **Platforms:** 2-3 Jetsons simultaneously (USV + UGV, or USV + UGV + drone)
-**Personnel:** All 3 instructors.
+**Personnel:** All 3 maintainers.
 
 ### 3.1 Multi-Instance Identity
 - [ ] Each Jetson has unique callsign (HYDRA-1-USV, HYDRA-2-UGV, etc.)
@@ -125,10 +125,10 @@ Solo, indoors. Validate every student-facing feature works before going to the f
 - [ ] Group command `HYDRA-ALL UNLOCK` (if implemented) — all vehicles respond
 - [ ] Duplicate callsign warning if two Jetsons have same callsign
 
-### 3.3 Instructor Overview (if implemented)
-- [ ] /instructor page shows all active Jetsons
+### 3.3 Fleet View (if implemented)
+- [ ] /fleet page shows all active Jetsons
 - [ ] Status cards update in real-time
-- [ ] Abort button on instructor page stops specific vehicle
+- [ ] Abort button on Fleet View stops specific vehicle
 - [ ] Works from phone over mesh/Tailscale
 
 ### 3.4 Network
@@ -139,7 +139,7 @@ Solo, indoors. Validate every student-facing feature works before going to the f
 
 ### 3.5 Platform-Specific
 - [ ] UGV (Stampede): Follow mode with person target (if implemented)
-  - Student walks, truck follows
+  - Operator walks, truck follows
   - Verify speed control (slow when close, faster when far)
   - Verify abort stops vehicle
 - [ ] USV (Enforcer): Follow mode with kayak target (if implemented)
@@ -147,7 +147,7 @@ Solo, indoors. Validate every student-facing feature works before going to the f
 - [ ] Drone (if available): Detection during hover and orbit
   - Verify TAK markers have correct GPS
 
-## Pre-Student Checklist (April 6)
+## Pre-Deployment Checklist (April 6)
 
 Before Week 4 begins, confirm:
 - [ ] All Jetsons auto-boot into operational dashboard
@@ -161,19 +161,19 @@ Before Week 4 begins, confirm:
 - [ ] ATAK shows TAK markers from all vehicles
 - [ ] At least one backup Jetson imaged and ready
 - [ ] WiFi AP tested at expected operating range
-- [ ] Tailscale VPN active on all Jetsons and instructor devices
+- [ ] Tailscale VPN active on all Jetsons and operator devices
 
 ## Known Risks
 - First field use of v2.0 — expect unexpected failures
 - WiFi range may limit dashboard usefulness at distance
 - USB camera reliability under vibration is untested
 - Battery runtime under Hydra load is unknown — measure during Phase 2
-- Student error modes unknown until Week 4 — document everything they break
+- Operator error modes unknown until Week 4 — document everything that breaks
 
 ## Post-Test Debrief Template
 For each phase, record:
 1. What worked as expected
 2. What failed and how it was fixed
-3. What students will definitely break
-4. What needs to change before student use
+3. What operators will likely break
+4. What needs to change before next deployment
 5. New issues to file

--- a/hydra_detect/approach.py
+++ b/hydra_detect/approach.py
@@ -283,7 +283,7 @@ class ApproachController:
                 )
 
         # Restore pre-approach mode if captured; fall back to configured abort mode.
-        # This ensures a student aborting from AUTO mid-mission returns to AUTO,
+        # This ensures an operator aborting from AUTO mid-sortie returns to AUTO,
         # not the generic LOITER fallback.
         restore_mode = pre_approach_mode or self._cfg.abort_mode
         try:

--- a/hydra_detect/audit/audit_log.py
+++ b/hydra_detect/audit/audit_log.py
@@ -451,7 +451,7 @@ def get_default_file_sink(
 
     Returns ``None`` when the section exists and ``enabled=false``.
     A missing section yields a sink with the schema defaults, matching
-    the ``enabled=true`` default — students ship with durable audit on.
+    the ``enabled=true`` default — platforms ship with durable audit on.
     """
     if config is None or not config.has_section("audit"):
         return FileJSONLSink()

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -72,15 +72,15 @@ app = FastAPI(title="Hydra Detect v2.0", version="2.0.0")
 # ── Capability status API (issue #146) ───────────────────────────────────────
 app.include_router(_capability_router)
 
-# CORS: restrict cross-origin to instructor-relevant paths only.
-# The instructor page polls /api/stats and /api/abort on peer Hydra
+# CORS: restrict cross-origin to fleet-view-relevant paths only.
+# The Fleet View page polls /api/stats and /api/abort on peer Hydra
 # instances, so those endpoints need permissive CORS.  All other
 # endpoints stay same-origin.
 _CORS_ALLOWED_PATHS = {"/api/stats", "/api/abort"}
 
 
-class _InstructorCORSMiddleware:
-    """Pure ASGI middleware — add CORS headers for instructor endpoints."""
+class _FleetCORSMiddleware:
+    """Pure ASGI middleware — add CORS headers for fleet-view endpoints."""
 
     def __init__(self, app):
         self.app = app
@@ -103,7 +103,7 @@ class _InstructorCORSMiddleware:
         await self.app(scope, receive, send_wrapper)
 
 
-app.add_middleware(_InstructorCORSMiddleware)
+app.add_middleware(_FleetCORSMiddleware)
 
 # Standard CSP for the SPA and standalone pages
 _CSP_DEFAULT = (
@@ -115,8 +115,8 @@ _CSP_DEFAULT = (
     "connect-src 'self'"
 )
 
-# Relaxed CSP for the instructor page — it fetches from other Jetsons
-_CSP_INSTRUCTOR = (
+# Relaxed CSP for the Fleet View page — it fetches from other Jetsons
+_CSP_FLEET = (
     "default-src 'self'; "
     "img-src 'self' data:; "
     "script-src 'self'; "
@@ -143,7 +143,7 @@ class _SecurityHeadersMiddleware:
                 headers = MutableHeaders(scope=message)
                 headers["X-Frame-Options"] = "DENY"
                 headers["X-Content-Type-Options"] = "nosniff"
-                csp = _CSP_INSTRUCTOR if path == "/instructor" else _CSP_DEFAULT
+                csp = _CSP_FLEET if path in ("/fleet", "/instructor") else _CSP_DEFAULT
                 headers["Content-Security-Policy"] = csp
             await send(message)
 
@@ -339,7 +339,7 @@ def _parse_cookies(cookie_header: str) -> dict[str, str]:
 _PUBLIC_PATH_PREFIXES = (
     "/login", "/auth/", "/static/",
     "/api/health", "/api/preflight", "/api/abort",
-    "/api/stats",      # instructor page polls peers cross-origin
+    "/api/stats",      # fleet view polls peers cross-origin
     "/api/tracks",     # read-only dashboard data
     "/api/mode",       # operating mode — dashboard polls; POST still auth-checked
     "/api/metrics",    # Prometheus scrape
@@ -933,8 +933,8 @@ async def api_preflight():
     """Run pre-flight checks and return structured results.
 
     Returns a JSON object with a list of checks (camera, mavlink, config,
-    models, disk) and an overall status (pass/warn/fail).  Designed for
-    student-facing error reporting before a mission.
+    models, disk) and an overall status (pass/warn/fail).  Used for
+    operator-facing status display before a sortie.
     """
     cb = stream_state.get_callback("get_preflight")
     if cb:
@@ -2434,32 +2434,39 @@ async def control_page(request: Request):
     return templates.TemplateResponse(request, "control.html")
 
 
-# ── Instructor Overview ────────────────────────────────────────────
+# ── Fleet View ─────────────────────────────────────────────────────
+
+@app.get("/fleet", response_class=HTMLResponse)
+async def fleet_page(request: Request):
+    """Serve the Fleet View page — multi-vehicle status and abort."""
+    return templates.TemplateResponse(request, "instructor.html")
+
 
 @app.get("/instructor", response_class=HTMLResponse)
-async def instructor_page(request: Request):
-    """Serve the standalone instructor overview page."""
-    return templates.TemplateResponse(request, "instructor.html")
+async def instructor_redirect(request: Request):
+    """Redirect legacy /instructor route to /fleet (307 preserves method)."""
+    from starlette.responses import RedirectResponse
+    return RedirectResponse(url="/fleet", status_code=307)
 
 
 @app.post("/api/abort")
 async def api_abort(request: Request):
     """Emergency abort — switch vehicle to RTL mode.
 
-    This endpoint is intentionally unauthenticated. The instructor page
-    is the safety exception: an instructor must be able to abort any
-    vehicle without configuring tokens.
+    Intentionally unauthenticated. Any device on the network can abort
+    any vehicle. This is the safety override: range control must be able
+    to abort without configuring tokens first.
     """
     _audit(request, "abort")
     # Try RTL first, then LOITER/HOLD as fallback.
-    # This is safety-critical — wrap in try/except so a callback crash
-    # never prevents the instructor from seeing an error response.
+    # Safety-critical — wrap in try/except so a callback crash
+    # never blocks an abort response.
     cb = stream_state.get_callback("on_set_mode_command")
     if cb:
         for mode in ("RTL", "LOITER", "HOLD"):
             try:
                 if cb(mode):
-                    logger.warning("ABORT: vehicle set to %s by instructor", mode)
+                    logger.warning("ABORT: vehicle set to %s by range control", mode)
                     return {"status": "ok", "mode": mode}
             except Exception as exc:
                 logger.error("ABORT callback failed for %s: %s", mode, exc)

--- a/hydra_detect/web/static/js/instructor.js
+++ b/hydra_detect/web/static/js/instructor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 (function() {
-    let endpoints = JSON.parse(localStorage.getItem('hydra-instructor-endpoints') || '[]');
+    let endpoints = JSON.parse(localStorage.getItem('hydra-fleet-endpoints') || localStorage.getItem('hydra-instructor-endpoints') || '[]');
     let vehicleState = {};
     let alertFeed = [];
     const MAX_ALERTS = 50;
@@ -28,7 +28,7 @@
     function saveEndpoints() {
         const raw = document.getElementById('endpoints-input').value;
         endpoints = raw.split(',').map(s => s.trim()).filter(Boolean);
-        localStorage.setItem('hydra-instructor-endpoints', JSON.stringify(endpoints));
+        localStorage.setItem('hydra-fleet-endpoints', JSON.stringify(endpoints));
         pollAll();
     }
 
@@ -178,7 +178,7 @@
         try {
             const resp = await fetch('http://' + host + ':8080/api/abort', {method: 'POST'});
             if (resp.ok) {
-                addAlert(vehicleState[host] ? (vehicleState[host].callsign || host) : host, 'ABORT sent by instructor');
+                addAlert(vehicleState[host] ? (vehicleState[host].callsign || host) : host, 'ABORT sent by range control');
             } else {
                 addAlert(host, 'ABORT failed — HTTP ' + resp.status);
             }

--- a/hydra_detect/web/static/js/tak-map.js
+++ b/hydra_detect/web/static/js/tak-map.js
@@ -93,7 +93,7 @@ const HydraTakMap = (() => {
         });
 
         // OSM tiles. For offline/field deployment we bundle a local tile
-        // server later; the CDN works in the classroom and is harmless
+        // server later; the CDN works on the bench and is harmless
         // everywhere else (falls back to grey tiles on no-network).
         L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
             maxZoom: 19,

--- a/hydra_detect/web/templates/config.html
+++ b/hydra_detect/web/templates/config.html
@@ -1,6 +1,6 @@
 <!-- Config View — mission tuning + engagement controls.
      Vehicle telemetry, pipeline stats, tracks list, and detection log all
-     live on Ops; this view focuses on what the instructor tunes between
+     live on Ops; this view covers what the operator tunes between
      sorties. The autonomy dashboard is included at the bottom. -->
 
 <!-- Loading State (hidden — snapshot polling handles its own state) -->

--- a/hydra_detect/web/templates/instructor.html
+++ b/hydra_detect/web/templates/instructor.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>SORCC Instructor Overview</title>
+    <title>Hydra Fleet View</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>
         /* Mobile-first, dark theme matching Hydra aesthetic */
@@ -97,7 +97,7 @@
     </style>
 </head>
 <body>
-    <h1>SORCC INSTRUCTOR OVERVIEW</h1>
+    <h1>HYDRA FLEET VIEW</h1>
 
     <div class="config-bar">
         <input id="endpoints-input" placeholder="Jetson IPs (comma-separated, e.g., 192.168.x.x, 192.168.x.y)" />

--- a/hydra_detect/web/templates/settings.html
+++ b/hydra_detect/web/templates/settings.html
@@ -100,7 +100,7 @@
         <div class="settings-recovery-label mock-section-label">Quick Links</div>
         <div class="settings-recovery-actions">
             <a class="btn btn-recovery" href="/control">Mobile Control</a>
-            <a class="btn btn-recovery" href="/instructor">Instructor Overview</a>
+            <a class="btn btn-recovery" href="/fleet">Fleet View</a>
             <a class="btn btn-recovery" href="/review">Sortie Review</a>
             <a class="btn btn-recovery" href="/setup">Setup Wizard</a>
         </div>

--- a/scripts/rf_hunt_demo.py
+++ b/scripts/rf_hunt_demo.py
@@ -6,7 +6,7 @@ Simulates vehicle movement based on waypoint commands so you can see the full
 IDLE → SEARCHING → HOMING → CONVERGED state machine in action.
 
 Usage:
-    # Hunt 915 MHz CRSF (students flying nearby)
+    # Hunt 915 MHz CRSF (other platforms nearby)
     python scripts/rf_hunt_demo.py --freq 915
 
     # Hunt 433 MHz SiK radio

--- a/scripts/setup_headless.sh
+++ b/scripts/setup_headless.sh
@@ -33,7 +33,7 @@ Options:
 
 Examples:
   # Full setup with WiFi
-  sudo bash scripts/setup_headless.sh --ssid "ClassroomWiFi" --password "s3cret"
+  sudo bash scripts/setup_headless.sh --ssid "FieldNetworkSSID" --password "s3cret"
 
   # Ethernet-only setup
   sudo bash scripts/setup_headless.sh --ethernet-only

--- a/tests/test_instructor_ops.py
+++ b/tests/test_instructor_ops.py
@@ -1,4 +1,4 @@
-"""Tests for instructor overview page, mission tagging, battery state, and abort."""
+"""Tests for Fleet View page, mission tagging, battery state, and abort."""
 
 from __future__ import annotations
 
@@ -55,22 +55,33 @@ def client():
 
 
 # ---------------------------------------------------------------------------
-# Instructor page
+# Fleet View page
 # ---------------------------------------------------------------------------
 
 
 class TestInstructorPage:
-    def test_instructor_page_returns_200(self, client):
-        resp = client.get("/instructor")
+    def test_fleet_page_returns_200(self, client):
+        resp = client.get("/fleet")
         assert resp.status_code == 200
-        assert "SORCC INSTRUCTOR OVERVIEW" in resp.text
+        assert "HYDRA FLEET VIEW" in resp.text
 
-    def test_instructor_page_csp_relaxed(self, client):
-        resp = client.get("/instructor")
+    def test_instructor_redirects_to_fleet(self, client):
+        resp = client.get("/instructor", follow_redirects=False)
+        assert resp.status_code == 307
+        assert resp.headers["location"] == "/fleet"
+
+    def test_fleet_page_csp_relaxed(self, client):
+        resp = client.get("/fleet")
         csp = resp.headers.get("Content-Security-Policy", "")
         assert "connect-src *" in csp
 
-    def test_non_instructor_page_csp_strict(self, client):
+    def test_instructor_redirect_csp_relaxed(self, client):
+        # The 307 itself should also get the relaxed CSP since it matches /instructor
+        resp = client.get("/instructor", follow_redirects=False)
+        csp = resp.headers.get("Content-Security-Policy", "")
+        assert "connect-src *" in csp
+
+    def test_non_fleet_page_csp_strict(self, client):
         resp = client.get("/api/stats")
         csp = resp.headers.get("Content-Security-Policy", "")
         assert "connect-src 'self'" in csp
@@ -212,7 +223,7 @@ class TestBatteryInStats:
         assert data["battery_pct"] is None
 
     def test_callsign_in_stats(self, client):
-        """Callsign appears in stats API for instructor page to read."""
+        """Callsign appears in stats API for Fleet View to read."""
         stream_state.update_stats(callsign="ENFORCER-1")
         resp = client.get("/api/stats")
         assert resp.json()["callsign"] == "ENFORCER-1"


### PR DESCRIPTION
Closes #151

## What changed

This pivot replaces course-management vocabulary with operator-owned, state-gated vocabulary throughout the codebase. No code variable names, class names, or function names were changed. CLAUDE.md files were not touched.

## Inventory

**UI / server (1 route added, 1 converted to redirect):**
- `GET /fleet` — new route serving `instructor.html` as the Fleet View
- `GET /instructor` — converted to 307 redirect → `/fleet` (backward compat for bookmarks)
- CSP middleware now applies relaxed `connect-src *` to both `/fleet` and `/instructor` paths
- `instructor.html`: title and h1 → "Hydra Fleet View" / "HYDRA FLEET VIEW"
- `settings.html`: Quick Links button updated to `/fleet`
- `instructor.js`: localStorage key `hydra-instructor-endpoints` → `hydra-fleet-endpoints` (reads old key as fallback)
- `instructor.js`: abort alert text "by instructor" → "by range control"

**Python source (comments only):**
- `approach.py`: "student aborting" → "operator aborting"
- `audit_log.py`: "students ship with" → "platforms ship with"
- `web/server.py`: internal class/constant renames (`_InstructorCORSMiddleware` → `_FleetCORSMiddleware`, `_CSP_INSTRUCTOR` → `_CSP_FLEET`), comments, abort log message

**Scripts:**
- `setup_headless.sh`: example SSID `ClassroomWiFi` → `FieldNetworkSSID`
- `rf_hunt_demo.py`: comment "students flying nearby" → "other platforms nearby"

**Docs (27 files):**
- instructor → fleet lead / range control / supervisor / maintainer
- student → operator
- classroom → bench / lab / range / field
- instructor dashboard → Fleet View
- instructor abort → range-control abort / safety override
- INSTRUCTOR-1 CoT example callsign → FLEETLEAD-1
- Route tables updated: `/fleet` added, `/instructor` shows 307 redirect
- Spec docs (historical record) updated in place with new vocabulary

## Rename decisions

| Old | New | Notes |
|-----|-----|-------|
| `/instructor` route | `/fleet` route | Old route kept as 307 redirect |
| Instructor Overview | Fleet View | Title, nav label, docs |
| instructor abort | range-control abort / safety override | Safety-critical, clearer ownership |
| student setup | Platform Setup | Headless boot doc |
| classroom | bench / lab / range / field | Context-dependent |
| INSTRUCTOR-1 | FLEETLEAD-1 | TAK callsign example |

## Voice pass

All prose edits applied ranger-voice (declarative, active, no significance inflation) and humanizer (no em dashes, no -ing endings, no AI filler). Spec docs with historical decisions updated vocabulary without changing the record of what was decided.

## Test plan

- [ ] `GET /fleet` returns 200, body contains "HYDRA FLEET VIEW"
- [ ] `GET /instructor` returns 307 with `Location: /fleet`
- [ ] Both `/fleet` and `/instructor` return relaxed CSP (`connect-src *`)
- [ ] `/api/stats` returns strict CSP (`connect-src 'self'`)
- [ ] Abort endpoint still unauthenticated and returns 200 with mode
- [ ] Mission start/end endpoints still work with and without auth
- [ ] Battery fields appear in `/api/stats`
- [ ] 201 non-server tests pass (confirmed locally)
- [ ] CI (Linux) runs `test_instructor_ops.py` without fcntl import errors