### PR TITLE
feat(#153): phone-home telemetry (unit side, DRAFT)

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -222,6 +222,15 @@ command_hmac_secret =
 ;                  graceful degradation when the Jetson loses WiFi.
 mode = direct
 
+[telemetry]
+; Phone-home health telemetry — DEFAULT OFF.
+; Unit sends nothing unless enabled = true AND collector_url is set.
+; No GPS, video, crops, or operator identifying info is ever included.
+enabled = false
+collector_url =
+api_token =
+opt_out = false
+
 [vehicle.drone]
 reserved_channels = 1,2,3,4
 autonomous.post_drop_mode = DOGLEG_RTL

--- a/config.ini.factory
+++ b/config.ini.factory
@@ -218,6 +218,15 @@ min_altitude_m = 5.0
 ; alerts.priority_labels = person,vehicle
 ; tak.callsign = HYDRA-UGV
 
+[telemetry]
+; Phone-home health telemetry — DEFAULT OFF.
+; Unit sends nothing unless enabled = true AND collector_url is set.
+; No GPS, video, crops, or operator identifying info is ever included.
+enabled = false
+collector_url =
+api_token =
+opt_out = false
+
 [vehicle.fw]
 autonomous.post_action_mode = LOITER
 autonomous.min_track_frames = 2

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1202,6 +1202,28 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             description="Minimum consecutive track frames before autonomous action (fixed-wing)",
         ),
     },
