### PR TITLE
feat(guidance): roll/pitch attitude compensation for strapdown camera

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -137,6 +137,8 @@ loop_delay_ms = 100.0
 predictor_enabled = true
 predictor_alpha = 0.5
 predictor_beta = 0.05
+attitude_compensation_enabled = true
+gimbal_stabilized = false
 
 [rf_homing]
 enabled = false

--- a/hydra_detect/approach.py
+++ b/hydra_detect/approach.py
@@ -558,7 +558,22 @@ class ApproachController:
             error_y = None
             bbox_ratio = None
 
-        cmd = self._guidance.update(error_x, error_y, bbox_ratio)
+        # Fetch current vehicle attitude (radians) for the pixel-error
+        # rotation; if unavailable the controller falls back to legacy.
+        roll_rad: float | None = None
+        pitch_rad: float | None = None
+        try:
+            attitude = self._mavlink.get_attitude()
+            if attitude.get("last_update", 0.0) > 0.0:
+                roll_rad = attitude.get("roll")
+                pitch_rad = attitude.get("pitch")
+        except Exception:
+            pass  # mavlink stub or older controller without attitude — ignore
+
+        cmd = self._guidance.update(
+            error_x, error_y, bbox_ratio,
+            roll_rad=roll_rad, pitch_rad=pitch_rad,
+        )
 
         # Enforce minimum altitude floor — prevent descent below threshold.
         # In NED, positive vz = descend.  Clamp to zero if near floor.

--- a/hydra_detect/config_migrate.py
+++ b/hydra_detect/config_migrate.py
@@ -44,7 +44,7 @@ from types import ModuleType
 logger = logging.getLogger(__name__)
 
 # Bump this when adding a new migration file.
-CURRENT_SCHEMA_VERSION: int = 2
+CURRENT_SCHEMA_VERSION: int = 3
 
 # Migration modules directory (monkeypatched in tests to point at fixtures).
 _MIGRATIONS_DIR: Path = Path(__file__).parent / "migrations"

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1212,6 +1212,16 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             default=0.05,
             description="Alpha-beta filter velocity gain",
         ),
