### PR TITLE
fix(rf-hunt): skip past geofence-rejected waypoints instead of stranding

### DIFF
--- a/hydra_detect/rf/hunt.py
+++ b/hydra_detect/rf/hunt.py
@@ -133,6 +133,20 @@ class RFHuntController:
         self._gps_required = gps_required
         self._check_geofence = geofence_check
         self._clip_to_geofence = geofence_clip
+
+        # Surface a likely misconfiguration early: a check callback without
+        # a clip callback means every out-of-fence waypoint is skipped,
+        # which — combined with the search-pattern advance logic — can strand
+        # the vehicle silently. Supported mode (some tests exercise it), so
+        # only a WARN, not a raise.
+        if geofence_check is not None and geofence_clip is None:
+            logger.warning(
+                "RFHuntController: geofence_check wired without geofence_clip. "
+                "Waypoints outside the fence will be skipped; the search loop "
+                "will advance past them but the vehicle may hover if every "
+                "remaining waypoint is suppressed. Pass geofence_clip too for "
+                "full coverage."
+            )
         self._consecutive_clips = 0
         self._MAX_CONSECUTIVE_CLIPS = 3
         self._consecutive_none = 0  # count of consecutive None RSSI reads in homing
@@ -482,19 +496,51 @@ class RFHuntController:
             check_lat, check_lon = self._effective_wp
         dist = haversine_m(lat, lon, check_lat, check_lon)
         if dist < self._arrival_tolerance:
+            # Arrived at current waypoint — advance to the next sendable one.
             self._wp_index += 1
-            self._effective_wp = None  # reset for next waypoint
-            if self._wp_index < len(self._waypoints):
-                nwp = self._waypoints[self._wp_index]
-                if not self._geofence_waypoint(nwp[0], nwp[1], nwp[2]):
-                    return
-                logger.debug(
-                    "Search WP %d/%d", self._wp_index, len(self._waypoints),
-                )
-        elif self._wp_index == 0 and self._effective_wp is None:
-            # Send first waypoint
-            if not self._geofence_waypoint(wp[0], wp[1], wp[2]):
+            self._effective_wp = None
+            self._advance_to_next_sendable_wp()
+        elif self._effective_wp is None:
+            # No waypoint has been commanded for the current index yet
+            # (first call, or the previous attempt was suppressed by the
+            # geofence). Try to send one now, skipping past any waypoints
+            # that can't be sent.
+            self._advance_to_next_sendable_wp()
+
+    def _advance_to_next_sendable_wp(self) -> None:
+        """Advance through waypoints until one is successfully commanded.
+
+        A waypoint can be suppressed when ``_check_geofence`` rejects it
+        and no ``_clip_to_geofence`` callback is wired. The previous
+        implementation sent exactly one waypoint per ``_do_search`` call
+        and returned silently on suppression — which left ``_wp_index``
+        advanced but no command sent, stranding the vehicle at its
+        current position until the entire pattern exhausted.
+
+        This helper loops forward through remaining waypoints until one
+        is sendable. If every remaining waypoint is suppressed, the loop
+        exits with ``_wp_index >= len(_waypoints)`` and the next
+        ``_do_search`` iteration hits the existing "pattern complete"
+        branch, aborting cleanly.
+
+        Also bails if a mid-loop state transition (e.g.
+        ``_geofence_waypoint`` pushing to CONVERGED after
+        ``_MAX_CONSECUTIVE_CLIPS``) moves the controller out of
+        ``SEARCHING``.
+        """
+        while self._wp_index < len(self._waypoints):
+            if self.state != HuntState.SEARCHING:
                 return
+            wp = self._waypoints[self._wp_index]
+            if self._geofence_waypoint(wp[0], wp[1], wp[2]):
+                logger.debug(
+                    "Search WP %d/%d",
+                    self._wp_index + 1, len(self._waypoints),
+                )
+                return
+            # Waypoint suppressed — advance and retry with the next one.
+            self._wp_index += 1
+            self._effective_wp = None
 
     def _do_homing(self) -> None:
         """Gradient ascent toward signal source."""