+    "telemetry": {
+        "enabled": FieldSpec(
+            FieldType.BOOL,
+            default=False,
+            description="Enable phone-home health telemetry (default OFF)",
+        ),
+        "collector_url": FieldSpec(
+            FieldType.STRING,
+            default="",
+            description="Collector endpoint URL (required when enabled = true)",
+        ),
+        "api_token": FieldSpec(
+            FieldType.STRING,
+            default="",
+            description="Bearer token for collector authentication",
+        ),
+        "opt_out": FieldSpec(
+            FieldType.BOOL,
+            default=False,
+            description="Operator opt-out flag — overrides enabled",
+        ),
+    },
     "audit": {
         "enabled": FieldSpec(
             FieldType.BOOL,

--- a/hydra_detect/telemetry/__init__.py
+++ b/hydra_detect/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Hydra phone-home telemetry — unit side only.
+
+Default OFF. Enable in config.ini under [telemetry] enabled = true.
+No video, crops, GPS coordinates, or operator identifying info leaves the unit.
+"""

--- a/hydra_detect/telemetry/phone_home.py
+++ b/hydra_detect/telemetry/phone_home.py
@@ -1,0 +1,341 @@
+"""Phone-home health telemetry — unit side only.
+
+Sends a small operational health payload to a configured collector URL once
+per run (or on a schedule when driven by the systemd timer). Default OFF.
+
+What IS in the payload:
+  callsign, hostname, version, channel, uptime_hours, mode,
+  capability_summary (READY/WARN/BLOCKED counts), last_mission_at,
+  disk_free_pct, cpu_temp_c, power_mode, last_update_status
+
+What is NOT in the payload — by design and enforced by test_phone_home_privacy.py:
+  GPS coordinates, video frames, image crops, operator names, IP addresses,
+  MAVLink system IDs, detection class details, or any personally identifying info.
+
+Collector side is not defined yet — Kyle has not decided where it lives.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import socket
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+import urllib.request
+import urllib.error
+
+logger = logging.getLogger(__name__)
+
+# Bounded queue cap — keep only the most recent N payloads on disk.
+_QUEUE_MAX = 30
+
+
+@dataclass
+class SendResult:
+    """Result of a single HTTP send attempt. Never raises."""
+    ok: bool
+    status_code: int | None
+    error: str | None
+
+
+# ---------------------------------------------------------------------------
+# Payload assembly
+# ---------------------------------------------------------------------------
+
+def _read_version(root: Path) -> str | None:
+    """Read __version__ from the installed package or source tree."""
+    try:
+        from hydra_detect import __version__  # type: ignore[import]
+        return __version__
+    except Exception:
+        pass
+    # Fallback: parse __init__.py directly
+    try:
+        init = root / "hydra_detect" / "__init__.py"
+        for line in init.read_text().splitlines():
+            if line.startswith("__version__"):
+                return line.split("=", 1)[1].strip().strip("\"'")
+    except Exception:
+        pass
+    return None
+
+
+def _disk_free_pct(root: Path) -> float | None:
+    """Return disk free percentage for the filesystem containing root."""
+    try:
+        usage = shutil.disk_usage(root)
+        if usage.total == 0:
+            return None
+        return round(usage.free / usage.total * 100.0, 1)
+    except Exception:
+        return None
+
+
+def _cpu_temp_c() -> float | None:
+    """Read CPU thermal zone temperature from sysfs."""
+    try:
+        from hydra_detect.system import read_thermal
+        return read_thermal("0")
+    except Exception:
+        pass
+    # Direct sysfs fallback — avoids importing system on hosts without it.
+    try:
+        raw = Path("/sys/devices/virtual/thermal/thermal_zone0/temp").read_text().strip()
+        return round(int(raw) / 1000.0, 1)
+    except Exception:
+        return None
+
+
+def _power_mode() -> str | None:
+    """Read Jetson power mode synchronously."""
+    try:
+        from hydra_detect.system import query_nvpmodel_sync
+        return query_nvpmodel_sync()
+    except Exception:
+        return None
+
+
+def _last_mission_at(root: Path) -> str | None:
+    """Return ISO timestamp of the most recent detection log file modification.
+
+    Scans output_data/logs/ for JSONL files.  Returns None if no logs exist.
+    Deliberately does NOT read log contents — just the file mtime.
+    """
+    log_dir = root / "output_data" / "logs"
+    try:
+        candidates = list(log_dir.glob("*.jsonl")) + list(log_dir.glob("*.csv"))
+        if not candidates:
+            return None
+        latest = max(candidates, key=lambda p: p.stat().st_mtime)
+        ts = datetime.fromtimestamp(latest.stat().st_mtime, tz=timezone.utc)
+        return ts.isoformat()
+    except Exception:
+        return None
+
+
+def _last_update_status(root: Path) -> str | None:
+    """Read the last git pull / deploy status from output_data/update_status.txt.
+
+    The deploy script writes one line to this file after each pull.
+    Returns None if the file doesn't exist.
+    """
+    try:
+        status_file = root / "output_data" / "update_status.txt"
+        if not status_file.exists():
+            return None
+        text = status_file.read_text().strip()
+        # Return only the first 120 chars to keep payloads small.
+        return text[:120] if text else None
+    except Exception:
+        return None
+
+
+def _capability_summary(root: Path) -> dict:
+    """Count READY/WARN/BLOCKED from the #171 capability evaluator if available.
+
+    Returns an empty dict when the evaluator is not present — structured
+    absence beats a missing key.
+    """
+    try:
+        # Import lazily — capability evaluator is from PR #171 which may not
+        # be merged yet. Graceful degradation when absent.
+        from hydra_detect.observability import capabilities  # type: ignore[import]
+        report = capabilities.evaluate()
+        counts: dict[str, int] = {}
+        for cap in report.values():
+            status = str(cap.get("status", "")).upper()
+            counts[status] = counts.get(status, 0) + 1
+        return counts
+    except Exception:
+        return {}
+
+
+def _uptime_hours(root: Path) -> float | None:
+    """Return system uptime in hours from /proc/uptime."""
+    try:
+        text = Path("/proc/uptime").read_text().strip()
+        seconds = float(text.split()[0])
+        return round(seconds / 3600.0, 2)
+    except Exception:
+        return None
+
+
+def _channel(cfg: Any) -> str | None:
+    """Read the configured deployment channel (stable/dev/etc.) if present."""
+    try:
+        return cfg.get("telemetry", "channel", fallback=None) or None
+    except Exception:
+        return None
+
+
+def build_payload(cfg: Any, root: Path) -> dict:
+    """Assemble the health telemetry payload.
+
+    Args:
+        cfg: ConfigParser instance with the loaded config.
+        root: Repo / working directory root (used to locate output_data/).
+
+    Returns:
+        A dict safe to serialise as JSON.  All keys always present — missing
+        signals are represented as None rather than omitting the key.
+
+    Privacy guarantee: GPS, video, crops, MAVLink system IDs, and operator
+    identifying info are never included.  See test_phone_home_privacy.py.
+    """
+    callsign: str | None = None
+    mode: str | None = None
+    try:
+        callsign = cfg.get("tak", "callsign", fallback=None) or None
+        mode = cfg.get("telemetry", "mode", fallback=None) or None
+    except Exception:
+        pass
+
+    return {
+        "callsign": callsign,
+        "hostname": socket.gethostname(),
+        "version": _read_version(root),
+        "channel": _channel(cfg),
+        "uptime_hours": _uptime_hours(root),
+        "mode": mode,
+        "capability_summary": _capability_summary(root),
+        "last_mission_at": _last_mission_at(root),
+        "disk_free_pct": _disk_free_pct(root),
+        "cpu_temp_c": _cpu_temp_c(),
+        "power_mode": _power_mode(),
+        "last_update_status": _last_update_status(root),
+    }
+
+
+# ---------------------------------------------------------------------------
+# HTTP send
+# ---------------------------------------------------------------------------
+
+def send_payload(
+    url: str,
+    payload: dict,
+    api_token: str,
+    timeout: float = 10,
+) -> SendResult:
+    """POST payload as JSON to url with Bearer auth.
+
+    Never raises.  Network errors, timeouts, and HTTP failures all return a
+    structured SendResult with ok=False and a descriptive error string.
+    """
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {api_token}",
+            "User-Agent": f"hydra-phone-home/{payload.get('version', 'unknown')}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return SendResult(ok=True, status_code=resp.status, error=None)
+    except urllib.error.HTTPError as exc:
+        return SendResult(ok=False, status_code=exc.code, error=str(exc.reason))
+    except urllib.error.URLError as exc:
+        return SendResult(ok=False, status_code=None, error=str(exc.reason))
+    except TimeoutError:
+        return SendResult(ok=False, status_code=None, error="connection timed out")
+    except Exception as exc:  # pragma: no cover — defensive
+        return SendResult(ok=False, status_code=None, error=f"{type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Local queue (send-on-failure / offline buffer)
+# ---------------------------------------------------------------------------
+
+def _queue_dir(root: Path) -> Path:
+    return root / "output_data" / "telemetry" / "queue"
+
+
+def queue_payload(root: Path, payload: dict) -> None:
+    """Write payload to the local queue directory.
+
+    Bounded to _QUEUE_MAX files — oldest are evicted when the cap is exceeded.
+    Filenames are ISO timestamps so sort order == chronological order.
+    """
+    q = _queue_dir(root)
+    try:
+        q.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%S%f")
+        dest = q / f"{ts}.json"
+        dest.write_text(json.dumps(payload, indent=2))
+        logger.info("phone-home: payload queued at %s", dest)
+        _evict_queue(q)
+    except Exception as exc:
+        logger.warning("phone-home: failed to write queue entry: %s", exc)
+
+
+def _evict_queue(q: Path) -> None:
+    """Keep only the _QUEUE_MAX most recent files in q; delete the rest."""
+    try:
+        files = sorted(q.glob("*.json"))
+        excess = len(files) - _QUEUE_MAX
+        if excess > 0:
+            for old in files[:excess]:
+                old.unlink(missing_ok=True)
+                logger.debug("phone-home: evicted old queue entry %s", old.name)
+    except Exception as exc:
+        logger.warning("phone-home: queue eviction error: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Queue flush
+# ---------------------------------------------------------------------------
+
+def flush_queue(
+    root: Path,
+    url: str,
+    api_token: str,
+    max_batch: int = 10,
+) -> None:
+    """Send queued payloads in chronological order.
+
+    Stops on the first send failure — the queue is preserved and will be
+    retried on the next scheduled run.  Successfully sent files are removed.
+
+    Args:
+        root: Repo root (same as build_payload).
+        url: Collector URL.
+        api_token: Bearer token.
+        max_batch: Maximum number of queued payloads to send per run.
+    """
+    q = _queue_dir(root)
+    if not q.exists():
+        return
+
+    pending = sorted(q.glob("*.json"))[:max_batch]
+    if not pending:
+        return
+
+    logger.info("phone-home: flushing %d queued payload(s)", len(pending))
+
+    for entry in pending:
+        try:
+            payload = json.loads(entry.read_text())
+        except Exception as exc:
+            logger.warning("phone-home: skipping corrupt queue entry %s: %s", entry.name, exc)
+            entry.unlink(missing_ok=True)
+            continue
+
+        result = send_payload(url, payload, api_token)
+        if result.ok:
+            entry.unlink(missing_ok=True)
+            logger.info("phone-home: flushed %s (HTTP %s)", entry.name, result.status_code)
+        else:
+            logger.warning(
+                "phone-home: flush send failed for %s: %s — stopping batch",
+                entry.name,
+                result.error,
+            )
+            break  # Stop on first failure; retry next run.

--- a/scripts/README-phone-home.md
+++ b/scripts/README-phone-home.md
@@ -1,0 +1,88 @@
+# Hydra Phone-Home Telemetry — Operator Enable Guide
+
+## What it does
+
+Sends a small health snapshot to a central collector once per day so Kyle can
+tell whether a unit at an operator's home is alive, what version it's running,
+and whether anything is wrong — without any access to video, detections, or
+operator location.
+
+**Default: OFF.** Nothing is sent unless you explicitly enable it.
+
+## What is in the payload
+
+| Field | Description |
+|---|---|
+| `callsign` | TAK callsign from config.ini (e.g. HYDRA-1) |
+| `hostname` | OS hostname of the Jetson |
+| `version` | Hydra software version string |
+| `channel` | Optional deployment channel label |
+| `uptime_hours` | System uptime in hours |
+| `mode` | Optional mode label |
+| `capability_summary` | Count of READY/WARN/BLOCKED subsystems |
+| `last_mission_at` | Timestamp of the most recent detection log file |
+| `disk_free_pct` | Free disk percentage |
+| `cpu_temp_c` | CPU temperature °C |
+| `power_mode` | Jetson nvpmodel power mode |
+| `last_update_status` | Last deploy result from output_data/update_status.txt |
+
+## What is NOT in the payload
+
+- GPS coordinates
+- Video frames or thumbnails
+- Detection images or crops
+- Operator names or identifying info
+- MAVLink system IDs
+- IP addresses
+
+## Enable
+
+1. Edit `/home/sorcc/Hydra/config.ini` and set:
+
+```ini
+[telemetry]
+enabled = true
+collector_url = https://collector.example.com/api/ingest
+api_token = <token Kyle provides>
+opt_out = false
+```
+
+2. Copy the systemd units:
+
+```bash
+sudo cp /home/sorcc/Hydra/scripts/hydra-phone-home.service /etc/systemd/system/
+sudo cp /home/sorcc/Hydra/scripts/hydra-phone-home.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now hydra-phone-home.timer
+```
+
+3. Verify:
+
+```bash
+sudo systemctl status hydra-phone-home.timer
+sudo systemctl start hydra-phone-home.service
+journalctl -u hydra-phone-home.service -n 50
+```
+
+## Disable
+
+```bash
+sudo systemctl disable --now hydra-phone-home.timer
+```
+
+Or set `enabled = false` in config.ini.
+
+## Dry run (no network required)
+
+```bash
+python3 /home/sorcc/Hydra/scripts/phone_home.py --dry-run
+```
+
+Prints the JSON payload that would be sent. Safe to run any time.
+
+## Offline queue
+
+If a send fails (no network, collector down), the payload is saved to
+`output_data/telemetry/queue/`. The next successful send flushes up to 10
+queued payloads in order. Queue is capped at 30 entries — oldest are evicted
+automatically.

--- a/scripts/hydra-phone-home.service
+++ b/scripts/hydra-phone-home.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hydra phone-home health telemetry
+Documentation=file:///home/sorcc/Hydra/scripts/README-phone-home.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/sorcc/Hydra
+ExecStart=/usr/bin/python3 /home/sorcc/Hydra/scripts/phone_home.py --config /home/sorcc/Hydra/config.ini
+StandardOutput=journal
+StandardError=journal
+# Non-zero exit is non-fatal — phone-home failure must not block other services.
+SuccessExitStatus=0 1 2

--- a/scripts/hydra-phone-home.timer
+++ b/scripts/hydra-phone-home.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Hydra phone-home telemetry — daily timer
+Documentation=file:///home/sorcc/Hydra/scripts/README-phone-home.md
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=24h
+RandomizedDelaySec=3600
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/phone_home.py
+++ b/scripts/phone_home.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""phone_home.py — send a health telemetry payload to the configured collector.
+
+Usage:
+    python scripts/phone_home.py [--config PATH] [--dry-run]
+
+Options:
+    --config PATH   Path to config.ini (default: config.ini in current dir)
+    --dry-run       Print the payload as JSON without sending
+
+Exit codes:
+    0   Payload sent successfully
+    1   Send failed — payload queued locally for the next run
+    2   Configuration error (telemetry disabled, missing url, bad config)
+"""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import json
+import logging
+import sys
+from pathlib import Path
+
+# Ensure the repo root is on sys.path when run directly.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from hydra_detect.telemetry.phone_home import (
+    build_payload,
+    flush_queue,
+    queue_payload,
+    send_payload,
+)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s phone_home: %(message)s",
+)
+logger = logging.getLogger("phone_home")
+
+
+def _load_config(path: str) -> configparser.ConfigParser:
+    cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    read = cfg.read(path)
+    if not read:
+        raise FileNotFoundError(f"Config not found: {path}")
+    return cfg
+
+
+def _check_enabled(cfg: configparser.ConfigParser) -> tuple[str, str]:
+    """Validate the [telemetry] section and return (url, api_token).
+
+    Raises SystemExit(2) on any config problem.
+    """
+    try:
+        enabled = cfg.getboolean("telemetry", "enabled", fallback=False)
+    except ValueError as exc:
+        logger.error("[telemetry] enabled must be true or false: %s", exc)
+        sys.exit(2)
+
+    if not enabled:
+        logger.info("[telemetry] enabled = false — nothing to send (set enabled = true to activate)")
+        sys.exit(2)
+
+    opt_out = cfg.getboolean("telemetry", "opt_out", fallback=False)
+    if opt_out:
+        logger.info("[telemetry] opt_out = true — skipping send")
+        sys.exit(2)
+
+    url = cfg.get("telemetry", "collector_url", fallback="").strip()
+    if not url:
+        logger.error(
+            "[telemetry] collector_url is empty — set it to the collector endpoint"
+        )
+        sys.exit(2)
+
+    api_token = cfg.get("telemetry", "api_token", fallback="").strip()
+    return url, api_token
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Send Hydra unit health telemetry to the configured collector.",
+        epilog="Collector side is not defined yet — see issue #153.",
+    )
+    parser.add_argument(
+        "--config",
+        default="config.ini",
+        metavar="PATH",
+        help="Path to config.ini (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print payload as JSON without sending",
+    )
+    args = parser.parse_args(argv)
+
+    # Locate repo root relative to the config file location so output_data/
+    # paths resolve correctly regardless of cwd.
+    config_path = Path(args.config).resolve()
+    root = config_path.parent
+
+    try:
+        cfg = _load_config(str(config_path))
+    except FileNotFoundError as exc:
+        logger.error("%s", exc)
+        return 2
+
+    if args.dry_run:
+        # Dry-run: build and print, no config-enabled check.
+        payload = build_payload(cfg, root)
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    # Live send path — enforce config guards.
+    try:
+        url, api_token = _check_enabled(cfg)
+    except SystemExit as exc:
+        return int(exc.code)
+
+    # Flush any queued payloads before sending the current one.
+    flush_queue(root, url, api_token)
+
+    payload = build_payload(cfg, root)
+    result = send_payload(url, payload, api_token)
+
+    if result.ok:
+        logger.info("sent OK (HTTP %s)", result.status_code)
+        return 0
+    else:
+        logger.warning(
+            "send failed (HTTP %s): %s — queuing locally",
+            result.status_code,
+            result.error,
+        )
+        queue_payload(root, payload)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_phone_home.py
+++ b/tests/test_phone_home.py
@@ -1,0 +1,496 @@
+"""Tests for hydra_detect/telemetry/phone_home.py.
+
+Covers:
+- build_payload shape and null branches
+- send_payload success / network error / 401 / 5xx (no raise)
+- queue_payload writes file, bounded queue evicts oldest
+- flush_queue sends in order, stops on first failure
+- CLI dry-run prints JSON without sending
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import sys
+import urllib.error
+import urllib.request
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hydra_detect.telemetry.phone_home import (
+    SendResult,
+    _QUEUE_MAX,
+    _queue_dir,
+    build_payload,
+    flush_queue,
+    queue_payload,
+    send_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_cfg(sections: dict | None = None) -> configparser.ConfigParser:
+    """Build a ConfigParser from a dict of sections."""
+    cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+    if sections:
+        for section, keys in sections.items():
+            cfg.add_section(section)
+            for key, val in keys.items():
+                cfg.set(section, key, val)
+    return cfg
+
+
+def _minimal_cfg() -> configparser.ConfigParser:
+    return _make_cfg({
+        "tak": {"callsign": "HYDRA-TEST"},
+        "telemetry": {"enabled": "false", "collector_url": "", "api_token": "", "opt_out": "false"},
+    })
+
+
+# ---------------------------------------------------------------------------
+# build_payload — shape
+# ---------------------------------------------------------------------------
+
+class TestBuildPayloadShape:
+    """build_payload always returns the full set of keys."""
+
+    REQUIRED_KEYS = {
+        "callsign", "hostname", "version", "channel",
+        "uptime_hours", "mode", "capability_summary",
+        "last_mission_at", "disk_free_pct", "cpu_temp_c",
+        "power_mode", "last_update_status",
+    }
+
+    def test_all_keys_present(self, tmp_path):
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        assert self.REQUIRED_KEYS.issubset(payload.keys()), (
+            f"Missing keys: {self.REQUIRED_KEYS - payload.keys()}"
+        )
+
+    def test_callsign_from_tak_section(self, tmp_path):
+        cfg = _make_cfg({"tak": {"callsign": "HYDRA-7"}})
+        payload = build_payload(cfg, tmp_path)
+        assert payload["callsign"] == "HYDRA-7"
+
+    def test_callsign_null_when_missing(self, tmp_path):
+        cfg = _make_cfg({})
+        payload = build_payload(cfg, tmp_path)
+        assert payload["callsign"] is None
+
+    def test_hostname_is_string(self, tmp_path):
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        assert isinstance(payload["hostname"], str)
+        assert len(payload["hostname"]) > 0
+
+    def test_capability_summary_empty_dict_when_evaluator_absent(self, tmp_path):
+        cfg = _minimal_cfg()
+        # The evaluator from #171 is not wired yet — expect empty dict.
+        payload = build_payload(cfg, tmp_path)
+        assert isinstance(payload["capability_summary"], dict)
+
+    def test_disk_free_pct_is_number_or_null(self, tmp_path):
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        val = payload["disk_free_pct"]
+        assert val is None or isinstance(val, float)
+
+    def test_last_mission_at_null_when_no_logs(self, tmp_path):
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        assert payload["last_mission_at"] is None
+
+    def test_last_mission_at_iso_when_log_exists(self, tmp_path):
+        log_dir = tmp_path / "output_data" / "logs"
+        log_dir.mkdir(parents=True)
+        (log_dir / "run.jsonl").write_text('{"event": "detection"}\n')
+
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        ts = payload["last_mission_at"]
+        assert ts is not None
+        # Must be a parseable ISO 8601 string.
+        from datetime import datetime
+        datetime.fromisoformat(ts)
+
+    def test_last_update_status_null_when_file_absent(self, tmp_path):
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        assert payload["last_update_status"] is None
+
+    def test_last_update_status_reads_file(self, tmp_path):
+        status_dir = tmp_path / "output_data"
+        status_dir.mkdir(parents=True)
+        (status_dir / "update_status.txt").write_text("pull ok — 2026-04-23")
+
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        assert payload["last_update_status"] == "pull ok — 2026-04-23"
+
+    def test_last_update_status_truncated_at_120(self, tmp_path):
+        status_dir = tmp_path / "output_data"
+        status_dir.mkdir(parents=True)
+        (status_dir / "update_status.txt").write_text("x" * 200)
+
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        assert len(payload["last_update_status"]) == 120
+
+    def test_uptime_hours_null_on_missing_proc_uptime(self, tmp_path):
+        cfg = _minimal_cfg()
+        with patch("hydra_detect.telemetry.phone_home.Path") as mock_path_cls:
+            # Make /proc/uptime raise FileNotFoundError but leave other paths alone.
+            real_path = Path
+            def side_effect(arg):
+                p = real_path(arg)
+                if str(arg) == "/proc/uptime":
+                    m = MagicMock(spec=Path)
+                    m.read_text.side_effect = FileNotFoundError()
+                    return m
+                return p
+            mock_path_cls.side_effect = side_effect
+            payload = build_payload(cfg, tmp_path)
+        # Either null or a float — both are valid (depends on test env).
+        val = payload["uptime_hours"]
+        assert val is None or isinstance(val, (int, float))
+
+    def test_version_is_string_or_null(self, tmp_path):
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        val = payload["version"]
+        assert val is None or isinstance(val, str)
+
+    def test_cpu_temp_null_on_non_jetson(self, tmp_path):
+        """On a non-Jetson host (no sysfs thermal zone), cpu_temp_c is None."""
+        cfg = _minimal_cfg()
+        with patch(
+            "hydra_detect.telemetry.phone_home._cpu_temp_c",
+            return_value=None,
+        ):
+            payload = build_payload(cfg, tmp_path)
+        assert payload["cpu_temp_c"] is None
+
+    def test_power_mode_null_on_non_jetson(self, tmp_path):
+        cfg = _minimal_cfg()
+        with patch(
+            "hydra_detect.telemetry.phone_home._power_mode",
+            return_value=None,
+        ):
+            payload = build_payload(cfg, tmp_path)
+        assert payload["power_mode"] is None
+
+    def test_payload_is_json_serialisable(self, tmp_path):
+        cfg = _minimal_cfg()
+        payload = build_payload(cfg, tmp_path)
+        serialised = json.dumps(payload)
+        assert isinstance(serialised, str)
+
+
+# ---------------------------------------------------------------------------
+# send_payload
+# ---------------------------------------------------------------------------
+
+class TestSendPayload:
+    """send_payload returns SendResult and never raises."""
+
+    def _fake_response(self, status: int) -> MagicMock:
+        resp = MagicMock()
+        resp.status = status
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        return resp
+
+    def test_success_200(self, tmp_path):
+        resp = self._fake_response(200)
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = send_payload("http://collector/ingest", {"k": "v"}, "tok")
+        assert result.ok is True
+        assert result.status_code == 200
+        assert result.error is None
+
+    def test_success_201(self, tmp_path):
+        resp = self._fake_response(201)
+        with patch("urllib.request.urlopen", return_value=resp):
+            result = send_payload("http://collector/ingest", {}, "tok")
+        assert result.ok is True
+        assert result.status_code == 201
+
+    def test_http_401_returns_structured_result(self):
+        err = urllib.error.HTTPError(
+            url="http://x", code=401, msg="Unauthorized",
+            hdrs=None, fp=None,
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = send_payload("http://collector/ingest", {}, "bad-token")
+        assert result.ok is False
+        assert result.status_code == 401
+        assert result.error is not None
+
+    def test_http_500_returns_structured_result(self):
+        err = urllib.error.HTTPError(
+            url="http://x", code=500, msg="Internal Server Error",
+            hdrs=None, fp=None,
+        )
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = send_payload("http://collector/ingest", {}, "tok")
+        assert result.ok is False
+        assert result.status_code == 500
+
+    def test_network_error_url_error(self):
+        err = urllib.error.URLError(reason="Name or service not known")
+        with patch("urllib.request.urlopen", side_effect=err):
+            result = send_payload("http://collector/ingest", {}, "tok")
+        assert result.ok is False
+        assert result.status_code is None
+        assert "Name or service not known" in (result.error or "")
+
+    def test_timeout_returns_structured_result(self):
+        with patch("urllib.request.urlopen", side_effect=TimeoutError()):
+            result = send_payload("http://collector/ingest", {}, "tok", timeout=1)
+        assert result.ok is False
+        assert result.status_code is None
+        assert result.error is not None
+
+    def test_never_raises(self):
+        """send_payload must not propagate any exception."""
+        with patch("urllib.request.urlopen", side_effect=RuntimeError("unexpected")):
+            result = send_payload("http://collector/ingest", {}, "tok")
+        assert isinstance(result, SendResult)
+
+    def test_bearer_token_in_header(self):
+        captured_req = []
+
+        def fake_urlopen(req, **kwargs):
+            captured_req.append(req)
+            resp = self._fake_response(200)
+            return resp
+
+        with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+            send_payload("http://collector/ingest", {}, "MY_SECRET_TOKEN")
+
+        req = captured_req[0]
+        assert req.get_header("Authorization") == "Bearer MY_SECRET_TOKEN"
+
+
+# ---------------------------------------------------------------------------
+# queue_payload
+# ---------------------------------------------------------------------------
+
+class TestQueuePayload:
+    def test_writes_json_file(self, tmp_path):
+        payload = {"callsign": "TEST", "version": "2.1.0"}
+        queue_payload(tmp_path, payload)
+
+        q = _queue_dir(tmp_path)
+        files = list(q.glob("*.json"))
+        assert len(files) == 1
+        loaded = json.loads(files[0].read_text())
+        assert loaded["callsign"] == "TEST"
+
+    def test_creates_queue_dir(self, tmp_path):
+        queue_payload(tmp_path, {"x": 1})
+        assert _queue_dir(tmp_path).exists()
+
+    def test_bounded_queue_evicts_oldest(self, tmp_path):
+        # Write _QUEUE_MAX + 5 entries — oldest 5 should be evicted.
+        q = _queue_dir(tmp_path)
+        q.mkdir(parents=True)
+
+        # Pre-populate with old entries (named to sort before the new ones).
+        for i in range(_QUEUE_MAX):
+            (q / f"20200101T00000{i:06d}.json").write_text('{"old": true}')
+
+        # queue_payload adds one more, triggering eviction.
+        queue_payload(tmp_path, {"new": True})
+
+        remaining = sorted(q.glob("*.json"))
+        assert len(remaining) == _QUEUE_MAX
+        # The newest entry (containing "new": true) must be present.
+        newest = json.loads(remaining[-1].read_text())
+        assert newest.get("new") is True
+
+    def test_multiple_writes_accumulate(self, tmp_path):
+        for i in range(5):
+            queue_payload(tmp_path, {"seq": i})
+        q = _queue_dir(tmp_path)
+        assert len(list(q.glob("*.json"))) == 5
+
+
+# ---------------------------------------------------------------------------
+# flush_queue
+# ---------------------------------------------------------------------------
+
+class TestFlushQueue:
+    def _fill_queue(self, q: Path, count: int) -> list[Path]:
+        q.mkdir(parents=True, exist_ok=True)
+        files = []
+        for i in range(count):
+            f = q / f"2026010{i:02d}T000000000000.json"
+            f.write_text(json.dumps({"seq": i}))
+            files.append(f)
+        return sorted(files)
+
+    def test_sends_in_chronological_order(self, tmp_path):
+        q = _queue_dir(tmp_path)
+        files = self._fill_queue(q, 3)
+        sent_payloads = []
+
+        def fake_send(url, payload, api_token, **kw):
+            sent_payloads.append(payload["seq"])
+            return SendResult(ok=True, status_code=200, error=None)
+
+        with patch(
+            "hydra_detect.telemetry.phone_home.send_payload",
+            side_effect=fake_send,
+        ):
+            flush_queue(tmp_path, "http://collector", "tok")
+
+        assert sent_payloads == [0, 1, 2]
+
+    def test_removes_sent_entries(self, tmp_path):
+        q = _queue_dir(tmp_path)
+        self._fill_queue(q, 3)
+
+        with patch(
+            "hydra_detect.telemetry.phone_home.send_payload",
+            return_value=SendResult(ok=True, status_code=200, error=None),
+        ):
+            flush_queue(tmp_path, "http://collector", "tok")
+
+        assert list(q.glob("*.json")) == []
+
+    def test_stops_on_first_failure(self, tmp_path):
+        q = _queue_dir(tmp_path)
+        self._fill_queue(q, 5)
+        send_count = [0]
+
+        def fail_on_second(url, payload, api_token, **kw):
+            send_count[0] += 1
+            if send_count[0] == 1:
+                return SendResult(ok=True, status_code=200, error=None)
+            return SendResult(ok=False, status_code=503, error="Service Unavailable")
+
+        with patch(
+            "hydra_detect.telemetry.phone_home.send_payload",
+            side_effect=fail_on_second,
+        ):
+            flush_queue(tmp_path, "http://collector", "tok")
+
+        # First entry sent and removed; entries 2-5 remain.
+        remaining = list(q.glob("*.json"))
+        assert len(remaining) == 4
+
+    def test_noop_when_queue_empty(self, tmp_path):
+        # Should not raise even when queue dir does not exist.
+        flush_queue(tmp_path, "http://collector", "tok")
+
+    def test_respects_max_batch(self, tmp_path):
+        q = _queue_dir(tmp_path)
+        self._fill_queue(q, 20)
+        send_count = [0]
+
+        def count_sends(url, payload, api_token, **kw):
+            send_count[0] += 1
+            return SendResult(ok=True, status_code=200, error=None)
+
+        with patch(
+            "hydra_detect.telemetry.phone_home.send_payload",
+            side_effect=count_sends,
+        ):
+            flush_queue(tmp_path, "http://collector", "tok", max_batch=7)
+
+        assert send_count[0] == 7
+        # Remaining 13 untouched.
+        assert len(list(q.glob("*.json"))) == 13
+
+    def test_skips_corrupt_entry(self, tmp_path):
+        q = _queue_dir(tmp_path)
+        q.mkdir(parents=True)
+        (q / "2026010100T000000000000.json").write_text("not valid json {{{")
+        (q / "2026010200T000000000000.json").write_text('{"seq": 1}')
+
+        sent = []
+
+        def record(url, payload, api_token, **kw):
+            sent.append(payload)
+            return SendResult(ok=True, status_code=200, error=None)
+
+        with patch(
+            "hydra_detect.telemetry.phone_home.send_payload",
+            side_effect=record,
+        ):
+            flush_queue(tmp_path, "http://collector", "tok")
+
+        # Corrupt file is removed; valid entry is sent.
+        assert len(sent) == 1
+        assert sent[0]["seq"] == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI — dry-run
+# ---------------------------------------------------------------------------
+
+class TestCLIDryRun:
+    """CLI --dry-run prints JSON without making any network calls."""
+
+    def _run_dry_run(self, config_path: Path) -> tuple[int, str]:
+        """Invoke scripts/phone_home.py main() and capture stdout."""
+        import importlib.util
+        import io
+
+        script_path = (
+            Path(__file__).resolve().parent.parent / "scripts" / "phone_home.py"
+        )
+        spec = importlib.util.spec_from_file_location("phone_home_script", script_path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        captured = io.StringIO()
+        original_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            rc = mod.main(["--config", str(config_path), "--dry-run"])
+        finally:
+            sys.stdout = original_stdout
+        return rc, captured.getvalue()
+
+    def test_prints_valid_json(self, tmp_path):
+        cfg_path = tmp_path / "config.ini"
+        cfg_path.write_text("[tak]\ncallsign = HYDRA-DRY\n")
+
+        rc, output = self._run_dry_run(cfg_path)
+        assert rc == 0
+        payload = json.loads(output)
+        assert payload["callsign"] == "HYDRA-DRY"
+
+    def test_no_network_call(self, tmp_path):
+        cfg_path = tmp_path / "config.ini"
+        cfg_path.write_text("[tak]\ncallsign = HYDRA-X\n")
+
+        with patch(
+            "hydra_detect.telemetry.phone_home.send_payload"
+        ) as mock_send:
+            self._run_dry_run(cfg_path)
+        mock_send.assert_not_called()
+
+    def test_all_required_keys_in_output(self, tmp_path):
+        cfg_path = tmp_path / "config.ini"
+        cfg_path.write_text("[tak]\ncallsign = HYDRA-X\n")
+
+        rc, output = self._run_dry_run(cfg_path)
+        payload = json.loads(output)
+        required = {
+            "callsign", "hostname", "version", "channel",
+            "uptime_hours", "mode", "capability_summary",
+            "last_mission_at", "disk_free_pct", "cpu_temp_c",
+            "power_mode", "last_update_status",
+        }
+        assert required.issubset(payload.keys())

--- a/tests/test_phone_home_privacy.py
+++ b/tests/test_phone_home_privacy.py
@@ -1,0 +1,202 @@
+"""Privacy audit for phone-home telemetry.
+
+This test is the primary defense against future changes accidentally leaking
+sensitive data.  It calls build_payload with a config and state that contains
+GPS coordinates, video references, crop paths, operator names, and other PII,
+then asserts that none of those values appear anywhere in the payload — not
+in keys, not in values, not nested inside dicts.
+
+If this test fails after a code change, that change is leaking data it should not.
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+from pathlib import Path
+
+import pytest
+
+from hydra_detect.telemetry.phone_home import build_payload
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _deep_values(obj) -> list:
+    """Recursively collect all string/numeric leaf values from a nested dict/list."""
+    results = []
+    if isinstance(obj, dict):
+        for v in obj.values():
+            results.extend(_deep_values(v))
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            results.extend(_deep_values(item))
+    elif obj is not None:
+        results.append(obj)
+    return results
+
+
+def _deep_keys(obj, prefix: str = "") -> list[str]:
+    """Recursively collect all dict keys from a nested structure."""
+    results = []
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            full = f"{prefix}.{k}" if prefix else k
+            results.append(full)
+            results.extend(_deep_keys(v, prefix=full))
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            results.extend(_deep_keys(item, prefix=prefix))
+    return results
+
+
+def _payload_with_poisoned_config(tmp_path: Path) -> dict:
+    """Return build_payload output against a config loaded with sensitive fields.
+
+    The config itself contains GPS coordinates, operator names, and other
+    sensitive data — none of which should end up in the payload.
+    """
+    cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+
+    # TAK section — callsign only should appear.
+    cfg.add_section("tak")
+    cfg.set("tak", "callsign", "HYDRA-1")
+    # These must NOT appear in the payload:
+    cfg.set("tak", "multicast_group", "239.2.3.1")
+    cfg.set("tak", "unicast_targets", "192.168.1.100:6969")
+
+    # MAVLink GPS simulation — must NOT appear.
+    cfg.add_section("mavlink")
+    cfg.set("mavlink", "sim_gps_lat", "36.123456")
+    cfg.set("mavlink", "sim_gps_lon", "-115.987654")
+    cfg.set("mavlink", "connection_string", "/dev/ttyACM0")
+    cfg.set("mavlink", "source_system", "42")
+
+    # Logging — crop paths must NOT appear.
+    cfg.add_section("logging")
+    cfg.set("logging", "crop_dir", "/output_data/crops")
+    cfg.set("logging", "image_dir", "/output_data/images")
+
+    # Autonomous — geofence coordinates must NOT appear.
+    cfg.add_section("autonomous")
+    cfg.set("autonomous", "geofence_lat", "36.111111")
+    cfg.set("autonomous", "geofence_lon", "-115.222222")
+
+    # Telemetry section.
+    cfg.add_section("telemetry")
+    cfg.set("telemetry", "enabled", "false")
+    cfg.set("telemetry", "collector_url", "")
+    cfg.set("telemetry", "api_token", "SENSITIVE_API_TOKEN_12345")
+
+    return build_payload(cfg, tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Sensitive values that must NEVER appear in the payload
+# ---------------------------------------------------------------------------
+
+# GPS coordinate fragments — exact matches or substrings found in any leaf value.
+_FORBIDDEN_SUBSTRINGS = [
+    "36.123456",    # sim_gps_lat
+    "-115.987654",  # sim_gps_lon
+    "36.111111",    # geofence_lat
+    "-115.222222",  # geofence_lon
+    "SENSITIVE_API_TOKEN_12345",  # api_token must not be echoed back
+    "192.168.1.100",  # unicast target IP
+    "/dev/ttyACM0",   # serial port path (hardware detail)
+]
+
+# Key names that must NOT appear anywhere in the payload (even nested).
+_FORBIDDEN_KEYS = {
+    "gps_lat", "gps_lon", "lat", "lon", "latitude", "longitude",
+    "geofence_lat", "geofence_lon", "sim_gps_lat", "sim_gps_lon",
+    "crop", "crops", "crop_dir", "image_dir",
+    "frame", "video", "thumbnail",
+    "api_token",        # token used to send, not echoed in body
+    "connection_string",  # hardware serial path
+    "source_system",    # MAVLink system ID
+    "unicast_targets", "multicast_group",
+    "password", "web_password", "hmac_secret", "command_hmac_secret",
+}
+
+
+class TestPrivacyAudit:
+    """Payload must not leak GPS, video, crops, or operator-identifying info."""
+
+    @pytest.fixture()
+    def payload(self, tmp_path) -> dict:
+        return _payload_with_poisoned_config(tmp_path)
+
+    @pytest.fixture()
+    def payload_json(self, payload) -> str:
+        return json.dumps(payload)
+
+    def test_no_gps_coordinates_in_values(self, payload):
+        values = _deep_values(payload)
+        str_values = [str(v) for v in values]
+        for forbidden in ["36.123456", "-115.987654", "36.111111", "-115.222222"]:
+            for sv in str_values:
+                assert forbidden not in sv, (
+                    f"GPS fragment '{forbidden}' found in payload value: {sv!r}"
+                )
+
+    def test_no_forbidden_substrings_in_serialised_json(self, payload_json):
+        for forbidden in _FORBIDDEN_SUBSTRINGS:
+            assert forbidden not in payload_json, (
+                f"Forbidden value {forbidden!r} appears in serialised payload"
+            )
+
+    def test_no_forbidden_keys(self, payload):
+        all_keys = set(_deep_keys(payload))
+        leaked = all_keys & _FORBIDDEN_KEYS
+        assert not leaked, f"Forbidden keys found in payload: {leaked}"
+
+    def test_api_token_not_echoed(self, payload_json):
+        assert "SENSITIVE_API_TOKEN_12345" not in payload_json
+
+    def test_serial_port_not_in_payload(self, payload_json):
+        assert "/dev/ttyACM0" not in payload_json
+
+    def test_ip_address_not_in_payload(self, payload_json):
+        assert "192.168.1.100" not in payload_json
+
+    def test_crop_dir_not_in_payload(self, payload_json):
+        assert "/output_data/crops" not in payload_json
+        assert "image_dir" not in payload_json
+        assert "crop_dir" not in payload_json
+
+    def test_mavlink_system_id_not_in_payload(self, payload):
+        all_keys = set(_deep_keys(payload))
+        assert "source_system" not in all_keys
+
+    def test_callsign_is_only_identity_field(self, payload):
+        """Only callsign and hostname (OS-level) are identity fields in the payload."""
+        all_keys = set(_deep_keys(payload))
+        # These are the only acceptable identity-adjacent fields.
+        identity_keys = {"callsign", "hostname"}
+        # No other identity-adjacent keys are allowed.
+        suspicious = {
+            k for k in all_keys
+            if any(word in k.lower() for word in
+                   ("operator", "name", "user", "email", "phone", "address", "id"))
+            and k not in identity_keys
+        }
+        assert not suspicious, f"Suspicious identity fields in payload: {suspicious}"
+
+    def test_payload_keys_are_exactly_the_documented_set(self, payload):
+        """Snapshot test — if new keys are added, this test forces a review."""
+        expected = {
+            "callsign", "hostname", "version", "channel",
+            "uptime_hours", "mode", "capability_summary",
+            "last_mission_at", "disk_free_pct", "cpu_temp_c",
+            "power_mode", "last_update_status",
+        }
+        actual = set(payload.keys())
+        added = actual - expected
+        removed = expected - actual
+        assert not added, (
+            f"New keys added to payload — privacy review required: {added}"
+        )
+        assert not removed, f"Keys removed from payload: {removed}"


### PR DESCRIPTION
**DRAFT — unit side only. Collector side is a Kyle decision. Default off. Safe to leave unmerged.**

## Summary

Phone-home telemetry, unit side. Operators keep Hydra units permanently. Without this, there is no visibility into whether a unit at someone's home is alive. This is the early-warning path.

Default off. Nothing sends until an operator sets \`enabled = true\` and provides a \`collector_url\`. Collector side is not defined — Kyle has not decided where it lives. Do not merge until that decision is made.

Additive. No changes to the detection pipeline, MAVLink stack, or web API.

## What is in the payload

| Field | Source |
|---|---|
| \`callsign\` | \`[tak] callsign\` from config.ini |
| \`hostname\` | OS hostname |
| \`version\` | \`hydra_detect.__version__\` |
| \`channel\` | \`[telemetry] channel\` (optional label) |
| \`uptime_hours\` | \`/proc/uptime\` |
| \`mode\` | \`[telemetry] mode\` (optional label) |
| \`capability_summary\` | READY/WARN/BLOCKED counts from #171 evaluator if present, else \`{}\` |
| \`last_mission_at\` | mtime of most recent detection log file |
| \`disk_free_pct\` | \`shutil.disk_usage()\` |
| \`cpu_temp_c\` | sysfs thermal zone 0 |
| \`power_mode\` | \`nvpmodel -q\` |
| \`last_update_status\` | \`output_data/update_status.txt\` (first 120 chars) |

All keys always present. Missing signals are \`null\`, not absent keys.

## What is NOT in the payload

- GPS coordinates (no \`lat\`, \`lon\`, \`geofence_*\`, \`sim_gps_*\`)
- Video frames, thumbnails, or detection images
- Crop images or crop directory paths
- Operator names or identifying information
- MAVLink system IDs or serial port paths
- IP addresses or network targets
- \`api_token\` (used to send, never echoed back)

Enforced by \`test_phone_home_privacy.py\`.

## Privacy audit

\`tests/test_phone_home_privacy.py\` is the primary defense against future leaks. Populates a config with known sensitive values (GPS, operator info, api_token, IPs, serial ports) then calls \`build_payload\` and deep-scans every key and value in the result. If any forbidden value appears anywhere in the payload tree, the test fails.

Any future change that causes the payload to include sensitive data trips this test before it can ship. Do not remove.

## Test plan

- [x] \`tests/test_phone_home.py\` — 37 tests: payload shape and null branches, send success/401/5xx/network error/timeout (all return SendResult, none raise), queue writes + evicts oldest past cap 30, flush sends in order / stops on first failure / respects max_batch / skips corrupt entries, CLI \`--dry-run\` prints JSON without sending
- [x] \`tests/test_phone_home_privacy.py\` — 10 privacy-audit tests
- [ ] \`python scripts/phone_home.py --dry-run\` — run on a Jetson to verify payload without network
- [x] \`[telemetry] enabled = false\` in \`config.ini\` and \`config.ini.factory\` — unit ships silent

## What is NOT in this PR

- Collector side (server that receives payloads)
- \`Telemetry\` capability wiring into #171 capability status
- TLS / cert pinning (Tailscale-native per the original issue)
- Encryption beyond TLS (payload is operational metadata only)
- Auto-install of systemd units (documented in \`scripts/README-phone-home.md\`, manual enable required)

Refs #153