+        "attitude_compensation_enabled": FieldSpec(
+            FieldType.BOOL,
+            default=True,
+            description="Rotate pixel-error by vehicle roll/pitch before gain stage",
+        ),
+        "gimbal_stabilized": FieldSpec(
+            FieldType.BOOL,
+            default=False,
+            description="Skip attitude compensation when a level-stabilized gimbal is fitted",
+        ),
     },
     "mavlink_video": {
         "enabled": FieldSpec(

--- a/hydra_detect/guidance.py
+++ b/hydra_detect/guidance.py
@@ -8,6 +8,7 @@ Raspberry Pi Zero 2W with colour/shape tracking).
 
 from __future__ import annotations
 
+import math
 import time
 from dataclasses import dataclass
 
@@ -40,6 +41,14 @@ class GuidanceConfig:
     predictor_enabled: bool = True
     predictor_alpha: float = 0.5    # alpha-beta position gain (0..1)
     predictor_beta: float = 0.05    # alpha-beta velocity gain (0..1)
+
+    # Attitude compensation: rotate the (ex, ey) pixel-error vector through
+    # the current vehicle roll/pitch before feeding the predictor and gain
+    # stages. Necessary for a strapdown camera; bypass when a gimbal already
+    # keeps the optical axis level. ArduPilot ATTITUDE convention: positive
+    # roll is right-wing-down, positive pitch is nose-up.
+    attitude_compensation_enabled: bool = True
+    gimbal_stabilized: bool = False
 
 
 @dataclass
@@ -126,6 +135,8 @@ class GuidanceController:
         error_y: float | None,
         bbox_ratio: float | None,
         now_s: float | None = None,
+        roll_rad: float | None = None,
+        pitch_rad: float | None = None,
     ) -> VelocityCommand:
         """Compute velocity command from current pixel errors.
 
@@ -136,6 +147,12 @@ class GuidanceController:
             now_s: Optional monotonic-clock timestamp in seconds. When None
                 (production path), time.monotonic() is used. Tests pass an
                 explicit clock so predictor convergence is deterministic.
+            roll_rad: Vehicle roll in radians from MAVLink ATTITUDE
+                (positive = right wing down). When None or attitude
+                compensation is disabled / gimbal-stabilized, no rotation
+                is applied.
+            pitch_rad: Vehicle pitch in radians from MAVLink ATTITUDE
+                (positive = nose up).
 
         Returns:
             VelocityCommand with body-frame velocities.  Returns zero
@@ -164,13 +181,20 @@ class GuidanceController:
 
         cfg = self._cfg
 
-        # Forward predictor on the smoothed series. Outputs the EMA-smoothed
-        # error projected by loop_delay_ms; if disabled, falls through to the
-        # raw smoothed value (legacy behavior).
+        # Attitude compensation: rotate (smooth_ex, smooth_ey) into the
+        # gravity-stable level-body frame so the predictor and gain stages
+        # see a stationary world-aligned signal.
+        corr_ex, corr_ey = self._attitude_correct(
+            self._smooth_ex, self._smooth_ey, roll_rad, pitch_rad,
+        )
+
+        # Forward predictor on the (attitude-corrected) smoothed series.
+        # Outputs the corrected error projected by loop_delay_ms; if disabled,
+        # falls through to the corrected value directly.
         if cfg.predictor_enabled:
-            ex_used, ey_used = self._predict(now, self._smooth_ex, self._smooth_ey)
+            ex_used, ey_used = self._predict(now, corr_ex, corr_ey)
         else:
-            ex_used, ey_used = self._smooth_ex, self._smooth_ey
+            ex_used, ey_used = corr_ex, corr_ey
 
         # Apply deadzone
         ex = _deadzone(ex_used, cfg.deadzone)
@@ -207,6 +231,56 @@ class GuidanceController:
             return False
         elapsed = time.monotonic() - self._last_track_time
         return elapsed >= self._cfg.lost_track_timeout_s
+
+    def _attitude_correct(
+        self,
+        ex: float,
+        ey: float,
+        roll_rad: float | None,
+        pitch_rad: float | None,
+    ) -> tuple[float, float]:
+        """Map (ex, ey) through current vehicle roll/pitch into the
+        gravity-stable level-body frame.
+
+        Geometry (strapdown forward-facing camera, no gimbal):
+            camera-x (right)   maps to body-y at zero attitude
+            camera-y (down)    maps to body-z
+            camera-z (forward) maps to body-x
+        So a pixel direction vector (ex, ey, 1) in the camera frame becomes
+        (1, ex, ey) in the body frame at zero attitude. Apply the vehicle
+        attitude rotation (yaw ignored; IBVS commands yaw-rate separately)
+        to express it in the level-body frame, then read off the y/z
+        components as the corrected pixel error.
+
+        Returns the input unchanged when compensation is disabled, the
+        gimbal-stabilized flag is set, or attitude is unavailable.
+        """
+        cfg = self._cfg
+        if cfg.gimbal_stabilized or not cfg.attitude_compensation_enabled:
+            return ex, ey
+        if roll_rad is None or pitch_rad is None:
+            return ex, ey
+
+        cos_r = math.cos(roll_rad)
+        sin_r = math.sin(roll_rad)
+        cos_p = math.cos(pitch_rad)
+        sin_p = math.sin(pitch_rad)
+
+        # v_body0 = (1, ex, ey) — camera-z in body-x, camera-x in body-y,
+        # camera-y in body-z at zero attitude.
+        bx = 1.0
+        by = ex
+        bz = ey
+
+        # R_x(roll): rotates (by, bz) around body-x.
+        by, bz = by * cos_r - bz * sin_r, by * sin_r + bz * cos_r
+
+        # R_y(pitch): rotates (bx, bz) around body-y.
+        bx, bz = bx * cos_p + bz * sin_p, -bx * sin_p + bz * cos_p
+
+        # The level-body y component drives vy, z drives vz. bx (forward
+        # depth) is unused — approach distance comes from bbox_ratio.
+        return by, bz
 
     def _predict(
         self,

--- a/hydra_detect/mavlink_io.py
+++ b/hydra_detect/mavlink_io.py
@@ -85,6 +85,16 @@ class MAVLinkIO:
             "climb": None,
         }
 
+        # Vehicle attitude (radians, populated from ATTITUDE msg 30).
+        # ArduPilot convention: positive roll = right wing down, positive
+        # pitch = nose up, yaw = body heading (0..2pi).
+        self._attitude: Dict[str, Any] = {
+            "roll": None,
+            "pitch": None,
+            "yaw": None,
+            "last_update": 0.0,
+        }
+
         # RC channel values (updated by _message_reader from RC_CHANNELS)
         self._rc_channels: list[int] = []
         self._rc_channels_lock = threading.Lock()
@@ -205,7 +215,7 @@ class MAVLinkIO:
     # ------------------------------------------------------------------
     _ALL_MSG_TYPES = [
         "GLOBAL_POSITION_INT", "GPS_RAW_INT", "HEARTBEAT",
-        "SYS_STATUS", "VFR_HUD", "RC_CHANNELS",
+        "SYS_STATUS", "VFR_HUD", "RC_CHANNELS", "ATTITUDE",
         "COMMAND_LONG", "NAMED_VALUE_INT",
     ]
 
@@ -243,6 +253,8 @@ class MAVLinkIO:
                             self._telemetry["battery_pct"] = msg.battery_remaining
                 elif msg_type == "VFR_HUD":
                     self._handle_vfr_hud(msg)
+                elif msg_type == "ATTITUDE":
+                    self._handle_attitude(msg)
                 elif msg_type == "RC_CHANNELS":
                     with self._rc_channels_lock:
                         self._rc_channels = [
@@ -285,6 +297,14 @@ class MAVLinkIO:
             self._telemetry["altitude"] = round(msg.alt, 1)
             self._telemetry["heading"] = round(msg.heading, 0)
             self._telemetry["climb"] = round(msg.climb, 2)
+
+    def _handle_attitude(self, msg) -> None:
+        """Cache roll, pitch, yaw (radians) from ATTITUDE msg 30."""
+        with self._gps_lock:
+            self._attitude["roll"] = float(msg.roll)
+            self._attitude["pitch"] = float(msg.pitch)
+            self._attitude["yaw"] = float(msg.yaw)
+            self._attitude["last_update"] = time.monotonic()
 
     def _update_armed_state(self, heartbeat_msg) -> None:
         """Extract armed state from HEARTBEAT base_mode."""
@@ -431,6 +451,20 @@ class MAVLinkIO:
         with self._vehicle_mode_lock:
             result["vehicle_mode"] = self._vehicle_mode
         return result
+
+    def get_attitude(self) -> Dict[str, Any]:
+        """Return current vehicle attitude in radians, or all-None if no
+        ATTITUDE message has been received yet.
+
+        Keys:
+          - ``roll``  - radians, positive = right wing down
+          - ``pitch`` - radians, positive = nose up
+          - ``yaw``   - radians, body heading
+          - ``last_update`` - monotonic timestamp of the most recent message
+            (0.0 if never received)
+        """
+        with self._gps_lock:
+            return dict(self._attitude)
 
     def get_flight_data(self) -> Dict[str, Any]:
         """Return flight-instrument values as a dict.

