### PR TITLE
feat(capability_status): SoC thermal WARN/BLOCKED gating

### DIFF
--- a/hydra_detect/capability_status.py
+++ b/hydra_detect/capability_status.py
@@ -84,6 +84,12 @@ class SystemState:
     schema_version: str | None = None
     schema_version_present: bool = False
 
+    # SoC temperatures in degrees Celsius (None on non-Jetson hosts).
+    # Populated from system.read_jetson_stats() via the merged
+    # stream_state stats dict; see build_system_state.
+    cpu_temp_c: float | None = None
+    gpu_temp_c: float | None = None
+
     # Raw config parser (optional — used by some evaluators)
     cfg: Any = None
 
@@ -113,6 +119,12 @@ def build_system_state(
             last_frame_ts = stats.get("last_frame_ts")
             if last_frame_ts is not None:
                 state.camera_frame_age_sec = time.monotonic() - float(last_frame_ts)
+            # Jetson SoC temps are merged into stats by pipeline.facade
+            # via system.read_jetson_stats(); read straight through.
+            cpu_t = stats.get("cpu_temp_c")
+            gpu_t = stats.get("gpu_temp_c")
+            state.cpu_temp_c = float(cpu_t) if cpu_t is not None else None
+            state.gpu_temp_c = float(gpu_t) if gpu_t is not None else None
         except Exception:
             pass
 
@@ -208,6 +220,10 @@ _STALE_FRAME_SEC = 5.0       # frame age beyond which detection is WARN
 _STALE_HEARTBEAT_SEC = 5.0   # heartbeat age beyond which MAVLink is WARN
 _DISK_WARN_GB = 2.0          # free disk WARN threshold
 _DISK_BLOCKED_GB = 0.5       # free disk BLOCKED threshold
+# SoC temp thresholds. Orin Nano begins thermal throttling around 85-92 °C
+# depending on rail; WARN at 75 leaves the operator margin to land/shade.
+_SOC_TEMP_WARN_C = 75.0
+_SOC_TEMP_BLOCK_C = 90.0
 
 
 # ── Evaluators ────────────────────────────────────────────────────────────────
@@ -397,6 +413,46 @@ def _eval_schema_version(state: SystemState) -> CapabilityReport:
     return CapabilityReport("Schema Version", CapabilityStatus.READY)
 
 
+def _eval_thermal(state: SystemState) -> CapabilityReport:
+    """Operator-visible SoC temperature gate.
+
+    Treats unknown temps (None on both zones) as READY rather than WARN —
+    dev boxes and SITL hosts have no sysfs thermal data, and surfacing a
+    nag-warn there would train operators to ignore the signal.
+    """
+    cpu = state.cpu_temp_c
+    gpu = state.gpu_temp_c
+
+    available = [t for t in (cpu, gpu) if t is not None]
+    if not available:
+        return CapabilityReport("Thermal", CapabilityStatus.READY)
+
+    hottest = max(available)
+    detail = (
+        f"cpu={cpu:.1f}C, gpu={gpu:.1f}C"
+        if (cpu is not None and gpu is not None)
+        else (f"cpu={cpu:.1f}C" if cpu is not None else f"gpu={gpu:.1f}C")
+    )
+
+    if hottest > _SOC_TEMP_BLOCK_C:
+        reasons = [
+            f"SoC at {hottest:.1f}C ({detail}). "
+            f"Above thermal-throttle limit of {_SOC_TEMP_BLOCK_C:.0f}C — "
+            "performance is degraded. Land or shade the unit immediately."
+        ]
+        return CapabilityReport("Thermal", CapabilityStatus.BLOCKED, reasons)
+
+    if hottest > _SOC_TEMP_WARN_C:
+        reasons = [
+            f"SoC at {hottest:.1f}C ({detail}). "
+            f"Above WARN threshold of {_SOC_TEMP_WARN_C:.0f}C — approaching "
+            "thermal throttling. Increase airflow or reduce load."
+        ]
+        return CapabilityReport("Thermal", CapabilityStatus.WARN, reasons)
+
+    return CapabilityReport("Thermal", CapabilityStatus.READY)
+
+
 def _eval_autonomy_live(state: SystemState) -> CapabilityReport:
     return CapabilityReport(
         "Autonomy Live",
@@ -436,6 +492,7 @@ _EVALUATORS: list[tuple[str, Any]] = [
     ("Time Source", _eval_time_source),
     ("Vehicle Profile", _eval_vehicle_profile),
     ("Schema Version", _eval_schema_version),
+    ("Thermal", _eval_thermal),
     ("Autonomy Live", _eval_autonomy_live),
     ("Drop", _eval_drop),
     ("RF Hunt", _eval_rf_hunt),

--- a/tests/test_capability_status.py
+++ b/tests/test_capability_status.py
@@ -48,6 +48,8 @@ def _make_state(**overrides) -> SystemState:
         vehicle_profile_present=True,
         schema_version="1",
         schema_version_present=True,
+        cpu_temp_c=50.0,
+        gpu_temp_c=55.0,
         cfg=None,
     )
     defaults.update(overrides)
@@ -111,6 +113,7 @@ EXPECTED_CAPABILITIES = [
     "Time Source",
     "Vehicle Profile",
     "Schema Version",
+    "Thermal",
     "Autonomy Live",
     "Drop",
     "RF Hunt",
@@ -398,6 +401,75 @@ class TestSchemaVersionEvaluator:
         r = next(r for r in reports if r.name == "Schema Version")
         assert r.status == CapabilityStatus.BLOCKED
         assert len(r.reasons) > 0
+
+
+# ---------------------------------------------------------------------------
+# Thermal evaluator (SoC temp from /sys/devices/virtual/thermal)
+# ---------------------------------------------------------------------------
+
+class TestThermalEvaluator:
+    """Operator-visible WARN/BLOCKED gating on Jetson SoC temperature.
+
+    Threshold rationale: Orin Nano begins thermal throttling around 85-92 °C
+    depending on the rail. WARN at 75 °C gives the operator margin to land
+    or shade the unit before performance degrades; BLOCKED at 90 °C is the
+    'stop using this unit' line.
+    """
+
+    def test_ready_when_temps_unavailable(self):
+        """No Jetson hardware (dev box, sim) — return READY rather than warn."""
+        state = _make_state(cpu_temp_c=None, gpu_temp_c=None)
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Thermal")
+        assert r.status == CapabilityStatus.READY
+
+    def test_ready_when_cool(self):
+        state = _make_state(cpu_temp_c=45.0, gpu_temp_c=50.0)
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Thermal")
+        assert r.status == CapabilityStatus.READY
+        assert r.reasons == []
+
+    def test_warn_when_cpu_above_threshold(self):
+        state = _make_state(cpu_temp_c=80.0, gpu_temp_c=50.0)
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Thermal")
+        assert r.status == CapabilityStatus.WARN
+        assert any("80" in reason or "75" in reason for reason in r.reasons)
+
+    def test_warn_when_gpu_above_threshold(self):
+        state = _make_state(cpu_temp_c=60.0, gpu_temp_c=82.0)
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Thermal")
+        assert r.status == CapabilityStatus.WARN
+
+    def test_warn_uses_hottest_zone(self):
+        """If only one zone is hot, the report still warns (max wins)."""
+        state = _make_state(cpu_temp_c=30.0, gpu_temp_c=78.0)
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Thermal")
+        assert r.status == CapabilityStatus.WARN
+
+    def test_blocked_when_at_throttle_limit(self):
+        state = _make_state(cpu_temp_c=92.0, gpu_temp_c=88.0)
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Thermal")
+        assert r.status == CapabilityStatus.BLOCKED
+
+    def test_partial_data_one_zone_only(self):
+        """One zone reporting None should not crash the evaluator."""
+        state = _make_state(cpu_temp_c=80.0, gpu_temp_c=None)
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Thermal")
+        assert r.status == CapabilityStatus.WARN
+
+    def test_at_warn_boundary_is_warn(self):
+        """75.0 °C exactly is the warn threshold — strictly-above triggers."""
+        # Slightly above to avoid floating-point ambiguity.
+        state = _make_state(cpu_temp_c=75.1, gpu_temp_c=50.0)
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Thermal")
+        assert r.status == CapabilityStatus.WARN
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Surfaces SoC temperature on the operator readiness page so thermal state shows up alongside Detection / MAVLink / GPS, not just on the `/metrics` scrape. Builds on the provider wiring from #181 — the data was already in `stream_state`, this PR turns it into operator-visible status.

## Why now

Per the May 2026 prior-art note: "Forum reports of 'fine in shop, terrible at noon outdoors' are universal on Orin Nano." The metrics endpoint that #181 enabled gives us telemetry off-box, but the field operator looking at the dashboard had no thermal signal at all. The Thermal capability is the in-cockpit version of that telemetry.

## Behaviour

| Hottest of cpu/gpu | Status | Notes |
|---|---|---|
| Both None (no Jetson sysfs) | READY | Dev / SITL — no nag |
| ≤ 75 °C | READY | Normal operating range |
| > 75 °C | WARN | Approaching throttling, increase airflow |
| > 90 °C | BLOCKED | At throttle limit, performance degraded |

Reasoning on threshold choices:
- Orin Nano begins thermal throttling at 85–92 °C depending on rail.
- WARN at 75 °C gives the operator margin to land or shade the unit before performance actually drops.
- BLOCKED at 90 °C is the "stop using this unit" line.

These are module-level constants matching the existing `_DISK_WARN_GB` pattern (operators don't tune them — they're physics-based defaults).

## Files touched

| File | Change |
|---|---|
| `hydra_detect/capability_status.py` | Two new `SystemState` fields, build_system_state read from stream_state, new `_eval_thermal`, registry entry |
| `tests/test_capability_status.py` | 8 new tests in `TestThermalEvaluator`; registry list updated |

`capability_status.py` is on the flagged-path list — flagging here. The change is purely additive: one new evaluator, two new SystemState fields, no existing behaviour modified, no defaults changed.

## Test plan

`TestThermalEvaluator` covers:
- [x] Both temps None (dev box) → READY, no reasons
- [x] Both temps cool → READY
- [x] CPU above 75, GPU cool → WARN
- [x] GPU above 75, CPU cool → WARN  
- [x] Hottest zone drives the status (max wins)
- [x] Above 90 °C → BLOCKED with land-immediately reason
- [x] One zone None, other hot → still WARN (no NoneType crash)
- [x] At 75.1 °C boundary → WARN (strictly-above semantics)

Local results:
- `test_capability_status.py`: **56 passed, 8 skipped** (skipped tests are the Linux-only API integration suite — pre-existing fcntl skip)
- 15-module Windows-runnable subset: **368 passed, 8 skipped**
- `flake8` clean on touched code (3 unrelated F401 warnings on test_capability_status.py imports were pre-existing)

## What this does NOT do

- Does not add the sustained-FPS WARN tracker (the "FPS < 70% target sustained 30s" half of the action item). That needs a stateful tracker fed from the pipeline hot loop and a target-FPS knob — bigger PR, will follow.
- Does not add a config knob for the thresholds. Hardcoded matches the existing `_DISK_WARN_GB` precedent. Open to flipping to config if you want tunable thresholds per-platform.
- Does not change `system.read_jetson_stats()` or `stream_state` — the data plumbing was already there.

## Reviewer asks

- **Threshold values** — 75 / 90 °C is from the prior-art research note. If your field experience suggests different limits per platform, easy to flip.
- **READY-on-unavailable** — picked READY rather than WARN for None temps so SITL / dev boxes don't carry a permanent yellow light. Flip to WARN if you'd rather force every host to surface real thermal data.