### PR TITLE
fix(detector): gate .to(cuda:0) on .pt models so TRT engines load

### DIFF
--- a/hydra_detect/detectors/yolo_detector.py
+++ b/hydra_detect/detectors/yolo_detector.py
@@ -36,17 +36,33 @@ class YOLODetector(BaseDetector):
         self._model = YOLO(self._model_path)
         logger.info("YOLO model: %d classes, task=%s",
                     len(self._model.names), getattr(self._model, 'task', 'unknown'))
-        # Force GPU inference on Jetson — CPU gives 1-2 FPS, GPU gives 5-10+
+        self._apply_device_placement(self._model, self._model_path)
+        logger.info("YOLO model loaded.")
+
+    def _apply_device_placement(self, model, model_path: str) -> None:
+        # `.to("cuda:0")` is a PyTorch-only call. TensorRT (.engine) and ONNX
+        # (.onnx) backends are pre-compiled or runtime-managed and reject it
+        # (ultralytics raises TypeError if you try). Only call .to() when the
+        # underlying weights are a PyTorch checkpoint.
+        if not model_path.lower().endswith(".pt"):
+            logger.info(
+                "YOLO model is %s — device handled by backend (no .to() call).",
+                model_path,
+            )
+            return
         try:
             import torch
             if torch.cuda.is_available():
-                self._model.to("cuda:0")
-                logger.info("YOLO model loaded on GPU (CUDA).")
+                model.to("cuda:0")
+                logger.info("YOLO model placed on GPU (CUDA).")
             else:
-                logger.warning("CUDA not available — running YOLO on CPU (expect slow inference).")
+                logger.warning(
+                    "CUDA not available — running YOLO on CPU (expect slow inference)."
+                )
         except ImportError:
-            logger.warning("torch not available for device check — YOLO using default device.")
-        logger.info("YOLO model loaded.")
+            logger.warning(
+                "torch not available for device check — YOLO using default device."
+            )
 
     def detect(self, frame: np.ndarray) -> DetectionResult:
         if self._model is None:
@@ -120,12 +136,7 @@ class YOLODetector(BaseDetector):
         logger.info("Switching YOLO model: %s -> %s", old_path, model_path)
         try:
             new_model = YOLO(model_path)
-            try:
-                import torch
-                if torch.cuda.is_available():
-                    new_model.to("cuda:0")
-            except ImportError:
-                pass
+            self._apply_device_placement(new_model, model_path)
             self._model = new_model
             self._model_path = model_path
             logger.info("YOLO model switched to: %s", model_path)

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -51,3 +51,56 @@ class TestSetClasses:
         det = YOLODetector(model_path="yolov8n.pt", confidence=0.5, classes=[0, 1])
         det.set_classes(None)
         assert det._classes is None
+
+
+class TestApplyDevicePlacement:
+    """`.to("cuda:0")` is PyTorch-only. TRT (.engine) and ONNX (.onnx) backends
+    reject it. Make sure the gate skips non-.pt model paths."""
+
+    def test_engine_path_skips_to_call(self):
+        from unittest.mock import MagicMock
+        from hydra_detect.detectors.yolo_detector import YOLODetector
+        det = YOLODetector()
+        model = MagicMock()
+        det._apply_device_placement(model, "yolov8n.engine")
+        model.to.assert_not_called()
+
+    def test_onnx_path_skips_to_call(self):
+        from unittest.mock import MagicMock
+        from hydra_detect.detectors.yolo_detector import YOLODetector
+        det = YOLODetector()
+        model = MagicMock()
+        det._apply_device_placement(model, "models/yolov8n.onnx")
+        model.to.assert_not_called()
+
+    def test_torchscript_path_skips_to_call(self):
+        from unittest.mock import MagicMock
+        from hydra_detect.detectors.yolo_detector import YOLODetector
+        det = YOLODetector()
+        model = MagicMock()
+        det._apply_device_placement(model, "models/yolov8n.torchscript")
+        model.to.assert_not_called()
+
+    def test_pt_path_calls_to_when_cuda_available(self):
+        # Only meaningful when torch is importable (Jetson runtime / CI with torch).
+        # Local laptop runs without torch — skip cleanly.
+        import pytest
+        pytest.importorskip("torch")
+        from unittest.mock import MagicMock, patch
+        from hydra_detect.detectors.yolo_detector import YOLODetector
+        det = YOLODetector()
+        model = MagicMock()
+        with patch("torch.cuda.is_available", return_value=True):
+            det._apply_device_placement(model, "yolov8n.pt")
+        model.to.assert_called_once_with("cuda:0")
+
+    def test_pt_path_skips_to_when_cuda_unavailable(self):
+        import pytest
+        pytest.importorskip("torch")
+        from unittest.mock import MagicMock, patch
+        from hydra_detect.detectors.yolo_detector import YOLODetector
+        det = YOLODetector()
+        model = MagicMock()
+        with patch("torch.cuda.is_available", return_value=False):
+            det._apply_device_placement(model, "yolov8n.pt")
+        model.to.assert_not_called()


### PR DESCRIPTION
## Summary
- Extracts `_apply_device_placement(model, model_path)` and skips the `.to("cuda:0")` call unless the model path ends in `.pt`. TensorRT (`.engine`) and ONNX (`.onnx`) backends reject the call (ultralytics raises `TypeError`), and any non-`.pt` `yolo_model` in `config.ini` previously sent the container into an exit-1 loop.
- Adds unit tests covering `.engine`, `.onnx`, `.torchscript`, and `.pt` paths. Torch-dependent tests use `pytest.importorskip` so they pass cleanly on machines without torch (laptop / non-CUDA CI), and fully exercise on the Jetson.
- Verified on team-4 USV (Jetson Orin Nano, JetPack 6.2.1, ultralytics + TensorRT 10.4.0.26): post-deploy + post-engine-regen FPS jumped from 9.59 (`.pt`) to **31.82** (`.engine`) — 3.3x speedup.

## Why this matters
Hydra ships `yolov8n.engine` in the model manifest but the runtime path was unreachable. Operators trying to flip to `.engine` for FPS hit a hard crash with no error path. This unblocks the TRT speedup that was already on disk.

## Test plan
- [x] `pytest tests/test_detectors.py` — 9 passed, 2 skipped (torch-only tests; skip is expected on non-CUDA hosts).
- [x] `flake8` clean on changed files.
- [x] Live deploy on hydra-team-4: `scripts/deploy.sh claude/yolo-trt-load-gate`, regenerated engine inside the new container, swapped `[detector] yolo_model` to `yolov8n.engine`, restarted, observed FPS 9.59 → 31.82, MAVLink reconnected, `/api/health` ok, detection logs writing on host.
- [ ] CI: pending.

## Notes
The pre-built `yolov8n.engine` shipped in the repo on team-4 (Apr 19, root-owned) was built against an older TensorRT runtime and crashed deserialize. After the new image was built, re-exporting the engine inside the new container produced a compatible binary. This is expected when the runtime version changes — operators / install scripts should re-export on first deploy.