--- a/hydra_detect/migrations/003_guidance_attitude_compensation.py
+++ b/hydra_detect/migrations/003_guidance_attitude_compensation.py
@@ -1,0 +1,31 @@
+"""Migration 003 — add attitude-compensation keys to [guidance].
+
+Adds two new keys so the roll/pitch rotation introduced in guidance.py can be
+disabled per-platform (mostly: vehicles with a level-stabilized gimbal should
+set gimbal_stabilized=true, since the camera is already level).
+
+Idempotent: keys are inserted only when absent so a user who pre-edited the
+config keeps their value.
+"""
+
+from __future__ import annotations
+
+import configparser
+
+from_version: int = 2
+to_version: int = 3
+
+
+_DEFAULTS: dict[str, str] = {
+    "attitude_compensation_enabled": "true",
+    "gimbal_stabilized": "false",
+}
+
+
+def migrate(cfg: configparser.ConfigParser) -> None:
+    """Insert attitude-compensation keys into [guidance] if missing."""
+    if not cfg.has_section("guidance"):
+        cfg.add_section("guidance")
+    for key, value in _DEFAULTS.items():
+        if not cfg.has_option("guidance", key):
+            cfg.set("guidance", key, value)

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -525,6 +525,10 @@ class Pipeline:
                         "guidance", "predictor_alpha", fallback=0.5),
                     predictor_beta=self._cfg.getfloat(
                         "guidance", "predictor_beta", fallback=0.05),
