### PR TITLE
feat(observability): wire SoC temp + RAM providers for Prometheus scrape

### DIFF
--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -45,8 +45,11 @@ from hydra_detect.observability import (
     attach_audit_counters as _attach_metrics_counters,
     get_client_error_sink as _get_client_error_sink,
     health_snapshot as _health_snapshot,
+    hydra_cpu_temp_c as _m_cpu_temp,
     hydra_fps as _m_fps,
+    hydra_gpu_temp_c as _m_gpu_temp,
     hydra_inference_ms as _m_inference_ms,
+    hydra_ram_pct as _m_ram_pct,
     render_metrics as _render_metrics,
 )
 
@@ -61,6 +64,28 @@ _client_error_sink = _get_client_error_sink()
 # every Prometheus scrape. Set once at import — provider closures are stable.
 _m_fps.set_provider(lambda: stream_state.get_stats().get("fps"))
 _m_inference_ms.set_provider(lambda: stream_state.get_stats().get("inference_ms"))
+
+
+def _ram_pct_from_stats() -> float | None:
+    """Compute RAM utilisation percent from the jetson_stats dict in stream_state.
+
+    Returns None when either total or used is missing or total is zero, so the
+    Prometheus exposition renders NaN rather than a misleading number.
+    """
+    stats = stream_state.get_stats()
+    total = stats.get("ram_total_mb")
+    used = stats.get("ram_used_mb")
+    if not total or used is None:
+        return None
+    return round(float(used) / float(total) * 100.0, 1)
+
+
+# SoC temp + RAM providers fed from system.read_jetson_stats(), which the
+# pipeline merges into stream_state every ~5 s. Keeps deployed-unit thermal
+# state visible via /metrics without adding a separate scrape thread.
+_m_cpu_temp.set_provider(lambda: stream_state.get_stats().get("cpu_temp_c"))
+_m_gpu_temp.set_provider(lambda: stream_state.get_stats().get("gpu_temp_c"))
+_m_ram_pct.set_provider(_ram_pct_from_stats)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

The `hydra_cpu_temp_c`, `hydra_gpu_temp_c`, and `hydra_ram_pct` gauges have existed in `observability.metrics` for a while but had no providers attached, so `/metrics` rendered them as `NaN` even though `system.read_jetson_stats()` was already collecting the data and the pipeline was already merging it into `stream_state` every ~5 s.

This change plugs the gauges into `stream_state` alongside the existing `fps` and `inference_ms` providers. Deployed Hydras start emitting per-unit thermal + RAM data through Prometheus immediately on next deploy.

## Why now

From the May 2026 prior-art note: `Forum reports of "fine in shop, 12 FPS at noon" are universal on Orin Nano. Currently no per-unit telemetry for thermal throttling. With 5+ deployed units (growing), Kyle is help-desk blind.`

This is the smallest change that closes the help-desk blindness on thermal. Three new providers plus a small `_ram_pct_from_stats` helper.

## Files touched

| File | Change |
|---|---|
| `hydra_detect/web/server.py` | Three new `set_provider` calls + a four-line helper for ram_pct |

That's the entire diff. No new modules, no flagged-path touches (web/server.py is not on the deployed-unit-affecting list — pipeline/facade.py was the actual probe, and it already runs `read_jetson_stats()`).

## Test plan

- The existing `tests/test_observability.py::TestPrometheusFormat::test_text_contains_all_expected_metrics` already asserts these three gauges appear in the rendered output. With providers wired they now have a real value (or `NaN` when stats are unavailable, e.g. on first scrape before pipeline pushes any jetson_stats).
- `_ram_pct_from_stats` returns None when `ram_total_mb` or `ram_used_mb` is missing or total is zero, so the Prometheus renderer outputs `NaN` rather than a misleading 0.
- Syntax validated locally; lint clean. Full integration tests do not collect on Windows (pre-existing fcntl issue) but CI exercises them on Linux.

## What this does NOT do

- Does not add a `Capability Status` WARN evaluator for thermal — that needs a sustained-window tracker (FPS < 70% target sustained 30s) and is a separate, larger PR.
- Does not add the phone-home payload integration (#153) — same reason.
- Does not modify `system.read_jetson_stats()` or any sysfs probe — those already work.

## Reviewer asks

None — wiring change only, no defaults shifted, no new config surface.