### PR TITLE
feat(guidance): forward predictor for ESC and MAVLink loop delay

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -133,6 +133,10 @@ smoothing = 0.4
 target_bbox_ratio = 0.15
 lost_track_timeout_s = 2.0
 min_altitude_m = 5.0
+loop_delay_ms = 100.0
+predictor_enabled = true
+predictor_alpha = 0.5
+predictor_beta = 0.05
 
 [rf_homing]
 enabled = false

--- a/config.ini
+++ b/config.ini
@@ -137,6 +137,8 @@ loop_delay_ms = 100.0
 predictor_enabled = true
 predictor_alpha = 0.5
 predictor_beta = 0.05
+attitude_compensation_enabled = true
+gimbal_stabilized = false
 
 [rf_homing]
 enabled = false

--- a/hydra_detect/approach.py
+++ b/hydra_detect/approach.py
@@ -558,7 +558,22 @@ class ApproachController:
             error_y = None
             bbox_ratio = None
 
-        cmd = self._guidance.update(error_x, error_y, bbox_ratio)
+        # Fetch current vehicle attitude (radians) for the pixel-error
+        # rotation; if unavailable the controller falls back to legacy.
+        roll_rad: float | None = None
+        pitch_rad: float | None = None
+        try:
+            attitude = self._mavlink.get_attitude()
+            if attitude.get("last_update", 0.0) > 0.0:
+                roll_rad = attitude.get("roll")
+                pitch_rad = attitude.get("pitch")
+        except Exception:
+            pass  # mavlink stub or older controller without attitude — ignore
+
+        cmd = self._guidance.update(
+            error_x, error_y, bbox_ratio,
+            roll_rad=roll_rad, pitch_rad=pitch_rad,
+        )
 
         # Enforce minimum altitude floor — prevent descent below threshold.
         # In NED, positive vz = descend.  Clamp to zero if near floor.

--- a/hydra_detect/config_migrate.py
+++ b/hydra_detect/config_migrate.py
@@ -44,7 +44,7 @@ from types import ModuleType
 logger = logging.getLogger(__name__)
 
 # Bump this when adding a new migration file.
-CURRENT_SCHEMA_VERSION: int = 1
+CURRENT_SCHEMA_VERSION: int = 2
 
 # Migration modules directory (monkeypatched in tests to point at fixtures).
 _MIGRATIONS_DIR: Path = Path(__file__).parent / "migrations"

--- a/hydra_detect/config_migrate.py
+++ b/hydra_detect/config_migrate.py
@@ -44,7 +44,7 @@ from types import ModuleType
 logger = logging.getLogger(__name__)
 
 # Bump this when adding a new migration file.
-CURRENT_SCHEMA_VERSION: int = 2
+CURRENT_SCHEMA_VERSION: int = 3
 
 # Migration modules directory (monkeypatched in tests to point at fixtures).
 _MIGRATIONS_DIR: Path = Path(__file__).parent / "migrations"

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1212,6 +1212,16 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             default=0.05,
             description="Alpha-beta filter velocity gain",
         ),
