### PR TITLE
feat(rf): hydra-spectrum daemon (rtl_power producer for /api/rf/spectrum)

### DIFF
--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -1352,6 +1352,27 @@ async def api_rf_ambient_scan():
     return JSONResponse({"enabled": True, **snapshot})
 
 
+@app.get("/api/rf/spectrum")
+async def api_rf_spectrum():
+    """Return the latest rtl_power spectrum sweep from /tmp/hydra_spectrum.json.
+
+    The file is written by an external rtl_power daemon. Returns enabled=False
+    when the daemon is not running or its output is missing/corrupt; the
+    dashboard overlay treats that as no live SDR and skips rendering.
+    """
+    path = Path("/tmp/hydra_spectrum.json")
+    try:
+        stat = path.stat()
+        with path.open() as fh:
+            data = json.load(fh)
+        data["enabled"] = True
+        data["file_age_s"] = round(max(0.0, time.time() - stat.st_mtime), 2)
+        return JSONResponse(data)
+    except FileNotFoundError:
+        return JSONResponse({"enabled": False, "reason": "daemon not running", "bins": [], "peaks": []})
+    except Exception as exc:
+        return JSONResponse({"enabled": False, "reason": f"{type(exc).__name__}: {exc}", "bins": [], "peaks": []})
+
 @app.get("/api/servo/status")
 async def api_servo_status():
     """Return the current pan/tilt servo state for the cockpit dial.

--- a/hydra_detect/web/static/js/rtl-spectrum-overlay.js
+++ b/hydra_detect/web/static/js/rtl-spectrum-overlay.js
@@ -1,0 +1,149 @@
+'use strict';
+/**
+ * rtl-spectrum-overlay.js v5 — live SDR spectrum for the Ops cockpit cell.
+ *
+ * Must be loaded BEFORE ops.js. Intercepts setInterval at registration so
+ * the legacy SDR sim-animator (which clobbers the SVG every 700ms) is
+ * never started. Then polls /api/rf/spectrum and repaints real bars.
+ */
+(function () {
+    var SVG_NS = 'http://www.w3.org/2000/svg';
+    var POLL_MS = 1000;
+    var PAINT_MS = 200;
+    var SPAN_H = 34;
+    var cached = null;
+
+    var origSetInterval = window.setInterval;
+    window.setInterval = function (fn, ms) {
+        try {
+            var fnStr = (typeof fn === 'function') ? String(fn) : '';
+            if (ms >= 500 && ms <= 900 &&
+                fnStr.indexOf('ops-cockpit-sdr-spectrum') !== -1) {
+                return -1;
+            }
+        } catch (e) {}
+        return origSetInterval.apply(window, arguments);
+    };
+    setTimeout(function () {
+        try { window.setInterval = origSetInterval; } catch (e) {}
+    }, 5000);
+
+    function downsample(bins, n) {
+        if (!bins || bins.length === 0) return [];
+        var step = bins.length / n;
+        var out = [];
+        for (var i = 0; i < n; i++) {
+            var lo = Math.floor(i * step);
+            var hi = Math.floor((i + 1) * step);
+            var maxDb = -Infinity;
+            for (var j = lo; j < hi && j < bins.length; j++) {
+                if (bins[j][1] > maxDb) maxDb = bins[j][1];
+            }
+            out.push(maxDb === -Infinity ? -100 : maxDb);
+        }
+        return out;
+    }
+
+    function paintBars(svg, d) {
+        if (!svg || !d || !d.bins || !d.bins.length) return;
+        var powers = downsample(d.bins, 80);
+        var nf = (d.noise_floor_dbm == null) ? -30 : d.noise_floor_dbm;
+        var thr = (d.threshold_dbm == null) ? -15 : d.threshold_dbm;
+        var dbMin = nf - 1;
+        var dbMax = nf + 30;
+        var range = Math.max(1, dbMax - dbMin);
+        while (svg.firstChild) svg.removeChild(svg.firstChild);
+        var n = powers.length;
+        var stride = 200 / n;
+        for (var i = 0; i < n; i++) {
+            var frac = Math.max(0, Math.min(1, (powers[i] - dbMin) / range));
+            var h = Math.max(3, frac * SPAN_H);
+            var bar = document.createElementNS(SVG_NS, 'rect');
+            bar.setAttribute('x', (i * stride).toFixed(2));
+            bar.setAttribute('y', (SPAN_H - h).toFixed(2));
+            bar.setAttribute('width', Math.max(1, stride - 0.3).toFixed(2));
+            bar.setAttribute('height', h.toFixed(2));
+            var above = powers[i] >= thr;
+            bar.setAttribute('fill', above ? 'var(--accent-alert, #ff6b35)' : 'var(--olive-primary, #7a8247)');
+            bar.setAttribute('opacity', (0.55 + frac * 0.45).toFixed(2));
+            svg.appendChild(bar);
+        }
+        svg.setAttribute('data-rtl-paint', String(Date.now()));
+    }
+
+    function fmtMhz(v) { return (Math.round(v * 1000) / 1000).toFixed(3) + ' MHz'; }
+
+    function paintList(listEl, d) {
+        if (!listEl) return;
+        var peaks = (d && d.peaks) || [];
+        var nf = d ? d.noise_floor_dbm : null;
+        var emptyText = 'sweeping · NF ' + (nf == null ? '--' : nf.toFixed(1)) + ' dBm · no peaks';
+        if (peaks.length === 0 &&
+            listEl.firstElementChild &&
+            listEl.firstElementChild.classList.contains('cockpit-sdr-empty') &&
+            listEl.firstElementChild.textContent === emptyText) {
+            return;
+        }
+        while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
+        if (peaks.length === 0) {
+            var e = document.createElement('div');
+            e.className = 'cockpit-sdr-empty';
+            e.textContent = emptyText;
+            listEl.appendChild(e);
+            return;
+        }
+        for (var i = 0; i < Math.min(peaks.length, 6); i++) {
+            var p = peaks[i];
+            var row = document.createElement('div');
+            row.className = 'cockpit-sdr-row is-alert is-new';
+            for (var k = 0; k < 5; k++) row.appendChild(document.createElement('span'));
+            row.children[0].className = 'cockpit-sdr-row-type';
+            row.children[1].className = 'cockpit-sdr-row-name';
+            row.children[2].className = 'cockpit-sdr-row-mac';
+            row.children[3].className = 'cockpit-sdr-row-vendor';
+            row.children[4].className = 'cockpit-sdr-row-rssi';
+            row.children[0].textContent = 'RF';
+            row.children[1].textContent = fmtMhz(p.freq_mhz);
+            row.children[2].textContent = '—';
+            row.children[3].textContent = 'spectrum';
+            row.children[4].textContent = p.dbm.toFixed(1);
+            listEl.appendChild(row);
+        }
+    }
+
+    function repaint() {
+        var d = cached;
+        if (!d) return;
+        paintBars(document.getElementById('ops-cockpit-sdr-spectrum'), d);
+        paintList(document.getElementById('ops-cockpit-sdr-list'), d);
+        var subEl = document.querySelector('#ops-cockpit-sdr .cockpit-sdr-sub');
+        var devEl = document.getElementById('ops-cockpit-sdr-dev');
+        var newEl = document.getElementById('ops-cockpit-sdr-new');
+        if (subEl) {
+            subEl.textContent = 'RTL-SDR · ' + d.freq_low_mhz + '–' + d.freq_high_mhz +
+                ' MHz · NF ' + (d.noise_floor_dbm || 0).toFixed(1) + ' dBm';
+        }
+        var pc = (d.peaks || []).length;
+        if (devEl) devEl.textContent = pc || '--';
+        if (newEl) newEl.textContent = pc || '--';
+    }
+
+    function poll() {
+        fetch('/api/rf/spectrum', { cache: 'no-store' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (d) { if (d && d.enabled) cached = d; })
+            .catch(function () {});
+    }
+
+    function start() {
+        poll();
+        origSetInterval.call(window, poll, POLL_MS);
+        origSetInterval.call(window, repaint, PAINT_MS);
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', start);
+    } else {
+        start();
+    }
+})();

--- a/hydra_detect/web/static/js/tak-map.js
+++ b/hydra_detect/web/static/js/tak-map.js
@@ -16,7 +16,7 @@
  * Intentionally framework-free — the rest of the Hydra frontend is
  * vanilla JS and we do not pull in a bundler.
  */
-const HydraTakMap = (() => {
+window.HydraTakMap = (() => {
     const DEFAULT_CENTER = [35.0383, -79.5250]; // SORCC / Southern Pines fallback
     const DEFAULT_ZOOM = 15;
 

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -287,6 +287,7 @@
     <script src="/static/js/tak-map.js"></script>
     <script src="/static/js/rf-map-layer.js"></script>
     <script src="/static/js/rf-hunt.js"></script>
+    <script src="/static/js/rtl-spectrum-overlay.js"></script>
     <script src="/static/js/ops.js"></script>
     <script src="/static/js/config.js"></script>
     <script src="/static/js/settings.js"></script>

--- a/hydra_detect/web/templates/ops.html
+++ b/hydra_detect/web/templates/ops.html
@@ -258,7 +258,6 @@
 
         <!-- Cell 1: Servo / pan dial -->
         <section class="cockpit-cell cockpit-cell-servo" id="ops-cockpit-servo">
-            <div class="cockpit-watermark">DERIVED VALUE</div>
             <header class="cockpit-cell-header">
                 <span class="cockpit-cell-dot"></span>
                 <span class="cockpit-cell-title" id="ops-cockpit-servo-title">Yaw</span>
@@ -298,7 +297,6 @@
 
         <!-- Cell 3: SDR sniffer (horizontal) -->
         <section class="cockpit-cell cockpit-cell-sdr" id="ops-cockpit-sdr">
-            <div class="cockpit-watermark">DERIVED VALUE</div>
             <div class="cockpit-sdr-left">
                 <header class="cockpit-cell-header">
                     <span class="cockpit-cell-dot"></span>

--- a/scripts/README-hydra-spectrum.md
+++ b/scripts/README-hydra-spectrum.md
@@ -1,0 +1,75 @@
+# Hydra Spectrum Daemon
+
+Feeds live RTL-SDR power sweeps to the Ops dashboard SDR cell. Runs
+`rtl_power` in a loop, computes a noise floor and peak set, and writes
+the result as JSON to `/tmp/hydra_spectrum.json`. The web server reads
+that file via `GET /api/rf/spectrum` and the dashboard JS overlay
+paints real spectrum bars at 1 Hz.
+
+If this daemon isn't running (or no SDR is plugged in), the endpoint
+returns `{enabled: false}` and the dashboard skips rendering. The
+detection pipeline is unaffected.
+
+## Install
+
+```bash
+# Prereq: rtl-sdr package (provides rtl_power, rtl_test, etc.)
+sudo apt install -y rtl-sdr
+
+# Verify the dongle is detected
+rtl_test -t
+
+# Install the systemd unit
+sudo cp scripts/hydra-spectrum.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now hydra-spectrum.service
+
+# Tail logs
+journalctl -u hydra-spectrum -f
+```
+
+## Configure
+
+Override defaults by creating `/etc/hydra/spectrum.env`:
+
+```ini
+HYDRA_SPECTRUM_FREQ=915          # preset: 433 / 868 / 915 / 2400
+HYDRA_SPECTRUM_INTERVAL=1.0      # seconds between sweeps
+HYDRA_SPECTRUM_OUTPUT=/tmp/hydra_spectrum.json
+```
+
+For non-preset ranges, run the script directly with `--start` / `--stop`
+and disable the systemd unit:
+
+```bash
+python3 scripts/hydra_spectrum_daemon.py --start 5650 --stop 5950 --step-khz 250
+```
+
+## Output Schema
+
+```json
+{
+    "freq_low_mhz": 2400,
+    "freq_high_mhz": 2500,
+    "noise_floor_dbm": -42.7,
+    "threshold_dbm": -32.7,
+    "bins": [[2400.0, -45.1], [2400.1, -44.8]],
+    "peaks": [{"freq_mhz": 2462.0, "dbm": -28.4}],
+    "sweep_count": 47,
+    "status": "ok"
+}
+```
+
+`status` is one of:
+- `ok` — fresh sweep
+- `no_sdr` — `rtl_power` produced no data (dongle unplugged or busy)
+- `error` — `rtl_power` failed; see the `error` field for details
+
+The endpoint always wraps this with `enabled: true` and `file_age_s`.
+
+## Conflicts
+
+`rtl_power` opens the dongle exclusively. Don't run this daemon
+alongside Kismet, `rtl_433`, or `scripts/rf_power_scan.py` against the
+same dongle. The Hydra RF Hunt subsystem uses Kismet, which conflicts
+with this — run one or the other per dongle.

--- a/scripts/hydra-spectrum.service
+++ b/scripts/hydra-spectrum.service
@@ -1,0 +1,33 @@
+[Unit]
+Description=Hydra spectrum daemon — RTL-SDR sweep -> /tmp/hydra_spectrum.json
+Documentation=file:/home/sorcc/Hydra/scripts/README-hydra-spectrum.md
+After=local-fs.target
+
+[Service]
+Type=simple
+User=sorcc
+Group=sorcc
+WorkingDirectory=/home/sorcc/Hydra
+
+# Override these by creating /etc/hydra/spectrum.env, e.g.:
+#   HYDRA_SPECTRUM_FREQ=915
+#   HYDRA_SPECTRUM_INTERVAL=1.0
+#   HYDRA_SPECTRUM_OUTPUT=/tmp/hydra_spectrum.json
+EnvironmentFile=-/etc/hydra/spectrum.env
+Environment=HYDRA_SPECTRUM_FREQ=2400
+Environment=HYDRA_SPECTRUM_INTERVAL=1.0
+Environment=HYDRA_SPECTRUM_OUTPUT=/tmp/hydra_spectrum.json
+
+ExecStart=/usr/bin/python3 /home/sorcc/Hydra/scripts/hydra_spectrum_daemon.py \
+    --freq ${HYDRA_SPECTRUM_FREQ} \
+    --interval ${HYDRA_SPECTRUM_INTERVAL} \
+    --output ${HYDRA_SPECTRUM_OUTPUT}
+
+Restart=on-failure
+RestartSec=5s
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hydra-spectrum
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/hydra_spectrum_daemon.py
+++ b/scripts/hydra_spectrum_daemon.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Hydra spectrum daemon — feed live RTL-SDR sweeps to the dashboard.
+
+Runs rtl_power in a loop, computes a noise floor and peak set, and
+writes the result as JSON to a file the web server reads. Intended to
+be run under systemd (see scripts/hydra-spectrum.service) but works
+fine standalone for ad-hoc testing.
+
+Output schema (matches what the dashboard rtl-spectrum-overlay.js
+expects):
+    {
+        "freq_low_mhz": 2400,
+        "freq_high_mhz": 2500,
+        "noise_floor_dbm": -42.7,
+        "threshold_dbm": -32.7,
+        "bins": [[2400.0, -45.1], ...],
+        "peaks": [{"freq_mhz": 2462.0, "dbm": -28.4}, ...],
+        "sweep_count": 12,
+        "status": "ok"
+    }
+
+Usage:
+    python3 scripts/hydra_spectrum_daemon.py
+    python3 scripts/hydra_spectrum_daemon.py --start 900 --stop 930
+    python3 scripts/hydra_spectrum_daemon.py --output /tmp/hydra_spectrum.json --interval 1.0
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import signal
+import statistics
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rf_power_scan import scan_once  # noqa: E402
+
+
+PRESETS = {
+    "915":  {"start": 900,  "stop": 930},
+    "433":  {"start": 430,  "stop": 440},
+    "2400": {"start": 2400, "stop": 2500},
+    "868":  {"start": 863,  "stop": 870},
+}
+
+DEFAULT_OUTPUT = "/tmp/hydra_spectrum.json"
+
+
+def find_peaks(samples, threshold_dbm, max_peaks=12, min_separation_mhz=1.0):
+    """Return top-N peaks above threshold, separated by min_separation_mhz."""
+    above = [(f, db) for (f, db) in samples if db >= threshold_dbm]
+    above.sort(key=lambda x: x[1], reverse=True)
+    chosen: list[tuple[float, float]] = []
+    for freq, db in above:
+        if all(abs(freq - f) >= min_separation_mhz for f, _ in chosen):
+            chosen.append((freq, db))
+            if len(chosen) >= max_peaks:
+                break
+    chosen.sort(key=lambda x: x[0])
+    return [{"freq_mhz": round(f, 4), "dbm": round(db, 2)} for f, db in chosen]
+
+
+def write_json_atomic(path: Path, payload: dict) -> None:
+    """Tempfile + rename so readers never see a partial file."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(prefix=path.name + ".", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w") as fh:
+            json.dump(payload, fh)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+def build_payload(start, stop, samples, sweep_count, threshold_delta_db,
+                  status="ok", error=None):
+    if not samples:
+        return {
+            "freq_low_mhz": start,
+            "freq_high_mhz": stop,
+            "noise_floor_dbm": None,
+            "threshold_dbm": None,
+            "bins": [],
+            "peaks": [],
+            "sweep_count": sweep_count,
+            "status": status,
+            "error": error,
+        }
+    db_values = [db for _, db in samples]
+    nf = statistics.median(db_values)
+    threshold = nf + threshold_delta_db
+    bins = [[round(f, 4), round(db, 2)] for f, db in samples]
+    peaks = find_peaks(samples, threshold)
+    return {
+        "freq_low_mhz": start,
+        "freq_high_mhz": stop,
+        "noise_floor_dbm": round(nf, 2),
+        "threshold_dbm": round(threshold, 2),
+        "bins": bins,
+        "peaks": peaks,
+        "sweep_count": sweep_count,
+        "status": status,
+        "error": error,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Hydra spectrum daemon (rtl_power -> JSON)")
+    parser.add_argument("--freq", choices=list(PRESETS.keys()),
+                        help="Preset frequency band (default: 2400)")
+    parser.add_argument("--start", type=float, help="Start frequency (MHz)")
+    parser.add_argument("--stop", type=float, help="Stop frequency (MHz)")
+    parser.add_argument("--step-khz", type=float, default=100.0,
+                        help="Bin width in kHz (default: 100)")
+    parser.add_argument("--interval", type=float, default=1.0,
+                        help="Seconds between sweeps (default: 1.0)")
+    parser.add_argument("--output", default=DEFAULT_OUTPUT,
+                        help=f"Output JSON path (default: {DEFAULT_OUTPUT})")
+    parser.add_argument("--threshold-delta-db", type=float, default=10.0,
+                        help="Peak threshold above noise floor in dB (default: 10)")
+    parser.add_argument("--retry-sleep", type=float, default=5.0,
+                        help="Sleep on no-data / error before retry (default: 5s)")
+    args = parser.parse_args()
+
+    if args.start is not None and args.stop is not None:
+        start, stop = args.start, args.stop
+    else:
+        preset = PRESETS[args.freq or "2400"]
+        start, stop = preset["start"], preset["stop"]
+
+    if stop <= start:
+        print("--stop must be greater than --start", file=sys.stderr)
+        sys.exit(2)
+
+    output = Path(args.output)
+    print(f"hydra-spectrum: {start}-{stop} MHz step={args.step_khz}kHz "
+          f"output={output}", flush=True)
+
+    running = True
+
+    def on_signal(sig, frame):
+        nonlocal running
+        running = False
+
+    signal.signal(signal.SIGINT, on_signal)
+    signal.signal(signal.SIGTERM, on_signal)
+
+    sweep_count = 0
+    while running:
+        loop_start = time.monotonic()
+        status = "ok"
+        error = None
+        samples = []
+        try:
+            samples = scan_once(start, stop, step_khz=args.step_khz)
+        except SystemExit:
+            status, error = "error", "rtl_power binary not found"
+        except Exception as exc:
+            status, error = "error", f"{type(exc).__name__}: {exc}"
+
+        if status == "ok" and not samples:
+            status = "no_sdr"
+            error = "rtl_power produced no samples (dongle unplugged or busy?)"
+
+        if samples:
+            sweep_count += 1
+
+        payload = build_payload(start, stop, samples, sweep_count,
+                                args.threshold_delta_db,
+                                status=status, error=error)
+        try:
+            write_json_atomic(output, payload)
+        except Exception as exc:
+            print(f"hydra-spectrum: failed to write {output}: {exc}",
+                  file=sys.stderr, flush=True)
+
+        if status != "ok":
+            time.sleep(args.retry_sleep)
+            continue
+
+        elapsed = time.monotonic() - loop_start
+        time.sleep(max(0.0, args.interval - elapsed))
+
+    print("hydra-spectrum: shutting down", flush=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Productionizes the data source that `GET /api/rf/spectrum` (added in #175) reads. Without this daemon, the dashboard SDR cell shows nothing on every Jetson except team-5, where it was being written by an ad-hoc `/tmp/hydra_spectrum_daemon.py` that died on the first reboot.

Stacked on top of #175 — this PR auto-rebases onto `main` once #175 merges.

## What's added

| File | Purpose |
|---|---|
| `scripts/hydra_spectrum_daemon.py` | runs `rtl_power` in a loop, computes noise floor + peaks, writes `/tmp/hydra_spectrum.json` atomically |
| `scripts/hydra-spectrum.service` | systemd unit, defaults to 2.4 GHz ISM at 1 Hz, env-file overridable |
| `scripts/README-hydra-spectrum.md` | install / configure / schema / conflicts |

## Design

- **Reuses `scan_once()` from `scripts/rf_power_scan.py`** — no duplicate `rtl_power` CSV parser. The new daemon is ~200 lines, mostly arg parsing and graceful-error plumbing.
- **Atomic writes** via tempfile + rename, so `web/server.py` never reads a partial JSON.
- **Graceful degradation:** missing dongle, missing `rtl_power` binary, or any other `scan_once` exception → writes `status="no_sdr"` / `status="error"` payload and sleeps. Never crashes, never blocks shutdown.
- **SIGTERM clean exit** for systemd `Restart=on-failure` semantics.
- **Schema matches the JS overlay** exactly: `{freq_low_mhz, freq_high_mhz, noise_floor_dbm, threshold_dbm, bins:[[mhz,dbm]], peaks:[{freq_mhz,dbm}], sweep_count, status, error}`. Endpoint wraps with `enabled: true` + `file_age_s`.

## Configure

Default = 2.4 GHz ISM (`2400–2500 MHz`, 100 kHz bins, 1 Hz). Override via `/etc/hydra/spectrum.env`:

```ini
HYDRA_SPECTRUM_FREQ=915          # preset: 433 / 868 / 915 / 2400
HYDRA_SPECTRUM_INTERVAL=1.0
HYDRA_SPECTRUM_OUTPUT=/tmp/hydra_spectrum.json
```

For arbitrary ranges run the script directly with `--start` / `--stop` / `--step-khz` and disable the unit.

## Conflicts

`rtl_power` opens the dongle exclusively. Don't run this alongside Kismet, `rtl_433`, or `scripts/rf_power_scan.py` against the same dongle. Hydra's RF Hunt subsystem uses Kismet, so on a single-SDR Jetson it's one or the other. Documented in the README. A multi-dongle setup (one for hunt, one for spectrum) avoids the conflict entirely.

## Test plan

- [x] `python3 -m py_compile scripts/hydra_spectrum_daemon.py` clean on team-5
- [x] Smoke run on team-5 with no SDR plugged in: starts cleanly, emits `{status: "no_sdr", bins: [], peaks: []}` per cycle, exits cleanly on SIGTERM
- [x] Output JSON parses and matches the schema the overlay expects
- [ ] Live test with SDR plugged in (deferred — no dongle on team-5 currently). Will confirm before merging.
- [ ] systemd unit install: `cp` + `daemon-reload` + `enable --now` (deferred until live SDR test)
- [ ] CI: pending

## Out of scope

- No automatic install in `scripts/hydra-setup.sh` — operator opts in by copying the `.service` file. Can fold into setup if/when this is universally useful.
- No multi-dongle device-id support yet — `rtl_power` defaults to device 0. Add `--device-index` flag when we actually have a multi-dongle Jetson.