+                    attitude_compensation_enabled=self._cfg.getboolean(
+                        "guidance", "attitude_compensation_enabled", fallback=True),
+                    gimbal_stabilized=self._cfg.getboolean(
+                        "guidance", "gimbal_stabilized", fallback=False),
                 ),
             )
             self._approach = ApproachController(self._mavlink, approach_cfg)

--- a/tests/test_config_migrate.py
+++ b/tests/test_config_migrate.py
@@ -247,6 +247,67 @@ class TestV1ToV2Migration:
         assert cfg.get("guidance", "predictor_enabled") == "true"
 
 
+class TestV2ToV3Migration:
+    """Migration 003: attitude-compensation keys are inserted into [guidance]."""
+
+    def test_v2_picks_up_attitude_keys(self, tmp_config):
+        """Migrating from v2 adds attitude_compensation_enabled and
+        gimbal_stabilized to [guidance]."""
+        v2 = textwrap.dedent("""\
+            [meta]
+            schema_version = 2
+
+            [guidance]
+            fwd_gain = 2.0
+            predictor_enabled = true
+        """)
+        p = tmp_config(v2)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.get("guidance", "attitude_compensation_enabled") == "true"
+        assert cfg.get("guidance", "gimbal_stabilized") == "false"
+        # Existing keys preserved.
+        assert cfg.get("guidance", "fwd_gain") == "2.0"
+        assert cfg.get("guidance", "predictor_enabled") == "true"
+
+    def test_v2_existing_attitude_value_preserved(self, tmp_config):
+        """A pre-existing user value in [guidance] survives the migration."""
+        v2 = textwrap.dedent("""\
+            [meta]
+            schema_version = 2
+
+            [guidance]
+            attitude_compensation_enabled = false
+        """)
+        p = tmp_config(v2)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.get("guidance", "attitude_compensation_enabled") == "false"
+        # Missing key still gets filled in.
+        assert cfg.get("guidance", "gimbal_stabilized") == "false"
+
+    def test_v0_chains_through_all_migrations(self, tmp_config):
+        """A v0 config must walk through 001 then 002 then 003 to reach
+        current. Verifies the chain is contiguous."""
+        p = tmp_config(GOLDEN_V0)
+        result = run_migrations(p)
+
+        assert result.from_version == 0
+        assert result.to_version == CURRENT_SCHEMA_VERSION
+        assert len(result.applied) == CURRENT_SCHEMA_VERSION
+        # Final state has both predictor and attitude keys.
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+        assert cfg.has_option("guidance", "predictor_enabled")
+        assert cfg.has_option("guidance", "attitude_compensation_enabled")
+
+
 # ---------------------------------------------------------------------------
 # 3. Migration discovery handles out-of-order files
 # ---------------------------------------------------------------------------

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -416,6 +416,152 @@ class TestForwardPredictor:
 
 
 # ------------------------------------------------------------------