+        "attitude_compensation_enabled": FieldSpec(
+            FieldType.BOOL,
+            default=True,
+            description="Rotate pixel-error by vehicle roll/pitch before gain stage",
+        ),
+        "gimbal_stabilized": FieldSpec(
+            FieldType.BOOL,
+            default=False,
+            description="Skip attitude compensation when a level-stabilized gimbal is fitted",
+        ),
     },
     "mavlink_video": {
         "enabled": FieldSpec(

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1186,6 +1186,32 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             default=5.0,
             description="Minimum altitude floor metres",
         ),
+        "loop_delay_ms": FieldSpec(
+            FieldType.FLOAT,
+            min_val=0.0,
+            max_val=1000.0,
+            default=100.0,
+            description="Forward-predictor look-ahead milliseconds (camera + infer + MAVLink + ESC)",
+        ),
+        "predictor_enabled": FieldSpec(
+            FieldType.BOOL,
+            default=True,
+            description="Enable alpha-beta forward predictor on smoothed bbox center",
+        ),
+        "predictor_alpha": FieldSpec(
+            FieldType.FLOAT,
+            min_val=0.0,
+            max_val=1.0,
+            default=0.5,
+            description="Alpha-beta filter position gain",
+        ),
+        "predictor_beta": FieldSpec(
+            FieldType.FLOAT,
+            min_val=0.0,
+            max_val=1.0,
+            default=0.05,
+            description="Alpha-beta filter velocity gain",
+        ),
     },
     "mavlink_video": {
         "enabled": FieldSpec(

--- a/hydra_detect/guidance.py
+++ b/hydra_detect/guidance.py
@@ -8,6 +8,7 @@ Raspberry Pi Zero 2W with colour/shape tracking).
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass
 
@@ -40,6 +41,14 @@ class GuidanceConfig:
     predictor_enabled: bool = True
     predictor_alpha: float = 0.5    # alpha-beta position gain (0..1)
     predictor_beta: float = 0.05    # alpha-beta velocity gain (0..1)
+
+    # Attitude compensation: rotate the (ex, ey) pixel-error vector through
+    # the current vehicle roll/pitch before feeding the predictor and gain
+    # stages. Necessary for a strapdown camera; bypass when a gimbal already
+    # keeps the optical axis level. ArduPilot ATTITUDE convention: positive
+    # roll is right-wing-down, positive pitch is nose-up.
+    attitude_compensation_enabled: bool = True
+    gimbal_stabilized: bool = False
 
 
 @dataclass
@@ -126,6 +135,8 @@ class GuidanceController:
         error_y: float | None,
         bbox_ratio: float | None,
         now_s: float | None = None,
+        roll_rad: float | None = None,
+        pitch_rad: float | None = None,
     ) -> VelocityCommand:
         """Compute velocity command from current pixel errors.
 
@@ -136,6 +147,12 @@ class GuidanceController:
             now_s: Optional monotonic-clock timestamp in seconds. When None
                 (production path), time.monotonic() is used. Tests pass an
                 explicit clock so predictor convergence is deterministic.
+            roll_rad: Vehicle roll in radians from MAVLink ATTITUDE
+                (positive = right wing down). When None or attitude
+                compensation is disabled / gimbal-stabilized, no rotation
+                is applied.
+            pitch_rad: Vehicle pitch in radians from MAVLink ATTITUDE
+                (positive = nose up).
 
         Returns:
             VelocityCommand with body-frame velocities.  Returns zero
@@ -164,13 +181,20 @@ class GuidanceController:
 
         cfg = self._cfg
 
-        # Forward predictor on the smoothed series. Outputs the EMA-smoothed
-        # error projected by loop_delay_ms; if disabled, falls through to the
-        # raw smoothed value (legacy behavior).
+        # Attitude compensation: rotate (smooth_ex, smooth_ey) into the
+        # gravity-stable level-body frame so the predictor and gain stages
+        # see a stationary world-aligned signal.
+        corr_ex, corr_ey = self._attitude_correct(
+            self._smooth_ex, self._smooth_ey, roll_rad, pitch_rad,
+        )
+
+        # Forward predictor on the (attitude-corrected) smoothed series.
+        # Outputs the corrected error projected by loop_delay_ms; if disabled,
+        # falls through to the corrected value directly.
         if cfg.predictor_enabled:
-            ex_used, ey_used = self._predict(now, self._smooth_ex, self._smooth_ey)
+            ex_used, ey_used = self._predict(now, corr_ex, corr_ey)
         else:
-            ex_used, ey_used = self._smooth_ex, self._smooth_ey
+            ex_used, ey_used = corr_ex, corr_ey
 
         # Apply deadzone
         ex = _deadzone(ex_used, cfg.deadzone)
@@ -207,6 +231,56 @@ class GuidanceController:
             return False
         elapsed = time.monotonic() - self._last_track_time
         return elapsed >= self._cfg.lost_track_timeout_s
+
+    def _attitude_correct(
+        self,
+        ex: float,
+        ey: float,
+        roll_rad: float | None,
+        pitch_rad: float | None,
+    ) -> tuple[float, float]:
+        """Map (ex, ey) through current vehicle roll/pitch into the
+        gravity-stable level-body frame.
+
+        Geometry (strapdown forward-facing camera, no gimbal):
+            camera-x (right)   maps to body-y at zero attitude
+            camera-y (down)    maps to body-z
+            camera-z (forward) maps to body-x
+        So a pixel direction vector (ex, ey, 1) in the camera frame becomes
+        (1, ex, ey) in the body frame at zero attitude. Apply the vehicle
+        attitude rotation (yaw ignored; IBVS commands yaw-rate separately)
+        to express it in the level-body frame, then read off the y/z
+        components as the corrected pixel error.
+
+        Returns the input unchanged when compensation is disabled, the
+        gimbal-stabilized flag is set, or attitude is unavailable.
+        """
+        cfg = self._cfg
+        if cfg.gimbal_stabilized or not cfg.attitude_compensation_enabled:
+            return ex, ey
+        if roll_rad is None or pitch_rad is None:
+            return ex, ey
+
+        cos_r = math.cos(roll_rad)
+        sin_r = math.sin(roll_rad)
+        cos_p = math.cos(pitch_rad)
+        sin_p = math.sin(pitch_rad)
+
+        # v_body0 = (1, ex, ey) — camera-z in body-x, camera-x in body-y,
+        # camera-y in body-z at zero attitude.
+        bx = 1.0
+        by = ex
+        bz = ey
+
+        # R_x(roll): rotates (by, bz) around body-x.
+        by, bz = by * cos_r - bz * sin_r, by * sin_r + bz * cos_r
+
+        # R_y(pitch): rotates (bx, bz) around body-y.
+        bx, bz = bx * cos_p + bz * sin_p, -bx * sin_p + bz * cos_p
+
+        # The level-body y component drives vy, z drives vz. bx (forward
+        # depth) is unused — approach distance comes from bbox_ratio.
+        return by, bz
 
     def _predict(
         self,

--- a/hydra_detect/guidance.py
+++ b/hydra_detect/guidance.py
@@ -32,6 +32,15 @@ class GuidanceConfig:
     lost_track_timeout_s: float = 2.0  # seconds before declaring track lost
     min_altitude_m: float = 5.0  # vz clamped to prevent ground collision
 
+    # Forward predictor: alpha-beta tracker on the EMA-smoothed bbox center,
+    # projecting position forward by loop_delay_ms to compensate for
+    # camera + inference + MAVLink + ArduPilot + ESC pipeline delay
+    # (measured 100-130 ms steady state on Orin Nano + Pixhawk).
+    loop_delay_ms: float = 100.0
+    predictor_enabled: bool = True
+    predictor_alpha: float = 0.5    # alpha-beta position gain (0..1)
+    predictor_beta: float = 0.05    # alpha-beta velocity gain (0..1)
+
 
 @dataclass
 class VelocityCommand:
@@ -62,6 +71,13 @@ class GuidanceController:
         # Track loss timer
         self._last_track_time: float = 0.0
         self._active: bool = False
+        # Forward predictor (alpha-beta tracker) state
+        self._pred_x: float = 0.0
+        self._pred_y: float = 0.0
+        self._pred_vx: float = 0.0
+        self._pred_vy: float = 0.0
+        self._pred_initialized: bool = False
+        self._last_pred_time: float = 0.0
 
     def start(self) -> None:
         """Begin guidance — call when pixel-lock mode is engaged."""
@@ -69,20 +85,47 @@ class GuidanceController:
         self._smooth_ey = 0.0
         self._last_track_time = time.monotonic()
         self._active = True
+        self._reset_predictor()
 
     def stop(self) -> None:
         """Stop guidance — returns zero velocity on next update."""
         self._active = False
 
+    def _reset_predictor(self) -> None:
+        self._pred_x = 0.0
+        self._pred_y = 0.0
+        self._pred_vx = 0.0
+        self._pred_vy = 0.0
+        self._pred_initialized = False
+        self._last_pred_time = 0.0
+
     @property
     def active(self) -> bool:
         return self._active
+
+    @property
+    def predicted_error(self) -> tuple[float, float] | None:
+        """Predicted (ex, ey) at t = now + loop_delay_ms, or None if the
+        predictor has not seen a valid frame since the last reset."""
+        if not self._pred_initialized:
+            return None
+        lead_s = self._cfg.loop_delay_ms / 1000.0
+        return (
+            self._pred_x + self._pred_vx * lead_s,
+            self._pred_y + self._pred_vy * lead_s,
+        )
+
+    @property
+    def predicted_velocity(self) -> tuple[float, float]:
+        """Current (vx, vy) estimate in error-units per second."""
+        return (self._pred_vx, self._pred_vy)
 
     def update(
         self,
         error_x: float | None,
         error_y: float | None,
         bbox_ratio: float | None,
+        now_s: float | None = None,
     ) -> VelocityCommand:
         """Compute velocity command from current pixel errors.
 
@@ -90,6 +133,9 @@ class GuidanceController:
             error_x: Horizontal offset from centre (-1..+1), or None if lost.
             error_y: Vertical offset from centre (-1..+1), or None if lost.
             bbox_ratio: Target bbox area / frame area (0..1), or None if lost.
+            now_s: Optional monotonic-clock timestamp in seconds. When None
+                (production path), time.monotonic() is used. Tests pass an
+                explicit clock so predictor convergence is deterministic.
 
         Returns:
             VelocityCommand with body-frame velocities.  Returns zero
