### PR TITLE
ci: build + publish hydra-detect to GHCR

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,56 @@
+name: Build and publish Docker image
+
+# Builds the Hydra Detect Docker image (linux/arm64, Jetson L4T R36.4 base)
+# and publishes it to GHCR so SORCC graduates can `docker pull` instead of
+# clone + build on their own Jetson. See sorcc-jetson-handoff/04-apps/hydra-detect/.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'requirements.txt'
+      - 'hydra_detect/**'
+      - '.github/workflows/build-image.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/hydra-detect
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short
+            type=ref,event=branch
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Adds `.github/workflows/build-image.yml` — builds the Hydra Detect Jetson image on every push to `main` and on manual dispatch, then publishes to `ghcr.io/rmeadomavic/hydra-detect` with `:latest`, `:sha-<short>`, and `:<branch>` tags.

Why: the new public `sorcc-jetson-handoff` repo (for SORCC graduates who keep their Jetson) currently does `git clone` + `docker build` per device, taking ~10 min and requiring a working build env on every Jetson. With this workflow live, the handoff `install.sh` will `docker pull` instead — first install drops to ~2 min and the build environment moves into CI.

Runs on a free `ubuntu-22.04-arm` runner so the image is genuine ARM64, not QEMU-emulated. GHA cache keeps repeat builds fast.

## Test plan

- [ ] Merge → workflow fires on push to `main`
- [ ] First run builds clean (no cache); takes ~10-15 min for the dustynv base pull
- [ ] Image appears at https://github.com/rmeadomavic/Hydra/pkgs/container/hydra-detect
- [ ] Set the package visibility to **public** in the GHCR UI (workflow can't do this for the first publish)
- [ ] Confirm a SORCC student can `docker pull ghcr.io/rmeadomavic/hydra-detect:latest` on a JP6 Jetson with no auth
- [ ] Re-run handoff `install.sh` (with the matching change in `sorcc-jetson-handoff`) and confirm it pulls instead of building