+# Attitude compensation (roll/pitch rotation of pixel-error vector)
+# ------------------------------------------------------------------
+
+class TestAttitudeCompensation:
+    """Roll/pitch rotation of the pixel-error vector before gain stage.
+
+    For a strapdown camera the image axes are no longer aligned with the
+    gravity-stable body frame when the vehicle is rolled or pitched. The
+    controller compensates by lifting (ex, ey) to a 3D direction vector and
+    rotating it through the current attitude before computing vy/vz commands.
+    """
+
+    def _make_cfg(self, **kwargs):
+        # Disable EMA + predictor so the rotation is the only transform.
+        defaults = dict(
+            deadzone=0.0,
+            smoothing=1.0,
+            predictor_enabled=False,
+            attitude_compensation_enabled=True,
+            gimbal_stabilized=False,
+        )
+        defaults.update(kwargs)
+        return GuidanceConfig(**defaults)
+
+    def test_zero_attitude_is_identity(self):
+        """At roll=pitch=0 the controller output matches the no-attitude path."""
+        cfg = self._make_cfg()
+        gc = GuidanceController(cfg)
+        gc.start()
+        gc.update(0.5, 0.3, 0.05, now_s=0.0)  # warmup EMA
+        cmd_with_attitude = gc.update(0.5, 0.3, 0.05, now_s=0.02,
+                                      roll_rad=0.0, pitch_rad=0.0)
+
+        gc2 = GuidanceController(cfg)
+        gc2.start()
+        gc2.update(0.5, 0.3, 0.05, now_s=0.0)
+        cmd_no_attitude = gc2.update(0.5, 0.3, 0.05, now_s=0.02)
+
+        assert cmd_with_attitude.vy == pytest.approx(cmd_no_attitude.vy, abs=1e-6)
+        assert cmd_with_attitude.vz == pytest.approx(cmd_no_attitude.vz, abs=1e-6)
+
+    def test_roll_reduces_vy_and_creates_vz(self):
+        """Rolling right (positive roll) on a target at +ex partially maps the
+        lateral pixel error into a vertical body-frame component: vy drops in
+        magnitude and vz appears."""
+        import math
+        cfg = self._make_cfg()
+        gc_no_roll = GuidanceController(cfg)
+        gc_rolled = GuidanceController(cfg)
+        gc_no_roll.start()
+        gc_rolled.start()
+
+        cmd_level = gc_no_roll.update(0.5, 0.0, 0.05, now_s=0.0,
+                                      roll_rad=0.0, pitch_rad=0.0)
+        cmd_rolled = gc_rolled.update(0.5, 0.0, 0.05, now_s=0.0,
+                                      roll_rad=math.radians(20.0),
+                                      pitch_rad=0.0)
+
+        # vy magnitude reduced (cos(20deg) factor on ex)
+        assert abs(cmd_rolled.vy) < abs(cmd_level.vy)
+        assert cmd_rolled.vy == pytest.approx(
+            cmd_level.vy * math.cos(math.radians(20.0)), abs=0.01,
+        )
+        # vz appears (sin(20deg) factor on ex). At zero attitude vz was 0.
+        assert cmd_level.vz == pytest.approx(0.0, abs=1e-6)
+        assert cmd_rolled.vz != pytest.approx(0.0, abs=0.01)
+
+    def test_pitch_reduces_vz_for_target_below_horizon(self):
+        """Pitching nose up rotates the optical axis up, so a target at +ey
+        (below image center) is closer to gravity-level forward than the raw
+        ey suggests. vz magnitude should be reduced."""
+        import math
+        cfg = self._make_cfg()
+        gc_level = GuidanceController(cfg)
+        gc_pitched = GuidanceController(cfg)
+        gc_level.start()
+        gc_pitched.start()
+
+        cmd_level = gc_level.update(0.0, 0.5, 0.05, now_s=0.0,
+                                    roll_rad=0.0, pitch_rad=0.0)
+        cmd_pitched = gc_pitched.update(0.0, 0.5, 0.05, now_s=0.0,
+                                        roll_rad=0.0,
+                                        pitch_rad=math.radians(20.0))
+
+        assert abs(cmd_pitched.vz) < abs(cmd_level.vz)
+
+    def test_gimbal_stabilized_bypasses_compensation(self):
+        """With gimbal_stabilized=True the rotation is skipped even at non-zero
+        attitude — the gimbal already keeps the camera level."""
+        import math
+        cfg = self._make_cfg(gimbal_stabilized=True)
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        cmd_with_roll = gc.update(0.5, 0.0, 0.05, now_s=0.0,
+                                  roll_rad=math.radians(30.0),
+                                  pitch_rad=0.0)
+
+        # Same input should produce the same output regardless of attitude.
+        gc2 = GuidanceController(cfg)
+        gc2.start()
+        cmd_no_roll = gc2.update(0.5, 0.0, 0.05, now_s=0.0,
+                                 roll_rad=0.0, pitch_rad=0.0)
+
+        assert cmd_with_roll.vy == pytest.approx(cmd_no_roll.vy, abs=1e-6)
+        assert cmd_with_roll.vz == pytest.approx(cmd_no_roll.vz, abs=1e-6)
+
+    def test_compensation_disabled_bypasses_rotation(self):
+        """attitude_compensation_enabled=False reproduces legacy behavior."""
+        import math
+        cfg = self._make_cfg(attitude_compensation_enabled=False)
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        cmd_with_attitude = gc.update(0.5, 0.0, 0.05, now_s=0.0,
+                                      roll_rad=math.radians(30.0),
+                                      pitch_rad=math.radians(15.0))
+
+        gc2 = GuidanceController(cfg)
+        gc2.start()
+        cmd_zero = gc2.update(0.5, 0.0, 0.05, now_s=0.0,
+                              roll_rad=0.0, pitch_rad=0.0)
+
+        assert cmd_with_attitude.vy == pytest.approx(cmd_zero.vy, abs=1e-6)
+        assert cmd_with_attitude.vz == pytest.approx(cmd_zero.vz, abs=1e-6)
+
+    def test_missing_attitude_falls_back_to_legacy(self):
+        """If roll/pitch are None (no MAVLink ATTITUDE yet), no rotation is
+        applied so the controller still produces a sensible command."""
+        cfg = self._make_cfg()
+        gc = GuidanceController(cfg)
+        gc.start()
+
+        cmd = gc.update(0.5, 0.3, 0.05, now_s=0.0,
+                        roll_rad=None, pitch_rad=None)
+
+        gc2 = GuidanceController(cfg)
+        gc2.start()
+        cmd_zero = gc2.update(0.5, 0.3, 0.05, now_s=0.0,
+                              roll_rad=0.0, pitch_rad=0.0)
+
+        assert cmd.vy == pytest.approx(cmd_zero.vy, abs=1e-6)
+        assert cmd.vz == pytest.approx(cmd_zero.vz, abs=1e-6)
+
+
+# ------------------------------------------------------------------
 # Integration: ApproachController pixel-lock auto-abort chain
 # ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Action items doc item 6: rotate the (ex, ey) pixel-error vector through the current vehicle roll/pitch before the predictor and gain stages so the strapdown-camera IBVS controller does not fight its own attitude.