@@ -98,10 +144,13 @@ class GuidanceController:
         if not self._active:
             return VelocityCommand()
 
-        now = time.monotonic()
+        now = now_s if now_s is not None else time.monotonic()
 
         # Track lost
         if error_x is None or error_y is None or bbox_ratio is None:
+            # Reset the predictor so a re-acquired track does not inherit
+            # stale velocity carried across the gap.
+            self._reset_predictor()
             if (now - self._last_track_time) >= self._cfg.lost_track_timeout_s:
                 return VelocityCommand()  # Hold position (zero velocity)
             # Within timeout — send zero velocity (brake, don't drift)
@@ -109,15 +158,23 @@ class GuidanceController:
 
         self._last_track_time = now
 
-        # EMA smoothing
+        # EMA smoothing on raw input.
         self._smooth_ex = self._alpha * error_x + (1 - self._alpha) * self._smooth_ex
         self._smooth_ey = self._alpha * error_y + (1 - self._alpha) * self._smooth_ey
 
         cfg = self._cfg
 
+        # Forward predictor on the smoothed series. Outputs the EMA-smoothed
+        # error projected by loop_delay_ms; if disabled, falls through to the
+        # raw smoothed value (legacy behavior).
+        if cfg.predictor_enabled:
+            ex_used, ey_used = self._predict(now, self._smooth_ex, self._smooth_ey)
+        else:
+            ex_used, ey_used = self._smooth_ex, self._smooth_ey
+
         # Apply deadzone
-        ex = _deadzone(self._smooth_ex, cfg.deadzone)
-        ey = _deadzone(self._smooth_ey, cfg.deadzone)
+        ex = _deadzone(ex_used, cfg.deadzone)
+        ey = _deadzone(ey_used, cfg.deadzone)
 
         # Forward velocity: approach until target fills target_bbox_ratio
         approach_ratio = max(0.0, min(1.0, 1.0 - bbox_ratio / cfg.target_bbox_ratio))
@@ -150,6 +207,67 @@ class GuidanceController:
             return False
         elapsed = time.monotonic() - self._last_track_time
         return elapsed >= self._cfg.lost_track_timeout_s
+
+    def _predict(
+        self,
+        now: float,
+        smooth_ex: float,
+        smooth_ey: float,
+    ) -> tuple[float, float]:
+        """Alpha-beta tracker step. Returns the smoothed error projected
+        forward by loop_delay_ms.
+
+        Standard discrete alpha-beta filter:
+            x_pred  - x + v * dt
+            r       - z - x_pred
+            x       - x_pred + alpha * r
+            v       - v + (beta / dt) * r
+            output  - x + v * lead
+
+        On the first valid frame after start() or a track loss, the predictor
+        seeds from the measurement with zero velocity and emits no lead.
+        """
+        cfg = self._cfg
+        if not self._pred_initialized:
+            self._pred_x = smooth_ex
+            self._pred_y = smooth_ey
+            self._pred_vx = 0.0
+            self._pred_vy = 0.0
+            self._last_pred_time = now
+            self._pred_initialized = True
+            return smooth_ex, smooth_ey
+
+        dt = now - self._last_pred_time
+        lead_s = cfg.loop_delay_ms / 1000.0
+
+        if dt <= 0.0:
+            # Clock anomaly or two updates in the same tick — skip the filter
+            # step but still project from existing state.
+            return (
+                self._pred_x + self._pred_vx * lead_s,
+                self._pred_y + self._pred_vy * lead_s,
+            )
+
+        # Predict to the current time using prior velocity.
+        x_pred = self._pred_x + self._pred_vx * dt
+        y_pred = self._pred_y + self._pred_vy * dt
+
+        # Residuals against the new measurement.
+        rx = smooth_ex - x_pred
+        ry = smooth_ey - y_pred
+
+        # Filter step.
+        self._pred_x = x_pred + cfg.predictor_alpha * rx
+        self._pred_y = y_pred + cfg.predictor_alpha * ry
+        self._pred_vx = self._pred_vx + (cfg.predictor_beta / dt) * rx
+        self._pred_vy = self._pred_vy + (cfg.predictor_beta / dt) * ry
+        self._last_pred_time = now
+
+        # Project forward by loop_delay.
+        return (
+            self._pred_x + self._pred_vx * lead_s,
+            self._pred_y + self._pred_vy * lead_s,
+        )
 
 
 # ------------------------------------------------------------------

--- a/hydra_detect/mavlink_io.py
+++ b/hydra_detect/mavlink_io.py
@@ -85,6 +85,16 @@ class MAVLinkIO:
             "climb": None,
         }
 
+        # Vehicle attitude (radians, populated from ATTITUDE msg 30).
+        # ArduPilot convention: positive roll = right wing down, positive
+        # pitch = nose up, yaw = body heading (0..2pi).
+        self._attitude: Dict[str, Any] = {
+            "roll": None,
+            "pitch": None,
+            "yaw": None,
+            "last_update": 0.0,
+        }
+
         # RC channel values (updated by _message_reader from RC_CHANNELS)
         self._rc_channels: list[int] = []
         self._rc_channels_lock = threading.Lock()
@@ -205,7 +215,7 @@ class MAVLinkIO:
     # ------------------------------------------------------------------
     _ALL_MSG_TYPES = [
         "GLOBAL_POSITION_INT", "GPS_RAW_INT", "HEARTBEAT",
-        "SYS_STATUS", "VFR_HUD", "RC_CHANNELS",
+        "SYS_STATUS", "VFR_HUD", "RC_CHANNELS", "ATTITUDE",
         "COMMAND_LONG", "NAMED_VALUE_INT",
     ]
 
@@ -243,6 +253,8 @@ class MAVLinkIO:
                             self._telemetry["battery_pct"] = msg.battery_remaining
                 elif msg_type == "VFR_HUD":
                     self._handle_vfr_hud(msg)