--- a/tests/test_rf_hunt_geofence_advance.py
+++ b/tests/test_rf_hunt_geofence_advance.py
@@ -1,0 +1,162 @@
+"""Regression tests for RF-hunt geofence waypoint skip-and-continue.
+
+Previously, if `_geofence_waypoint` rejected a waypoint (outside the
+fence with no clip callback wired), `_do_search` returned silently and
+the vehicle was stranded at its current position. The hunt then aborted
+with "no signal found" — a silent failure indistinguishable from a
+legitimate negative result.
+
+These tests verify that `_advance_to_next_sendable_wp` walks past
+suppressed waypoints until it finds a sendable one, and exits cleanly
+when every remaining waypoint is suppressed or a state transition
+interrupts the loop.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hydra_detect.rf.hunt import HuntState, RFHuntController
+
+
+def _make_mavlink():
+    mav = MagicMock()
+    mav.get_lat_lon.return_value = (34.05, -118.25, 50.0)
+    mav.connected = True
+    return mav
+
+
+def _make_controller(mav=None, **kwargs):
+    defaults = dict(
+        mode="wifi",
+        target_bssid="AA:BB:CC:DD:EE:FF",
+        kismet_host="http://localhost:2501",
+        poll_interval_sec=0.01,
+    )
+    defaults.update(kwargs)
+    return RFHuntController(mav or _make_mavlink(), **defaults)
+
+
+def test_advance_skips_suppressed_waypoint_and_sends_next():
+    """If wp[0] is rejected by geofence (no clip), helper must advance to wp[1]."""
+    mav = _make_mavlink()
+    # First waypoint outside fence, rest inside.
+    check_fn = MagicMock(side_effect=[False, True, True])
+    ctrl = _make_controller(mav=mav, geofence_check=check_fn, geofence_clip=None)
+    ctrl._waypoints = [
+        (34.10, -118.30, 15.0),  # outside
+        (34.05, -118.25, 15.0),  # inside
+        (34.06, -118.26, 15.0),  # inside
+    ]
+    ctrl._wp_index = 0
+    ctrl._set_state(HuntState.SEARCHING)
+
+    ctrl._advance_to_next_sendable_wp()
+
+    # wp_index should now point at the sent waypoint (index 1)
+    assert ctrl._wp_index == 1
+    # command_guided_to called exactly once with the second waypoint
+    mav.command_guided_to.assert_called_once_with(34.05, -118.25, 15.0)
+
+
+def test_advance_exhausts_without_sending_when_all_suppressed():
+    """All remaining waypoints outside fence, no clip → no send, wp_index past end."""
+    mav = _make_mavlink()
+    check_fn = MagicMock(return_value=False)  # all suppressed
+    ctrl = _make_controller(mav=mav, geofence_check=check_fn, geofence_clip=None)
+    ctrl._waypoints = [
+        (34.10, -118.30, 15.0),
+        (34.11, -118.31, 15.0),
+    ]
+    ctrl._wp_index = 0
+    ctrl._set_state(HuntState.SEARCHING)
+
+    ctrl._advance_to_next_sendable_wp()
+
+    assert ctrl._wp_index >= len(ctrl._waypoints)
+    mav.command_guided_to.assert_not_called()
+
+
+def test_advance_bails_on_state_transition_to_converged():
+    """When MAX_CONSECUTIVE_CLIPS triggers CONVERGED mid-loop, stop advancing."""
+    mav = _make_mavlink()
+    # Always outside; clip returns same coords (no real clipping)
+    check_fn = MagicMock(return_value=False)
+    clip_fn = MagicMock(side_effect=lambda la, lo: (la, lo))
+    ctrl = _make_controller(mav=mav, geofence_check=check_fn, geofence_clip=clip_fn)
+    ctrl._waypoints = [
+        (34.10, -118.30, 15.0),
+        (34.11, -118.31, 15.0),
+        (34.12, -118.32, 15.0),
+        (34.13, -118.33, 15.0),
+        (34.14, -118.34, 15.0),
+    ]
+    ctrl._wp_index = 0
+    ctrl._set_state(HuntState.SEARCHING)
+
+    ctrl._advance_to_next_sendable_wp()
+
+    # After _MAX_CONSECUTIVE_CLIPS (3) clips, state should flip to CONVERGED
+    # and the loop must bail rather than walk the whole pattern.
+    assert ctrl.state == HuntState.CONVERGED
+    assert ctrl._wp_index < len(ctrl._waypoints), (
+        "Loop did not bail on CONVERGED — advanced past the state transition"
+    )
+
+
+def test_advance_sends_first_waypoint_when_all_inside():
+    """Normal case: wp[0] inside fence, sends immediately."""
+    mav = _make_mavlink()
+    check_fn = MagicMock(return_value=True)
+    ctrl = _make_controller(mav=mav, geofence_check=check_fn, geofence_clip=None)
+    ctrl._waypoints = [(34.05, -118.25, 15.0), (34.06, -118.26, 15.0)]
+    ctrl._wp_index = 0
+    ctrl._set_state(HuntState.SEARCHING)
+
+    ctrl._advance_to_next_sendable_wp()
+
+    assert ctrl._wp_index == 0
+    mav.command_guided_to.assert_called_once_with(34.05, -118.25, 15.0)
+
+
+def test_advance_no_geofence_configured_sends_first():
+    """Without any geofence callback, helper sends the current waypoint directly."""
+    mav = _make_mavlink()
+    ctrl = _make_controller(mav=mav)  # no geofence_check
+    ctrl._waypoints = [(34.05, -118.25, 15.0)]
+    ctrl._wp_index = 0
+    ctrl._set_state(HuntState.SEARCHING)
+
+    ctrl._advance_to_next_sendable_wp()
+
+    mav.command_guided_to.assert_called_once_with(34.05, -118.25, 15.0)
+
+
+def test_misconfig_warn_on_check_without_clip(caplog):
+    """geofence_check without geofence_clip should log a WARNING at construction."""
+    import logging
+    caplog.set_level(logging.WARNING, logger="hydra_detect.rf.hunt")
+    _make_controller(geofence_check=MagicMock(return_value=True), geofence_clip=None)
+
+    assert any(
+        "geofence_clip" in rec.message and rec.levelno == logging.WARNING
+        for rec in caplog.records
+    ), f"Expected geofence misconfig WARNING; got {caplog.records}"
+
+
+def test_no_warn_when_both_wired(caplog):
+    """Both callbacks wired → no misconfig warning."""
+    import logging
+    caplog.set_level(logging.WARNING, logger="hydra_detect.rf.hunt")
+    _make_controller(
+        geofence_check=MagicMock(return_value=True),
+        geofence_clip=MagicMock(side_effect=lambda la, lo: (la, lo)),
+    )
+
+    geofence_warns = [
+        r for r in caplog.records
+        if "geofence_clip" in r.message and r.levelno == logging.WARNING
+    ]
+    assert geofence_warns == [], f"Unexpected warnings: {geofence_warns}"


### PR DESCRIPTION
## Summary
- RF hunt previously stranded the vehicle on the first waypoint rejected by the geofence
- Now skips rejected waypoints and continues to the next valid one

## Test plan
- [ ] Validate geofence rejection path in SITL with a hunt mission that crosses the fence
- [ ] Confirm normal hunt traversal still works for fully-inside waypoints