> **Stacked on #179.** This PR is opened against `claude/guidance-forward-predictor` so the migration chain (002 then 003) stays clean. When #179 merges to main, please retarget this PR to main.

## Why now

Per the May 2026 prior-art note: "Strapdown camera + non-zero vehicle pitch/roll means image-x doesn't map cleanly to body-y. Currently ignored. Most hobbyist projects ignore this and burn it into yaw + pitch hacks." Without compensation, a banked turn maps lateral pixel error into a roll-rotated body axis, and the controller commands a vy that pulls the target out of the frame instead of toward it. Combined with the predictor (#179), this is the second textbook IBVS mitigation for wind-induced oscillation.

## Math

Strapdown camera, no gimbal:
- camera-x (right)   maps to body-y at zero attitude
- camera-y (down)    maps to body-z
- camera-z (forward) maps to body-x

Pixel direction `(ex, ey, 1)` becomes `(1, ex, ey)` in the body frame at zero attitude. Apply `R_y(pitch) * R_x(roll)` (yaw is ignored — the IBVS controller commands yaw_rate separately). Read off the resulting y and z components as the corrected pixel error. ArduPilot ATTITUDE convention: positive roll is right wing down, positive pitch is nose up.

The rotation runs after EMA and before the forward predictor, so the predictor tracks a stationary world-aligned signal even as the vehicle banks.

## Bypass conditions

The rotation is short-circuited (returns input unchanged) when any of:
- `gimbal_stabilized = true` (a level-stabilized gimbal already holds the optical axis horizontal)
- `attitude_compensation_enabled = false` (legacy escape hatch)
- `roll_rad` or `pitch_rad` is None (ATTITUDE message has not been received yet — older controllers, sim stubs, or boot-up before the first MAVLink frame)

## Files touched

| File | Change |
|---|---|
| `hydra_detect/guidance.py` | New `_attitude_correct()`, two new config fields, two new `update()` parameters |
| `hydra_detect/mavlink_io.py` | **Flagged**: additive ATTITUDE handler + `get_attitude()` getter, same shape as VFR_HUD |
| `hydra_detect/approach.py` | Pixel-lock fetches attitude via `get_attitude()` and passes it to `guidance.update()` |
| `hydra_detect/config_schema.py` | Two new FieldSpec entries |
| `hydra_detect/pipeline/facade.py` | Two new fallback wires |
| `config.ini` | Two new keys appended to `[guidance]` |
| `hydra_detect/migrations/003_guidance_attitude_compensation.py` | New migration |
| `hydra_detect/config_migrate.py` | `CURRENT_SCHEMA_VERSION` 2 -> 3 |
| `tests/test_guidance.py` | `TestAttitudeCompensation` (6 tests) |
| `tests/test_config_migrate.py` | `TestV2ToV3Migration` (3 tests including full v0 to current chain) |

### `mavlink_io.py` flag

Per CLAUDE.md the touch is flagged here explicitly. The change is purely additive:
1. `"ATTITUDE"` added to `_ALL_MSG_TYPES`.
2. New `_handle_attitude(msg)` writes roll/pitch/yaw to `self._attitude` under the existing `_gps_lock`.
3. New `get_attitude()` returns a copy of the dict.

No existing behavior is modified, no locks reorganized, no message parsing reshaped. Pattern matches VFR_HUD line-for-line.

## New config keys

| Key | Default | Notes |
|---|---|---|
| `attitude_compensation_enabled` | `true` | Master enable for the rotation |
| `gimbal_stabilized` | `false` | Set true on platforms with a level-stabilized gimbal |

## Test plan

`TestAttitudeCompensation` (all passing locally):
- [x] Zero attitude is identity (rotation is a no-op at roll=pitch=0)
- [x] Roll on +ex: vy reduced by cos(roll), vz appears (sin(roll) * ex)
- [x] Pitch on +ey: vz reduced (target closer to level forward when camera pitched up)
- [x] Gimbal-stabilized bypasses rotation regardless of attitude
- [x] Compensation-disabled bypasses rotation regardless of attitude
- [x] None roll/pitch (no MAVLink ATTITUDE yet) falls back to legacy

`TestV2ToV3Migration`:
- [x] Predictor keys preserved, attitude keys inserted on v2 to v3 step
- [x] Pre-existing user override survives the migration
- [x] Full v0 to current chain walks 001 then 002 then 003

Local results:
- `tests/test_guidance.py` plus `test_config_migrate.py` plus `test_approach.py`: **90/90 pass**
- Broader Windows-runnable subset (15 modules including `test_mavlink_commands` and `test_mavlink_safety`): **360/360 pass, 8 skipped**
- `flake8` clean on all touched files
- Migration chain smoke test: v0 fixture promotes cleanly to v3 with all expected keys present

Web-server tests still do not collect locally on Windows (pre-existing `fcntl` issue, not related to this PR). CI on Linux exercises them.

## What this does NOT touch

- No changes to identity, capability_status, or the detector pipeline.
- No new Python dependencies.
- mavlink_io changes are additive only (no existing send paths or message handlers modified).

## Reviewer asks

1. **`attitude_compensation_enabled = true` default.** Same call as the predictor PR — on by default with the migration step as the visible breadcrumb. Flip to false-default if you want it shadowed first; the rotation can then be enabled per-profile after a soak.
2. **`gimbal_stabilized = false` default.** The default platform (5/10 inch FPV quads, T1 Ranger fixed-wing, Stampede UGV, Bonzai USV) is strapdown. Anything with a brushless gimbal should set true at the profile level. Worth a follow-up PR to set this in the gimbal-equipped profiles, not this one.
3. **Yaw deliberately ignored** in the rotation. The IBVS controller already commands yaw_rate separately, and including yaw in the pixel-error transform would create a feedback loop. If you want yaw decoupling for some reason, call it out and I will revisit.