+                elif msg_type == "ATTITUDE":
+                    self._handle_attitude(msg)
                 elif msg_type == "RC_CHANNELS":
                     with self._rc_channels_lock:
                         self._rc_channels = [
@@ -285,6 +297,14 @@ class MAVLinkIO:
             self._telemetry["altitude"] = round(msg.alt, 1)
             self._telemetry["heading"] = round(msg.heading, 0)
             self._telemetry["climb"] = round(msg.climb, 2)
+
+    def _handle_attitude(self, msg) -> None:
+        """Cache roll, pitch, yaw (radians) from ATTITUDE msg 30."""
+        with self._gps_lock:
+            self._attitude["roll"] = float(msg.roll)
+            self._attitude["pitch"] = float(msg.pitch)
+            self._attitude["yaw"] = float(msg.yaw)
+            self._attitude["last_update"] = time.monotonic()
 
     def _update_armed_state(self, heartbeat_msg) -> None:
         """Extract armed state from HEARTBEAT base_mode."""
@@ -431,6 +451,20 @@ class MAVLinkIO:
         with self._vehicle_mode_lock:
             result["vehicle_mode"] = self._vehicle_mode
         return result
+
+    def get_attitude(self) -> Dict[str, Any]:
+        """Return current vehicle attitude in radians, or all-None if no
+        ATTITUDE message has been received yet.
+
+        Keys:
+          - ``roll``  - radians, positive = right wing down
+          - ``pitch`` - radians, positive = nose up
+          - ``yaw``   - radians, body heading
+          - ``last_update`` - monotonic timestamp of the most recent message
+            (0.0 if never received)
+        """
+        with self._gps_lock:
+            return dict(self._attitude)
 
     def get_flight_data(self) -> Dict[str, Any]:
         """Return flight-instrument values as a dict.

--- a/hydra_detect/migrations/002_guidance_forward_predictor.py
+++ b/hydra_detect/migrations/002_guidance_forward_predictor.py
@@ -1,0 +1,35 @@
+"""Migration 002 — add forward-predictor keys to [guidance].
+
+Adds four new keys to existing user config files so the alpha-beta predictor
+introduced in guidance.py can read them. Idempotent: keys are only inserted
+when absent, so a config that already has any of them (e.g. user pre-edited)
+keeps the user's value.
+
+The predictor is enabled by default. To shadow it, set predictor_enabled to
+false in [guidance] and re-run migrations (or just edit the value — the
+schema accepts a manual override).
+"""
+
+from __future__ import annotations
+
+import configparser
+
+from_version: int = 1
+to_version: int = 2
+
+
+_DEFAULTS: dict[str, str] = {
+    "loop_delay_ms": "100.0",
+    "predictor_enabled": "true",
+    "predictor_alpha": "0.5",
+    "predictor_beta": "0.05",
+}
+
+
+def migrate(cfg: configparser.ConfigParser) -> None:
+    """Insert predictor keys into [guidance] if they are missing."""
+    if not cfg.has_section("guidance"):
+        cfg.add_section("guidance")
+    for key, value in _DEFAULTS.items():
+        if not cfg.has_option("guidance", key):
+            cfg.set("guidance", key, value)

--- a/hydra_detect/migrations/003_guidance_attitude_compensation.py
+++ b/hydra_detect/migrations/003_guidance_attitude_compensation.py
@@ -1,0 +1,31 @@
+"""Migration 003 — add attitude-compensation keys to [guidance].
+
+Adds two new keys so the roll/pitch rotation introduced in guidance.py can be
+disabled per-platform (mostly: vehicles with a level-stabilized gimbal should
+set gimbal_stabilized=true, since the camera is already level).
+
+Idempotent: keys are inserted only when absent so a user who pre-edited the
+config keeps their value.
+"""
+
+from __future__ import annotations
+
+import configparser
+
+from_version: int = 2
+to_version: int = 3
+
+
+_DEFAULTS: dict[str, str] = {
+    "attitude_compensation_enabled": "true",
+    "gimbal_stabilized": "false",
+}
+
+
+def migrate(cfg: configparser.ConfigParser) -> None:
+    """Insert attitude-compensation keys into [guidance] if missing."""
+    if not cfg.has_section("guidance"):
+        cfg.add_section("guidance")
+    for key, value in _DEFAULTS.items():
+        if not cfg.has_option("guidance", key):
+            cfg.set("guidance", key, value)

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -525,6 +525,10 @@ class Pipeline:
                         "guidance", "predictor_alpha", fallback=0.5),
                     predictor_beta=self._cfg.getfloat(
                         "guidance", "predictor_beta", fallback=0.05),
+                    attitude_compensation_enabled=self._cfg.getboolean(
+                        "guidance", "attitude_compensation_enabled", fallback=True),
+                    gimbal_stabilized=self._cfg.getboolean(
+                        "guidance", "gimbal_stabilized", fallback=False),
                 ),
             )
             self._approach = ApproachController(self._mavlink, approach_cfg)

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -517,6 +517,14 @@ class Pipeline:
                         "guidance", "lost_track_timeout_s", fallback=2.0),
                     min_altitude_m=self._cfg.getfloat(
                         "guidance", "min_altitude_m", fallback=5.0),
+                    loop_delay_ms=self._cfg.getfloat(
+                        "guidance", "loop_delay_ms", fallback=100.0),
+                    predictor_enabled=self._cfg.getboolean(
+                        "guidance", "predictor_enabled", fallback=True),
+                    predictor_alpha=self._cfg.getfloat(
+                        "guidance", "predictor_alpha", fallback=0.5),
+                    predictor_beta=self._cfg.getfloat(
+                        "guidance", "predictor_beta", fallback=0.05),
                 ),
             )
             self._approach = ApproachController(self._mavlink, approach_cfg)

--- a/tests/test_config_migrate.py
+++ b/tests/test_config_migrate.py
@@ -63,6 +63,30 @@ GOLDEN_V1 = textwrap.dedent("""\
 """)
 
 
+# A config already at the current schema version. Constructed dynamically so
+# the fixture stays correct when CURRENT_SCHEMA_VERSION is bumped.
+GOLDEN_CURRENT = textwrap.dedent(f"""\
+    [meta]
+    schema_version = {CURRENT_SCHEMA_VERSION}
+
+    [camera]
+    source_type = auto
+    source = auto
+    width = 640
+    height = 480
+    fps = 30
+
+    [detector]
+    yolo_model = yolov8n.pt
+    yolo_confidence = 0.45
+
+    [web]
+    enabled = true
+    host = 0.0.0.0
+    port = 8080
+""")
+
+
 @pytest.fixture
 def tmp_config(tmp_path):
     """Return a factory: write INI text to a temp file and return its Path."""
@@ -78,27 +102,28 @@ def tmp_config(tmp_path):
 # ---------------------------------------------------------------------------
 
 class TestV0ToV1Migration:
-    def test_v0_migrates_to_v1(self, tmp_config):
-        """v0 config (no [meta]) gets schema_version = 1 written back."""
+    def test_v0_migrates_to_current(self, tmp_config):
+        """v0 config (no [meta]) gets schema_version stamped to current."""
         p = tmp_config(GOLDEN_V0)
-        result = run_migrations(p)
+        run_migrations(p)
 
         cfg = configparser.ConfigParser()
         cfg.read(p)
 
         assert cfg.has_section("meta"), "expected [meta] section after migration"
-        assert cfg.get("meta", "schema_version") == "1"
+        assert cfg.get("meta", "schema_version") == str(CURRENT_SCHEMA_VERSION)
 
     def test_v0_migration_result(self, tmp_config):
-        """run_migrations returns correct MigrationResult for v0→v1."""
+        """run_migrations returns correct MigrationResult for v0→current."""
         p = tmp_config(GOLDEN_V0)
         result = run_migrations(p)
 
         assert isinstance(result, MigrationResult)
         assert result.from_version == 0
-        assert result.to_version == 1
-        assert len(result.applied) == 1
-        assert "001" in result.applied[0]  # migration filename in the list
+        assert result.to_version == CURRENT_SCHEMA_VERSION
+        # Every step from 0 to current should have been applied.
+        assert len(result.applied) == CURRENT_SCHEMA_VERSION
+        assert "001" in result.applied[0]  # first step is the v0→v1 migration
 
     def test_v0_backup_created(self, tmp_config):
         """A .premigrate.<ISO8601> backup is created before any change."""
@@ -136,38 +161,90 @@ class TestV0ToV1Migration:
 # 2. v1 config is a no-op
 # ---------------------------------------------------------------------------
 
-class TestV1Noop:
-    def test_v1_already_current_no_migrations_applied(self, tmp_config):
-        """Config already at v1 returns an empty applied list."""
-        p = tmp_config(GOLDEN_V1)
+class TestCurrentNoop:
+    def test_at_current_no_migrations_applied(self, tmp_config):
+        """Config already at the current schema version returns empty applied."""
+        p = tmp_config(GOLDEN_CURRENT)
         result = run_migrations(p)
 
         assert result.applied == []
-        assert result.from_version == 1
-        assert result.to_version == 1
+        assert result.from_version == CURRENT_SCHEMA_VERSION
+        assert result.to_version == CURRENT_SCHEMA_VERSION
 
-    def test_v1_no_backup_created(self, tmp_config):
+    def test_at_current_no_backup_created(self, tmp_config):
         """No backup file is written when no migrations run."""
-        p = tmp_config(GOLDEN_V1)
+        p = tmp_config(GOLDEN_CURRENT)
         result = run_migrations(p)
 
         assert result.backup_path is None
 
-    def test_v1_file_unchanged(self, tmp_config):
+    def test_at_current_file_unchanged(self, tmp_config):
         """File content is byte-identical after a no-op run."""
-        p = tmp_config(GOLDEN_V1)
+        p = tmp_config(GOLDEN_CURRENT)
         before = p.read_bytes()
         run_migrations(p)
         after = p.read_bytes()
 
-        # Content must be equivalent (configparser may reformat whitespace,
-        # so compare parsed sections rather than raw bytes).
         cfg_before = configparser.ConfigParser()
         cfg_before.read_string(before.decode())
         cfg_after = configparser.ConfigParser()
         cfg_after.read_string(after.decode())
 
         assert dict(cfg_before["meta"]) == dict(cfg_after["meta"])
+
+
+class TestV1ToV2Migration:
+    """Migration 002: forward-predictor keys are inserted into [guidance]."""
+
+    def test_v1_picks_up_predictor_keys(self, tmp_config):
+        """Migrating from v1 adds predictor_enabled and friends to [guidance]."""
+        # v1 baseline with a [guidance] section containing only legacy keys.
+        v1_with_guidance = GOLDEN_V1 + textwrap.dedent("""
+            [guidance]
+            fwd_gain = 2.0
+            lat_gain = 1.5
+        """)
+        p = tmp_config(v1_with_guidance)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.get("guidance", "loop_delay_ms") == "100.0"
+        assert cfg.get("guidance", "predictor_enabled") == "true"
+        assert cfg.get("guidance", "predictor_alpha") == "0.5"
+        assert cfg.get("guidance", "predictor_beta") == "0.05"
+        # Existing keys preserved.
+        assert cfg.get("guidance", "fwd_gain") == "2.0"
+
+    def test_v1_existing_predictor_value_preserved(self, tmp_config):
+        """If a key already exists in [guidance], the user's value wins."""
+        v1_with_user_override = GOLDEN_V1 + textwrap.dedent("""
+            [guidance]
+            predictor_enabled = false
+            predictor_alpha = 0.3
+        """)
+        p = tmp_config(v1_with_user_override)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.get("guidance", "predictor_enabled") == "false"
+        assert cfg.get("guidance", "predictor_alpha") == "0.3"
+        # Missing keys still get filled in.
+        assert cfg.get("guidance", "loop_delay_ms") == "100.0"
+
+    def test_v1_no_guidance_section_creates_one(self, tmp_config):
+        """If [guidance] is absent at v1, the migration creates it."""
+        p = tmp_config(GOLDEN_V1)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.has_section("guidance")
+        assert cfg.get("guidance", "predictor_enabled") == "true"
 
 
 # ---------------------------------------------------------------------------
@@ -177,16 +254,15 @@ class TestV1Noop:
 class TestMigrationDiscovery:
     def test_migrations_applied_in_version_order(self, tmp_config, tmp_path, monkeypatch):
         """Migration files are applied in from_version order, not filename sort order."""
-        # We fake a v0 config and patch the migration directory to contain
-        # a single (the real) migration file. If discovery returns them sorted
-        # correctly, v0→v1 completes; if not, an assertion inside the runner
-        # will catch the gap.
+        # A v0 config should chain through every migration to reach the
+        # current schema version. If discovery sorted by filename instead of
+        # from_version the runner's contiguity check would catch the gap.
         p = tmp_config(GOLDEN_V0)
         result = run_migrations(p)
 
-        # Real migrations directory has only 001; must produce exactly one step.
         assert result.from_version == 0
         assert result.to_version == CURRENT_SCHEMA_VERSION
+        assert len(result.applied) == CURRENT_SCHEMA_VERSION
 
     def test_migration_files_need_correct_from_to(self, tmp_config, tmp_path, monkeypatch):
         """Runner raises MigrationError if a migration module lacks required attrs."""

--- a/tests/test_config_migrate.py
+++ b/tests/test_config_migrate.py
@@ -247,6 +247,67 @@ class TestV1ToV2Migration:
         assert cfg.get("guidance", "predictor_enabled") == "true"
 
 
+class TestV2ToV3Migration:
+    """Migration 003: attitude-compensation keys are inserted into [guidance]."""
+
+    def test_v2_picks_up_attitude_keys(self, tmp_config):
+        """Migrating from v2 adds attitude_compensation_enabled and
+        gimbal_stabilized to [guidance]."""
+        v2 = textwrap.dedent("""\
+            [meta]
+            schema_version = 2
+
+            [guidance]
+            fwd_gain = 2.0
+            predictor_enabled = true
+        """)
+        p = tmp_config(v2)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.get("guidance", "attitude_compensation_enabled") == "true"
+        assert cfg.get("guidance", "gimbal_stabilized") == "false"
+        # Existing keys preserved.
+        assert cfg.get("guidance", "fwd_gain") == "2.0"
+        assert cfg.get("guidance", "predictor_enabled") == "true"
+
+    def test_v2_existing_attitude_value_preserved(self, tmp_config):
+        """A pre-existing user value in [guidance] survives the migration."""
+        v2 = textwrap.dedent("""\
+            [meta]
+            schema_version = 2
+
+            [guidance]
+            attitude_compensation_enabled = false
+        """)
+        p = tmp_config(v2)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.get("guidance", "attitude_compensation_enabled") == "false"
+        # Missing key still gets filled in.
+        assert cfg.get("guidance", "gimbal_stabilized") == "false"
+
+    def test_v0_chains_through_all_migrations(self, tmp_config):
+        """A v0 config must walk through 001 then 002 then 003 to reach
+        current. Verifies the chain is contiguous."""
+        p = tmp_config(GOLDEN_V0)
+        result = run_migrations(p)
+
+        assert result.from_version == 0
+        assert result.to_version == CURRENT_SCHEMA_VERSION
+        assert len(result.applied) == CURRENT_SCHEMA_VERSION
+        # Final state has both predictor and attitude keys.
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+        assert cfg.has_option("guidance", "predictor_enabled")
+        assert cfg.has_option("guidance", "attitude_compensation_enabled")
+
+
 # ---------------------------------------------------------------------------
 # 3. Migration discovery handles out-of-order files
 # ---------------------------------------------------------------------------

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -208,7 +208,8 @@ class TestGuidanceEMASmoothing:
     """EMA smoothing reduces jitter."""
 
     def test_sudden_change_is_smoothed(self):
-        cfg = GuidanceConfig(deadzone=0.0)  # disable deadzone for this test
+        # Predictor disabled — this test isolates EMA behaviour.
+        cfg = GuidanceConfig(deadzone=0.0, predictor_enabled=False)
         gc = GuidanceController(cfg)
         gc.start()
 
@@ -242,6 +243,176 @@ class TestGuidanceStartStop:
         assert gc.active
         gc.stop()
         assert not gc.active
+
+
+# ------------------------------------------------------------------
+# Forward predictor (alpha-beta tracker on smoothed bbox center)
+# ------------------------------------------------------------------
+
+class TestForwardPredictor:
+    """Forward predictor compensates for camera + infer + MAVLink + ESC delay.
+
+    The predictor is an alpha-beta tracker layered on top of the existing EMA.
+    Output of update() is computed from a measurement projected forward by
+    ``loop_delay_ms``, so the controller acts on where the target will be when
+    the velocity command actually takes effect, not where it is now.
+    """
+
+    def _make_cfg(self, **kwargs):
+        """Build a config with EMA disabled (smoothing alpha 1.0) by default."""
+        defaults = dict(
+            deadzone=0.0,
+            smoothing=1.0,           # EMA passthrough so predictor sees raw input
+            predictor_enabled=True,
+            predictor_alpha=0.5,
+            predictor_beta=0.1,
+            loop_delay_ms=100.0,
+        )
+        defaults.update(kwargs)
+        return GuidanceConfig(**defaults)
+
+    def test_constant_velocity_lead(self):
+        """After convergence on constant-velocity motion, predicted error leads
+        measured error by velocity * loop_delay."""
+        cfg = self._make_cfg()
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        dt = 0.02              # 50 Hz frame rate
+        velocity_per_frame = 0.01  # error units per frame
+        ex_final = 0.0
+        for i in range(200):   # plenty of frames for the alpha-beta to converge
+            ex_final = i * velocity_per_frame
+            gc.update(ex_final, 0.0, 0.05, now_s=i * dt)
+
+        pred_x, pred_y = gc.predicted_error
+        # velocity in error units per second
+        true_velocity = velocity_per_frame / dt   # 0.5 units/sec
+        expected_lead = true_velocity * (cfg.loop_delay_ms / 1000.0)  # 0.05
+        assert pred_x == pytest.approx(ex_final + expected_lead, abs=0.01)
+        assert pred_y == pytest.approx(0.0, abs=0.01)
+
+    def test_stationary_target_no_lead(self):
+        """Predictor on a still target converges to truth with zero velocity."""
+        cfg = self._make_cfg()
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        for i in range(100):
+            gc.update(0.3, 0.0, 0.05, now_s=i * 0.02)
+
+        pred_x, pred_y = gc.predicted_error
+        pred_vx, pred_vy = gc.predicted_velocity
+        assert pred_x == pytest.approx(0.3, abs=0.01)
+        assert pred_y == pytest.approx(0.0, abs=0.01)
+        assert pred_vx == pytest.approx(0.0, abs=0.05)
+        assert pred_vy == pytest.approx(0.0, abs=0.05)
+
+    def test_predictor_disabled_matches_legacy_behavior(self):
+        """With predictor_enabled false, the controller reproduces the
+        pre-predictor formula: gain * deadzone(EMA-smoothed error)."""
+        cfg = GuidanceConfig(
+            fwd_gain=2.0, lat_gain=1.5, vert_gain=1.0, yaw_gain=30.0,
+            max_fwd_speed=5.0, max_lat_speed=2.0, max_vert_speed=1.5,
+            max_yaw_rate=45.0,
+            deadzone=0.05,
+            smoothing=0.4,           # default EMA alpha
+            target_bbox_ratio=0.15,
+            lost_track_timeout_s=2.0,
+            min_altitude_m=5.0,
+            predictor_enabled=False,
+        )
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        # Two frames of identical input. EMA at alpha 0.4:
+        #   frame 1: smooth_ex equals 0.4 * 0.3 plus 0.6 * 0.0 equals 0.12
+        #   frame 2: smooth_ex equals 0.4 * 0.3 plus 0.6 * 0.12 equals 0.192
+        gc.update(0.3, 0.2, 0.05, now_s=0.0)
+        cmd = gc.update(0.3, 0.2, 0.05, now_s=0.02)
+
+        # vy equals lat_gain * deadzoned(smooth_ex)
+        # 0.192 is above the 0.05 deadzone, so vy equals 1.5 * 0.192 equals 0.288
+        assert cmd.vy == pytest.approx(0.288, abs=0.005)
+
+    def test_predictor_disabled_lateral_exceeds_enabled_on_zero_velocity(self):
+        """On a stationary target, predictor-on output should match predictor-off
+        output (no lead to add). This guards against the predictor introducing
+        spurious lead on still targets."""
+        cfg_off = self._make_cfg(predictor_enabled=False)
+        cfg_on = self._make_cfg(predictor_enabled=True)
+
+        gc_off = GuidanceController(cfg_off)
+        gc_on = GuidanceController(cfg_on)
+        gc_off.start()
+        gc_on.start()
+
+        cmd_off = None
+        cmd_on = None
+        for i in range(50):
+            cmd_off = gc_off.update(0.4, 0.0, 0.05, now_s=i * 0.02)
+            cmd_on = gc_on.update(0.4, 0.0, 0.05, now_s=i * 0.02)
+
+        # On a stationary target both controllers should produce the same vy
+        # within filter-noise tolerance.
+        assert cmd_on.vy == pytest.approx(cmd_off.vy, abs=0.05)
+
+    def test_track_lost_resets_predictor_state(self):
+        """A None-input frame must clear the velocity estimate so a re-acquired
+        track does not inherit stale velocity."""
+        cfg = self._make_cfg()
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        # Build up a non-zero velocity estimate.
+        for i in range(50):
+            gc.update(i * 0.01, 0.0, 0.05, now_s=i * 0.02)
+        assert abs(gc.predicted_velocity[0]) > 0.1
+
+        # Track lost.
+        gc.update(None, None, None, now_s=1.0)
+        assert gc.predicted_error is None
+        assert gc.predicted_velocity == (0.0, 0.0)
+
+    def test_predictor_extreme_input_does_not_break_clamps(self):
+        """Aggressive predictor settings on a fast target must still produce
+        clamped, finite velocity commands."""
+        import math
+
+        cfg = self._make_cfg(
+            loop_delay_ms=500.0,
+            predictor_alpha=0.9,
+            predictor_beta=0.5,
+            max_lat_speed=2.0,
+            max_fwd_speed=5.0,
+            max_vert_speed=1.5,
+            max_yaw_rate=45.0,
+        )
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        for i in range(20):
+            gc.update(i * 0.5, 0.0, 0.05, now_s=i * 0.02)
+        cmd = gc.update(10.0, 0.0, 0.05, now_s=0.42)
+
+        for value in (cmd.vx, cmd.vy, cmd.vz, cmd.yaw_rate):
+            assert math.isfinite(value)
+        assert abs(cmd.vy) <= cfg.max_lat_speed
+        assert cmd.vx <= cfg.max_fwd_speed
+        assert abs(cmd.vz) <= cfg.max_vert_speed
+        assert abs(cmd.yaw_rate) <= cfg.max_yaw_rate
+
+    def test_first_frame_no_lead(self):
+        """The first valid frame after start() initializes the predictor and
+        emits no lead (no velocity history yet)."""
+        cfg = self._make_cfg()
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        gc.update(0.3, 0.1, 0.05, now_s=0.0)
+        pred_x, pred_y = gc.predicted_error
+        assert pred_x == pytest.approx(0.3, abs=1e-6)
+        assert pred_y == pytest.approx(0.1, abs=1e-6)
 
 
 # ------------------------------------------------------------------

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -416,6 +416,152 @@ class TestForwardPredictor:
 
 
 # ------------------------------------------------------------------
+# Attitude compensation (roll/pitch rotation of pixel-error vector)
+# ------------------------------------------------------------------
+
+class TestAttitudeCompensation:
+    """Roll/pitch rotation of the pixel-error vector before gain stage.
+
+    For a strapdown camera the image axes are no longer aligned with the
+    gravity-stable body frame when the vehicle is rolled or pitched. The
+    controller compensates by lifting (ex, ey) to a 3D direction vector and
+    rotating it through the current attitude before computing vy/vz commands.
+    """
+
+    def _make_cfg(self, **kwargs):
+        # Disable EMA + predictor so the rotation is the only transform.
+        defaults = dict(
+            deadzone=0.0,
+            smoothing=1.0,
+            predictor_enabled=False,
+            attitude_compensation_enabled=True,
+            gimbal_stabilized=False,
+        )
+        defaults.update(kwargs)
+        return GuidanceConfig(**defaults)
+
+    def test_zero_attitude_is_identity(self):
+        """At roll=pitch=0 the controller output matches the no-attitude path."""
+        cfg = self._make_cfg()
+        gc = GuidanceController(cfg)
+        gc.start()
+        gc.update(0.5, 0.3, 0.05, now_s=0.0)  # warmup EMA
+        cmd_with_attitude = gc.update(0.5, 0.3, 0.05, now_s=0.02,
+                                      roll_rad=0.0, pitch_rad=0.0)
+
+        gc2 = GuidanceController(cfg)
+        gc2.start()
+        gc2.update(0.5, 0.3, 0.05, now_s=0.0)
+        cmd_no_attitude = gc2.update(0.5, 0.3, 0.05, now_s=0.02)
+
+        assert cmd_with_attitude.vy == pytest.approx(cmd_no_attitude.vy, abs=1e-6)
+        assert cmd_with_attitude.vz == pytest.approx(cmd_no_attitude.vz, abs=1e-6)
+
+    def test_roll_reduces_vy_and_creates_vz(self):
+        """Rolling right (positive roll) on a target at +ex partially maps the
+        lateral pixel error into a vertical body-frame component: vy drops in
+        magnitude and vz appears."""
+        import math
+        cfg = self._make_cfg()
+        gc_no_roll = GuidanceController(cfg)
+        gc_rolled = GuidanceController(cfg)
+        gc_no_roll.start()
+        gc_rolled.start()
+
+        cmd_level = gc_no_roll.update(0.5, 0.0, 0.05, now_s=0.0,
+                                      roll_rad=0.0, pitch_rad=0.0)
+        cmd_rolled = gc_rolled.update(0.5, 0.0, 0.05, now_s=0.0,
+                                      roll_rad=math.radians(20.0),
+                                      pitch_rad=0.0)
+
+        # vy magnitude reduced (cos(20deg) factor on ex)
+        assert abs(cmd_rolled.vy) < abs(cmd_level.vy)
+        assert cmd_rolled.vy == pytest.approx(
+            cmd_level.vy * math.cos(math.radians(20.0)), abs=0.01,
+        )
+        # vz appears (sin(20deg) factor on ex). At zero attitude vz was 0.
+        assert cmd_level.vz == pytest.approx(0.0, abs=1e-6)
+        assert cmd_rolled.vz != pytest.approx(0.0, abs=0.01)
+
+    def test_pitch_reduces_vz_for_target_below_horizon(self):
+        """Pitching nose up rotates the optical axis up, so a target at +ey
+        (below image center) is closer to gravity-level forward than the raw
+        ey suggests. vz magnitude should be reduced."""
+        import math
+        cfg = self._make_cfg()
+        gc_level = GuidanceController(cfg)
+        gc_pitched = GuidanceController(cfg)
+        gc_level.start()
+        gc_pitched.start()
+
+        cmd_level = gc_level.update(0.0, 0.5, 0.05, now_s=0.0,
+                                    roll_rad=0.0, pitch_rad=0.0)
+        cmd_pitched = gc_pitched.update(0.0, 0.5, 0.05, now_s=0.0,
+                                        roll_rad=0.0,
+                                        pitch_rad=math.radians(20.0))
+
+        assert abs(cmd_pitched.vz) < abs(cmd_level.vz)
+
+    def test_gimbal_stabilized_bypasses_compensation(self):
+        """With gimbal_stabilized=True the rotation is skipped even at non-zero
+        attitude — the gimbal already keeps the camera level."""
+        import math
+        cfg = self._make_cfg(gimbal_stabilized=True)
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        cmd_with_roll = gc.update(0.5, 0.0, 0.05, now_s=0.0,
+                                  roll_rad=math.radians(30.0),
+                                  pitch_rad=0.0)
+
+        # Same input should produce the same output regardless of attitude.
+        gc2 = GuidanceController(cfg)
+        gc2.start()
+        cmd_no_roll = gc2.update(0.5, 0.0, 0.05, now_s=0.0,
+                                 roll_rad=0.0, pitch_rad=0.0)
+
+        assert cmd_with_roll.vy == pytest.approx(cmd_no_roll.vy, abs=1e-6)
+        assert cmd_with_roll.vz == pytest.approx(cmd_no_roll.vz, abs=1e-6)
+
+    def test_compensation_disabled_bypasses_rotation(self):
+        """attitude_compensation_enabled=False reproduces legacy behavior."""
+        import math
+        cfg = self._make_cfg(attitude_compensation_enabled=False)
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        cmd_with_attitude = gc.update(0.5, 0.0, 0.05, now_s=0.0,
+                                      roll_rad=math.radians(30.0),
+                                      pitch_rad=math.radians(15.0))
+
+        gc2 = GuidanceController(cfg)
+        gc2.start()
+        cmd_zero = gc2.update(0.5, 0.0, 0.05, now_s=0.0,
+                              roll_rad=0.0, pitch_rad=0.0)
+
+        assert cmd_with_attitude.vy == pytest.approx(cmd_zero.vy, abs=1e-6)
+        assert cmd_with_attitude.vz == pytest.approx(cmd_zero.vz, abs=1e-6)
+
+    def test_missing_attitude_falls_back_to_legacy(self):
+        """If roll/pitch are None (no MAVLink ATTITUDE yet), no rotation is
+        applied so the controller still produces a sensible command."""
+        cfg = self._make_cfg()
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        cmd = gc.update(0.5, 0.3, 0.05, now_s=0.0,
+                        roll_rad=None, pitch_rad=None)
+
+        gc2 = GuidanceController(cfg)
+        gc2.start()
+        cmd_zero = gc2.update(0.5, 0.3, 0.05, now_s=0.0,
+                              roll_rad=0.0, pitch_rad=0.0)
+
+        assert cmd.vy == pytest.approx(cmd_zero.vy, abs=1e-6)
+        assert cmd.vz == pytest.approx(cmd_zero.vz, abs=1e-6)
+
+
+# ------------------------------------------------------------------
 # Integration: ApproachController pixel-lock auto-abort chain
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Layers an alpha-beta tracker on top of the existing EMA in `GuidanceController` to project the smoothed bbox center forward by `loop_delay_ms` (default 100 ms, matching the 100-130 ms steady-state pipeline delay measured on Orin Nano plus Pixhawk). Controller acts on where the target will be when the velocity command takes effect, not where it was when the frame was captured.

This is the textbook mitigation for IBVS oscillation in wind under non-trivial loop delay, called out in the May 2026 prior-art research note as the biggest single win for Follow-mode quality.

## Why now

Per `~/Obsidian/Vault/Hydra/Research/yolo-mavlink-action-items-2026-05.md` item 2 (Tier 1, top priority): "Real e2e latency is 100-130 ms... at 5 m/s lateral target motion that's 50-65 cm of lag - explains the wind-oscillation Kyle has seen."

## Design

- Alpha-beta tracker (constant-velocity assumption), not full Kalman. ~30 lines vs ~50; the action-items note explicitly allows either.
- Predictor runs on the **output** of the EMA (not the raw input) so it tracks the denoised series.
- On `start()` and on any track-loss frame, predictor state resets so a re-acquired track does not inherit stale velocity carried across the gap.
- `update()` accepts an optional `now_s` parameter for deterministic tests; production path still uses `time.monotonic()`.
- Added `predicted_error` and `predicted_velocity` properties for inspection by tests and future Capability Status surfacing.

## New config keys

Added to `[guidance]` section, schema-validated, with matching pipeline fallbacks:

| Key | Default | Range | Notes |
|---|---|---|---|
| `loop_delay_ms` | 100.0 | 0-1000 | Forward look-ahead in ms |
| `predictor_enabled` | true | bool | Set false to reproduce legacy behavior |
| `predictor_alpha` | 0.5 | 0-1 | Position gain |
| `predictor_beta` | 0.05 | 0-1 | Velocity gain |

Migration 002 adds these keys to existing user config files. `CURRENT_SCHEMA_VERSION` bumped to 2. Existing user values are preserved if any of the keys are already present.

## Test plan

New tests in `tests/test_guidance.py::TestForwardPredictor`:
- [x] Constant-velocity lead convergence (predicted leads measured by velocity times loop-delay)
- [x] Stationary-target zero-lead (no spurious lead on still targets)
- [x] Predictor-disabled matches legacy controller output formula
- [x] Predictor-on vs predictor-off parity on still targets
- [x] Track-loss resets predictor state
- [x] Aggressive settings produce finite, clamped output (no NaN/inf escape)
- [x] First valid frame seeds predictor with no lead

New tests in `tests/test_config_migrate.py::TestV1ToV2Migration`:
- [x] Predictor keys inserted on existing v1 configs
- [x] User-override values preserved when keys already exist
- [x] Missing `[guidance]` section is created by the migration

Existing test `test_sudden_change_is_smoothed` updated to explicitly disable the predictor (its intent is to isolate EMA behavior).

Local results:
- `tests/test_guidance.py` plus `tests/test_config_migrate.py`: **59/59 pass**
- Broader Windows-runnable subset (`test_approach`, `test_tracker`, `test_geo_tracking`, `test_dogleg_rtl`, `test_autonomous`, `test_capability_status`, `test_drop_strike`, `test_camera`, `test_alert_filter`, `test_event_logger`, `test_detection_logger`): **296/296 pass, 8 skipped**
- Web-server tests do not collect locally on Windows (pre-existing `fcntl` import issue, not related to this PR) - CI will exercise them on Linux.
- `flake8` clean on touched files.

## What this does NOT touch

- No changes to `pipeline.py`, `mavlink_io.py`, `approach.py`, `capability_status.py`, identity, or any deployed-unit-affecting code path. Pure inner-loop math change.
- No new dependencies.
- No changes to existing config defaults.

## Reviewer asks

- Is `predictor_enabled = true` the right default, or do you want it shadowed (off by default, enable per-profile)?
- `loop_delay_ms = 100.0` is the conservative center of the 100-130 ms range from the prior-art note. If you want to tune up to 130 on the drone profile, that's a `[vehicle.drone]` override and can land in a follow-up.