### PR TITLE
feat(tracker): optional boxmot re-ID layer for cluttered-scene Follow

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -27,6 +27,14 @@ low_light_luminance = 40
 track_thresh = 0.5
 track_buffer = 30
 match_thresh = 0.8
+; Re-ID layer (BoT-SORT + OSNet via boxmot). Default off — preserves
+; ByteTrack behaviour and zero runtime cost. When true, requires the
+; optional boxmot package (pip install -r requirements-extra.txt).
+; Use for Follow mode in cluttered scenes where pure ByteTrack swaps
+; IDs across full occlusions or similar-appearing targets.
+reid_enabled = false
+reid_tracker_type = botsort
+
 
 [mavlink]
 enabled = true

--- a/docs/adversarial/184.md
+++ b/docs/adversarial/184.md
@@ -1,0 +1,143 @@
+# Adversarial Analysis — PR #184 (claude/tracker-reid)
+
+**Generated:** 2026-05-05T00:12:49Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/184
+**PR head:** fe3f3db8a34ed9314c900826e09effc49875e451
+**Base:** main at 56fbd2de
+**Diff size:** +539 / -24 across 9 files
+
+## Summary
+
+- **Round 1:** 11 findings (2 high · 5 medium · 4 low). Pattern-match dominated by fail-safe and operational/deployment categories; thread-safety and memory quiet.
+- **Round 2:** 6 second-order findings, confirmed 10 of 11 R1 findings, **challenged R1-5** by directly running CPython 3.12 to verify `importlib.util.find_spec('boxmot')` returns `None` (not ValueError) when `sys.modules['boxmot']=None` — the dependency-probe test is correct after all.
+- **Round 3:** 9 findings, framing identified — *both prior rounds audited the wrapper from inside without auditing the deploy pipeline that decides whether boxmot can ever be present, nor the downstream consumers that a tracker swap silently invalidates.*
+- **Consolidated:** 1 blocker · 5 gates · 9 follow-ups · 1 dropped (R1-5).
+
+## Round 1 — Pattern Match
+
+11 findings. Dominant pattern: operational/deployment failure modes — uncaught ImportError on init at both boot and restart paths, default OSNet weights gdown'd from Google Drive on first use, no pre-flight check despite `reid_dependency_available()` being defined, no schema choices= constraint on `reid_tracker_type`, hardcoded cuda:0 / half=True with no CPU fallback. Tracker logic itself (boxmot output parsing, empty-detection handling, ByteTracker forward-compat) is reasonable.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | high | fail-safe | facade.py:1016 | Pipeline boot crash on ImportError when reid_enabled true and boxmot missing — no try/except guard. |
+| R1-2 | high | network-dep | tracker.py:226-255 | OSNet weights auto-fetched from Google Drive on first use; offline field Jetson hangs. |
+| R1-3 | medium | input-validation | config_schema.py:186-193 | reid_tracker_type free-form string with no choices=; typos surface as boxmot exceptions. |
+| R1-4 | medium | input-validation | facade.py:196 | reid_dependency_available() defined but never called for pre-flight. |
+| R1-5 | medium | test-quality | tests/test_tracker.py:69-75 | (DROPPED — R2 verification on Python 3.12 shows the test is correct.) |
+| R1-6 | medium | api-surface | tracker.py:247-251 | TypeError fallback drops device/half/reid_weights silently. |
+| R1-7 | medium | hardware | tracker.py:213-225 | device cuda:0 / half True hardcoded; no CPU fallback. |
+| R1-8 | low | boundary | tracker.py:319-323 | Nx5 boxmot output silently degrades to conf=0.0, cls=0. |
+| R1-9 | low | real-time | facade.py:1465 | OSNet adds 15-30ms per frame; no FPS regression test for the 5 FPS floor. |
+| R1-10 | low | memory | facade.py:1266-1286 | Restart path briefly holds two OSNet inference graphs in GPU memory. |
+| R1-11 | low | doc-drift | tracker.py:309-311 | Test stub shape inconsistency between Nx7 and Nx8. |
+
+## Round 2 — Counter-Critique
+
+**Challenged:** R1-5 — R2 ran `python -c "import sys, importlib.util; sys.modules['boxmot']=None; print(importlib.util.find_spec('boxmot'))"` on Python 3.12.10 and observed it returns `None` (not ValueError). CPython has handled this consistently since 3.5+. Dependency probe test passes correctly. Drop.
+
+**Confirmed:** 10 of 11 R1 findings (R1-1 through R1-4, R1-6 through R1-11) with sharper evidence. R1-10's adjacent concern about active Approach lock surviving a tracker swap was closed: `_init_target_state()` resets `_locked_track_id`, `_shutdown()` calls `_approach.abort()` — the lock-state machine is clean. Operator-visible effects are still a concern (see R3-2).
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | high | fail-safe | facade.py:1271 | Restart-path detector.load() also bare; outer try/except logs+breaks but no STATUSTEXT, no servo-safe — silent process exit on bad config mid-engagement. |
+| R2-2 | high | operator | facade.py:196 | Tension between R1-1's implied fallback fix and R1-4's pre-flight refusal — silent ByteTrack downgrade after operator promised re-ID is operationally worse than a crash for Follow mode safety. Right fix order: pre-flight first, guarded init second. |
+| R2-3 | medium | config | web/server.py | Dashboard "Active Model" has no awareness of OSNet appearance model; missing/loading/loaded state hidden from operator. |
+| R2-4 | medium | config | migrations/004_tracker_reid.py:26 | Migration touches only base [tracker]; per-vehicle [vehicle.*] override sections ignored — sets a precedent that misfires when planned per-vehicle reid_enabled follow-up lands. |
+| R2-5 | low | test-quality | tests/test_tracker.py:154 | No test for the raise branch when boxmot ValueErrors on NON-empty detections. |
+| R2-6 | nit | api-surface | tracker.py:124 | frame_shape kwarg dead surface area on both ByteTracker and ReIDTracker.update(). |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds framed PR #184 as "is the new tracker option safe at the module/init layer if boxmot is missing or misconfigured" — they audited the wrapper's failure modes but did not audit the deploy pipeline that decides whether boxmot can ever be present, nor the downstream consumers (Approach lock, TAK UID, detection-logger track_id continuity) that a tracker swap silently invalidates.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **blocker** | other | Dockerfile + .github/workflows/ci.yml + scripts/deploy.sh | **`requirements-extra.txt` is never installed by any deploy or CI path**; `reid_enabled=true` is permanently unreachable in production no matter how correct the wrapper is. **Verified:** Dockerfile:21-23 only `COPY requirements.txt`; ci.yml:64-67 installs requirements.txt + requirements-dev.txt only; scripts/* contain zero references to requirements-extra. R1-1's ImportError is 100% reachable, not a corner case. |
+| R3-2 | high | emergent-coupling | facade.py:1269 + approach.py:86 + tak/tak_output.py:341 | Runtime tracker swap reassigns IDs from a different pool while `ApproachController._target_track_id`, TAK CoT UIDs (`callsign-DET-{id}`), detection_logger rows, and geo_tracking histories all hold the OLD pool's IDs. ATAK sees a flood of "new contacts," log replay sees ID collisions, operator-visible Follow break at the moment of swap. |
+| R3-3 | high | no-sim | tests/test_tracker.py | The PR's central claim — "ID-stable across full occlusions, target crossings in cluttered scenes" — has zero perception-layer test coverage. No two-target-crossing replay, no IDF1/HOTA, no identical-uniform adversarial fixture, no FPS regression on Jetson. Tests cover wiring only. |
+| R3-4 | high | operator-adversarial | config.ini + migrations/004_tracker_reid.py | A SORCC student flips reid_enabled true mid-sortie, hits /api/restart: gdown blocks on tethered field WiFi → boxmot anyway absent (R3-1) → ImportError → outer try/except logs+breaks with no STATUSTEXT, no servo-safe — dashboard says "restarted," vehicle no longer being tracked. Schema-valid, operationally catastrophic. |
+| R3-5 | medium | operator-adversarial | config_schema.py:186-193 | reid_tracker_type accepts strongsort, deepocsort etc. but boxmot pin >=12,<16 spans algorithm implementations that differ across the range — fleet units running different boxmot versions get fundamentally different tracking behind the same config value. |
+| R3-6 | medium | operator-adversarial | migrations/004_tracker_reid.py:26 | Heewing T1 fixed-wing inheriting reid_enabled true (planned drone-profile follow-up bleeds across) extracts appearance embeddings from motion-blurred 60 km/h pass — re-ID is approximately useless on a fixed-wing and the system gives no platform-aware advice. |
+| R3-7 | medium | other | docs/ | No upgrade guide, release notes, or operator-facing documentation accompanies the migration, optional install, OSNet weights cache, or v3→v4 schema bump. Existing fleet hits migration 004 silently on next start. |
+| R3-8 | medium | consistency-bias | N/A | R1+R2 agreed on 10 of 11 findings (91% concordance) — both inside the "audit the wrapper" frame, ranking threats relative to wrapper correctness rather than deploy reachability or operator outcome. R3-1 is the strict superset of R1-1's blast radius that neither earlier round flagged. |
+| R3-9 | high | emergent-coupling | facade.py:1463-1465 + tracker.py:272 | Calibration target #7 (frozen-frame watchdog) interacts with this PR: ReIDTracker.update() only checks `frame is None`, but a frozen camera returning the same byte buffer repeatedly satisfies the check while the perception layer is blind. Appearance embeddings extracted from a frozen frame REINFORCE stale IDs and survive a Follow lock indefinitely on a black-screen camera — the exact pathology target #7 calls out, now harder to escape. |
+
+### Consistency-bias callouts
+
+- **R1-1 (high) + R2 confirm:** Both rounds rated "unguarded init crashes process" as high without observing R3-1 makes it 100% reachable on default Docker build — actual operator-experienced severity is **blocker**, not high.
+- **R1-2 (high) + R2 confirm:** Both treated gdown-on-field-WiFi independently of R3-1; once R3-1 is accepted, gdown never runs because boxmot is never imported, and the real risk shifts to operators believing re-ID is active when it has been impossible since deploy.
+- **R1-10 (low) + R2 confirm:** Both rated transient double-OSNet GPU residency low, but on a 4GB shared-memory Jetson during /api/restart with YOLO + old-OSNet + new-OSNet + activations, an OOM kill mid-engagement is platform-failure, not low. Under-rated because neither could measure it.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| **blocker** | other | R3-1 | `requirements-extra.txt` is referenced nowhere in Dockerfile, CI workflow, or deploy scripts — `reid_enabled=true` is permanently unreachable in production. Fix: add `pip install -r requirements-extra.txt` (gated on a build flag or always-on with the optional pin) to Dockerfile and update `scripts/deploy.sh` to mirror the install on bare-Python deploys. The PR cannot ship as a usable feature without this. | R3-1 (subsumes R1-1's blast radius) | **blocker** — must fix before merge |
+| high | fail-safe | R1-1 + R2-1 | Bare `self._tracker.init()` at facade.py:1016 (boot) and the bare `_detector.load()` at facade.py:1271 (restart) crash uncaught on ImportError or model-corruption; restart path's outer try/except logs+breaks with no operator-visible STATUSTEXT, no servo-safe. | R1-1 + R2-1 | **gate** — wrap with try/except, emit STATUSTEXT, run safe-state on failure |
+| high | emergent-coupling | R3-2 | Runtime tracker swap invalidates downstream state keyed on track_id (Approach lock, TAK CoT UIDs, detection_logger, geo_tracking). Lock-state machine itself is clean (R2 closed that vector); the operator-visible effects (Follow break, ATAK contact churn, log-replay collisions) are the failure mode. | R3-2 | **gate** — design fix or document operator-side restart contract |
+| high | no-sim | R3-3 | Zero perception-layer test for "ID-stable across full occlusions / target crossings." Tests cover wiring only. | R3-3 | **gate** — add a two-target-crossing replay or property-based fixture before flipping reid_enabled true on any platform profile |
+| high | operator-adversarial | R3-4 | SORCC student flipping reid_enabled mid-sortie + /api/restart → gdown hang on tethered WiFi → boxmot absent (R3-1) → ImportError → silent process exit. End-to-end operator-catastrophic chain. | R3-4 (composite of R1-1, R1-2, R2-1, R3-1) | **gate** — closed once R3-1 + R1-1/R2-1 fixes are landed and a pre-flight exposes "reid_enabled=true but boxmot missing" via dashboard |
+| high | network-dep | R1-2 | Default OSNet weights auto-fetched from Google Drive on first use; offline field Jetson hangs or crashes. | R1-2 | **gate** — pre-cache the OSNet weights into the Jetson Docker image; ReIDTracker should refuse to init() when `reid_weights=None` AND the cache path is empty AND no internet is reachable |
+| high | emergent-coupling | R3-9 | ReIDTracker.update only checks `frame is None`; a frozen camera (calibration target #7) passes the check, embeddings reinforce stale IDs, Follow lock survives indefinitely on a black-screen camera. | R3-9 | **gate** — couple this fix to whatever target #7 lands; e.g. hash-check on consecutive frames or require fresh-frame timestamp |
+| medium | input-validation | R1-3 | reid_tracker_type free-form FieldType.STRING with no choices=. Typos surface as boxmot init exceptions. | R1-3 | **follow-up** — change to FieldType.ENUM with choices=["botsort", "bytetrack", "deepocsort", "ocsort", "strongsort", "hybridsort", "imprassoc"] |
+| medium | input-validation | R1-4 + R3-4 | reid_dependency_available() defined but never called. Pre-flight cannot tell operator "reid_enabled true but boxmot missing" before the pipeline crashes. | R1-4 | **follow-up** — call from validate_config() and surface on dashboard pre-flight |
+| medium | api-surface | R1-6 | TypeError fallback at tracker.py:247-251 silently drops device/half/reid_weights. | R1-6 | **follow-up** — log a WARNING and propagate the original TypeError if boxmot version doesn't match the documented signature |
+| medium | hardware | R1-7 | device cuda:0 / half True hardcoded; no CPU fallback or torch.cuda.is_available() probe. | R1-7 | **follow-up** — probe CUDA availability at init(); fall back to cpu/half=False with a logged WARN if absent |
+| medium | config | R2-3 | Dashboard "Active Model" registry has no OSNet awareness; weight load state hidden from operator. | R2-3 | **follow-up** — register the OSNet weights with model_manifest and surface on dashboard |
+| medium | config | R2-4 + R3-6 | Migration 004 only touches base [tracker]; per-vehicle [vehicle.*] override sections ignored. The planned per-vehicle reid_enabled follow-up will misfire on fleets running fixed-wing alongside drone. | R2-4 + R3-6 | **follow-up** — design per-vehicle migration scope before the planned drone-profile flip lands |
+| medium | operator-adversarial | R3-5 | Schema-valid reid_tracker_type values map to algorithms that differ across boxmot 12-15 — fleet units get different tracking behind the same config value. | R3-5 | **follow-up** — pin boxmot tighter (e.g. exact ==12.x) or assert version at init() |
+| medium | other | R3-7 | No upgrade guide / release notes / operator docs for migration, optional install, OSNet cache, or schema bump. | R3-7 | **follow-up** — add docs/upgrade notes before the v3→v4 fleet rollout |
+| medium | consistency-bias | R3-8 | R1+R2 agreed on 10 of 11; both inside the "audit the wrapper" frame; missed deploy-pipeline reachability. | R3-8 | **follow-up** — process note: future PRs touching opt-in features should include a deploy-pipeline audit |
+| medium | memory | R1-10 | Transient double-OSNet GPU residency on /api/restart on a 4GB Jetson — OOM kill mid-engagement is platform failure. | R1-10 | **follow-up** — add `if self._tracker is not None: self._tracker.reset(); self._tracker = None` in `_shutdown()` before the new tracker is instantiated |
+| low | boundary | R1-8 | Nx5 boxmot output silently degrades to conf=0.0, cls=0; alert thresholds and class filtering corrupt quietly. | R1-8 | **follow-up** — assert minimum column count or log a once-per-version WARN |
+| low | real-time | R1-9 | OSNet adds 15-30 ms per frame; 5 FPS floor unverified with reid_enabled true. | R1-9 | **follow-up** — pairs with R3-3's gate; add an FPS-regression hypothesis test |
+| low | doc-drift | R1-11 | Test stub returns Nx7 in one test, Nx8 in another — cosmetic. | R1-11 | **follow-up** |
+| low | test-quality | R2-5 | No test for the raise branch when boxmot ValueErrors on non-empty detections. | R2-5 | **follow-up** |
+| nit | api-surface | R2-6 | frame_shape kwarg dead surface area. | R2-6 | **follow-up** |
+| dropped | test-quality | R1-5 | find_spec test breakage — R2 directly verified on Python 3.12 that find_spec returns None (not ValueError) for sys.modules[name]=None sentinel. | R1-5 (R2 challenge) | dropped |
+
+## Recommended Gates
+
+**Blocker (must fix before merge):**
+- **R3-1** — Add `requirements-extra.txt` install path. Either bake into Dockerfile unconditionally (cheap install if boxmot import is lazy in tracker.py) or gate on a build arg `WITH_REID=1`. Either way, the deploy pipeline must be capable of producing a Jetson image where `reid_enabled=true` works. The PR ships a feature flag whose runtime is currently unreachable in any deployed image — that is not "opt-in," it is "broken."
+
+**Gate (need a small test, design fix, or hardware/sim validation before this signal is trusted):**
+- **R1-1 + R2-1** — wrap both bare init paths with try/except + STATUSTEXT + servo-safe.
+- **R1-2** — pre-cache OSNet weights in the Jetson image AND refuse to init() when cache path is missing.
+- **R3-2** — runtime tracker swap operator-visible effects: design fix (drop ATAK markers + reset detection-logger ID space + abort approach) or document the operator-side contract that tracker swaps require sortie boundaries.
+- **R3-3** — add a perception-layer test (two-target crossing replay or hypothesis property test) before flipping reid_enabled true on any platform profile.
+- **R3-9** — couple to whatever calibration target #7 fix lands. Frozen-camera detection (frame hash, fresh-frame timestamp) needed to avoid OSNet reinforcing stale IDs indefinitely.
+- **R3-4** — composite gate; closed when R3-1 + R1-1 fixes are landed AND R1-4 pre-flight exposes the missing-boxmot case via dashboard.
+
+**Follow-up (file an issue; merge can proceed once blocker + gates are addressed):**
+- R1-3 (FieldType.ENUM with choices for reid_tracker_type)
+- R1-4 (call reid_dependency_available from validate_config / pre-flight)
+- R1-6 (log WARN on TypeError fallback)
+- R1-7 (CUDA availability probe + CPU fallback)
+- R2-3 (dashboard OSNet awareness)
+- R2-4 + R3-6 (per-vehicle migration scope)
+- R3-5 (tighter boxmot pin or version assert)
+- R3-7 (upgrade docs)
+- R3-8 (deploy-pipeline audit as a process step)
+- R1-10 (tracker teardown in _shutdown)
+- R1-8, R1-9, R1-11, R2-5, R2-6 (minor test/doc/code-quality items)
+
+**Accepted risk:**
+- R1-5 — verified non-issue. Documented for future readers.
+
+## Known ceiling
+
+Prompt-based analysis cannot catch:
+- Whether the SORCC field deploy actually rebuilds the Docker image vs pulls a pre-baked one — R3-1 is decisive only if rebuilds happen. CLAUDE.md's "no auto-deploy" note suggests deploys go through `scripts/deploy.sh` which DOES rebuild, so R3-1 is decisive.
+- ATAK behavior on duplicate UIDs after tracker swap (R3-2) — needs a TAK server replay.
+- OSNet embedding stability on a frozen-frame camera (R3-9) — needs hardware test.
+- OSNet inference latency on Jetson Orin Nano under cluttered Follow workload (R1-9) — published benchmarks suggest 2-3ms/det but field measurement required.
+- Whether boxmot's gdown call honors a network timeout vs hangs indefinitely on a non-routable Google Drive — needs offline hardware test.
+- Whether boxmot v12 vs v15 produces materially different tracking on the same input (R3-5) — needs version-matrix replay.
+
+R3-1 is the single most consequential finding and is reachable by static read; it should not block on hardware time. The rest of the gates either pair with R3-1 (R3-4) or need a small targeted test (R3-3, R3-9) that can be a hypothesis property test rather than a full SITL replay.

--- a/hydra_detect/config_migrate.py
+++ b/hydra_detect/config_migrate.py
@@ -44,7 +44,7 @@ from types import ModuleType
 logger = logging.getLogger(__name__)
 
 # Bump this when adding a new migration file.
-CURRENT_SCHEMA_VERSION: int = 3
+CURRENT_SCHEMA_VERSION: int = 4
 
 # Migration modules directory (monkeypatched in tests to point at fixtures).
 _MIGRATIONS_DIR: Path = Path(__file__).parent / "migrations"

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -175,6 +175,22 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             default=0.8,
             description="IOU match threshold",
         ),
+        "reid_enabled": FieldSpec(
+            FieldType.BOOL,
+            default=False,
+            description=(
+                "Enable BoT-SORT + OSNet re-ID via boxmot. "
+                "Requires optional boxmot package."
+            ),
+        ),
+        "reid_tracker_type": FieldSpec(
+            FieldType.STRING,
+            default="botsort",
+            description=(
+                "boxmot tracker variant: botsort, bytetrack, deepocsort, "
+                "ocsort, strongsort, hybridsort, imprassoc."
+            ),
+        ),
     },
     "mavlink": {
         "enabled": FieldSpec(FieldType.BOOL, default=True, description="Enable MAVLink connection"),

--- a/hydra_detect/migrations/004_tracker_reid.py
+++ b/hydra_detect/migrations/004_tracker_reid.py
@@ -1,0 +1,32 @@
+"""Migration 004 — add re-ID keys to [tracker].
+
+Defaults preserve existing behaviour: reid_enabled=false keeps ByteTrack
+as the active tracker so deployed units that do not flip the flag pay
+zero runtime cost. The boxmot dependency is optional (see
+requirements-extra.txt) — installing it is only required when an
+operator turns reid_enabled=true on a specific unit.
+
+Idempotent: keys are only inserted when absent.
+"""
+
+from __future__ import annotations
+
+import configparser
+
+from_version: int = 3
+to_version: int = 4
+
+
+_DEFAULTS: dict[str, str] = {
+    "reid_enabled": "false",
+    "reid_tracker_type": "botsort",
+}
+
+
+def migrate(cfg: configparser.ConfigParser) -> None:
+    """Insert re-ID keys into [tracker] if missing."""
+    if not cfg.has_section("tracker"):
+        cfg.add_section("tracker")
+    for key, value in _DEFAULTS.items():
+        if not cfg.has_option("tracker", key):
+            cfg.set("tracker", key, value)

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -48,7 +48,7 @@ from ..mavlink_video import MAVLinkVideoSender
 from ..tak.mavlink_relay import MAVLinkRelayOutput
 from ..tak.tak_input import TAKInput
 from ..tak.tak_output import TAKOutput
-from ..tracker import ByteTracker
+from ..tracker import ByteTracker, ReIDTracker
 from ..profiles import get_profile, load_profiles
 from ..web.config_api import set_config_path, set_engagement_check
 from ..web.server import (
@@ -189,13 +189,24 @@ class Pipeline:
         # Detector
         self._detector = _build_detector(self._cfg, self._models_dir)
 
-        # Tracker
-        self._tracker = ByteTracker(
-            track_thresh=self._cfg.getfloat("tracker", "track_thresh", fallback=0.5),
-            track_buffer=self._cfg.getint("tracker", "track_buffer", fallback=30),
-            match_thresh=self._cfg.getfloat("tracker", "match_thresh", fallback=0.8),
-            frame_rate=self._cfg.getint("camera", "fps", fallback=30),
-        )
+        # Tracker — ByteTrack by default, optional boxmot re-ID layer when
+        # [tracker] reid_enabled=true. The re-ID path requires the optional
+        # boxmot dependency (see requirements-extra.txt) and the actual
+        # frame to extract appearance embeddings each update.
+        if self._cfg.getboolean("tracker", "reid_enabled", fallback=False):
+            self._reid_enabled = True
+            self._tracker = ReIDTracker(
+                tracker_type=self._cfg.get(
+                    "tracker", "reid_tracker_type", fallback="botsort"),
+            )
+        else:
+            self._reid_enabled = False
+            self._tracker = ByteTracker(
+                track_thresh=self._cfg.getfloat("tracker", "track_thresh", fallback=0.5),
+                track_buffer=self._cfg.getint("tracker", "track_buffer", fallback=30),
+                match_thresh=self._cfg.getfloat("tracker", "match_thresh", fallback=0.8),
+                frame_rate=self._cfg.getint("camera", "fps", fallback=30),
+            )
 
         # Alert class filter (shared with MAVLink and overlay)
         alert_classes_raw = self._cfg.get("mavlink", "alert_classes", fallback="")
@@ -1258,12 +1269,20 @@ class Pipeline:
                 self._cfg.read(get_config_path())
                 self._detector = _build_detector(self._cfg, self._models_dir)
                 self._detector.load()
-                self._tracker = ByteTracker(
-                    track_thresh=self._cfg.getfloat("tracker", "track_thresh", fallback=0.5),
-                    track_buffer=self._cfg.getint("tracker", "track_buffer", fallback=30),
-                    match_thresh=self._cfg.getfloat("tracker", "match_thresh", fallback=0.8),
-                    frame_rate=self._cfg.getint("camera", "fps", fallback=30),
-                )
+                if self._cfg.getboolean("tracker", "reid_enabled", fallback=False):
+                    self._reid_enabled = True
+                    self._tracker = ReIDTracker(
+                        tracker_type=self._cfg.get(
+                            "tracker", "reid_tracker_type", fallback="botsort"),
+                    )
+                else:
+                    self._reid_enabled = False
+                    self._tracker = ByteTracker(
+                        track_thresh=self._cfg.getfloat("tracker", "track_thresh", fallback=0.5),
+                        track_buffer=self._cfg.getint("tracker", "track_buffer", fallback=30),
+                        match_thresh=self._cfg.getfloat("tracker", "match_thresh", fallback=0.8),
+                        frame_rate=self._cfg.getint("camera", "fps", fallback=30),
+                    )
                 self._tracker.init()
                 self._camera = Camera(
                     source=self._cfg.get("camera", "source", fallback="auto"),
@@ -1441,8 +1460,9 @@ class Pipeline:
             # the pipeline is alive even if render/RTSP/stats takes time.
             self._last_frame_time = time.monotonic()
 
-            # Track
-            track_result = self._tracker.update(det_result)
+            # Track. ReIDTracker needs the raw frame for appearance
+            # embeddings; ByteTracker accepts and ignores it (forward-compat).
+            track_result = self._tracker.update(det_result, frame=frame)
             with self._state_lock:
                 self._last_track_result = track_result
                 self._total_detections += len(track_result)

--- a/hydra_detect/tracker.py
+++ b/hydra_detect/tracker.py
@@ -1,16 +1,44 @@
-"""ByteTrack multi-object tracker wrapper."""
+"""Multi-object tracker wrappers.
+
+Two implementations live here:
+
+- ``ByteTracker``: the default. Wraps the supervision ByteTrack backend.
+  Cheap, robust, but swaps IDs on full occlusion and in groups.
+
+- ``ReIDTracker``: optional, gated by ``[tracker] reid_enabled = true``.
+  Wraps boxmot (BoT-SORT / DeepOCSORT / etc.) which layers an appearance
+  embedding on top of motion-based tracking. Survives target crossings in
+  cluttered scenes — the textbook fix for Follow-mode flying to the wrong
+  person. Requires the optional ``boxmot`` dependency from
+  ``requirements-extra.txt``; the import is lazy so deployed units that
+  do not enable the flag pay zero runtime cost.
+"""
 
 from __future__ import annotations
 
+import importlib
+import importlib.util
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import numpy as np
 
 from .detectors.base import DetectionResult
 
 logger = logging.getLogger(__name__)
+
+
+_BOXMOT_INSTALL_HINT = (
+    "Install with: pip install -r requirements-extra.txt "
+    "(boxmot is optional and not in the base requirements set)."
+)
+
+
+def reid_dependency_available() -> bool:
+    """Return True iff the optional ``boxmot`` package is importable."""
+    spec = importlib.util.find_spec("boxmot")
+    return spec is not None
 
 
 @dataclass
@@ -94,8 +122,14 @@ class ByteTracker:
         self,
         detection_result: DetectionResult,
         frame_shape: tuple[int, int] | None = None,
+        frame: np.ndarray | None = None,
     ) -> TrackingResult:
-        """Feed detections and return tracked objects."""
+        """Feed detections and return tracked objects.
+
+        ``frame`` is accepted for API compatibility with ``ReIDTracker`` but
+        ignored — ByteTrack does not use appearance embeddings.
+        """
+        del frame  # unused
         if self._tracker is None:
             # Pass-through: assign sequential IDs
             tracks = [
@@ -155,3 +189,141 @@ class ByteTracker:
         """Reset tracker state."""
         if self._tracker is not None:
             self._tracker.reset()
+
+
+class ReIDTracker:
+    """Wraps a boxmot motion + appearance tracker (BoT-SORT by default).
+
+    Layered on top of ByteTrack-style motion association by an OSNet
+    appearance embedding so identity survives full occlusions and target
+    crossings in cluttered scenes — the documented failure mode of plain
+    ByteTrack on Follow-mode group scenarios.
+
+    The boxmot dependency is optional: ``init()`` lazy-imports it and
+    raises a clear ImportError pointing at ``requirements-extra.txt`` if
+    the package is absent, so deployed units that do not flip
+    ``[tracker] reid_enabled = true`` pay zero runtime cost beyond the
+    optional install footprint.
+
+    Public API mirrors ``ByteTracker``: ``init()``, ``update(det, frame=...)``,
+    ``reset()``. ``update()`` requires a frame — appearance embeddings cannot
+    be extracted without the image data.
+    """
+
+    def __init__(
+        self,
+        tracker_type: str = "botsort",
+        reid_weights: Optional[str] = None,
+        device: str = "cuda:0",
+        half: bool = True,
+    ):
+        self._tracker_type = tracker_type
+        self._reid_weights = reid_weights
+        self._device = device
+        self._half = half
+        self._tracker = None  # boxmot tracker handle, populated by init()
+
+    def init(self) -> None:
+        """Lazy-import boxmot and instantiate the underlying tracker.
+
+        Raises ImportError with an install hint if boxmot is not present.
+        """
+        try:
+            boxmot = importlib.import_module("boxmot")
+        except ImportError as exc:
+            raise ImportError(
+                f"ReIDTracker requires the optional boxmot package. "
+                f"{_BOXMOT_INSTALL_HINT}"
+            ) from exc
+
+        # boxmot.create_tracker accepts tracker_type as a positional or
+        # keyword arg depending on version; pass as kw for clarity.
+        kwargs: dict = {"tracker_type": self._tracker_type}
+        if self._reid_weights:
+            kwargs["reid_weights"] = self._reid_weights
+        kwargs["device"] = self._device
+        kwargs["half"] = self._half
+
+        try:
+            self._tracker = boxmot.create_tracker(**kwargs)
+        except TypeError:
+            # Older boxmot versions take tracker_type positionally only.
+            self._tracker = boxmot.create_tracker(self._tracker_type)
+        logger.info(
+            "ReIDTracker initialised (boxmot %s, device=%s).",
+            self._tracker_type, self._device,
+        )
+
+    def update(
+        self,
+        detection_result: DetectionResult,
+        frame_shape: tuple[int, int] | None = None,
+        frame: np.ndarray | None = None,
+    ) -> TrackingResult:
+        """Feed detections + frame and return tracked objects.
+
+        Unlike ByteTracker, ``frame`` is required — the appearance
+        embedding extractor needs the actual image. Passing ``None``
+        raises ValueError rather than silently degrading to ID-swap-prone
+        motion-only tracking.
+        """
+        if self._tracker is None:
+            raise RuntimeError("ReIDTracker.init() must be called before update().")
+        if frame is None:
+            raise ValueError(
+                "ReIDTracker.update() requires the current frame for "
+                "appearance-embedding extraction; got frame=None."
+            )
+
+        dets = detection_result.detections
+        if not dets:
+            # Some boxmot versions accept an empty Nx6; others reject it.
+            # Skip the call entirely to keep behaviour deterministic.
+            return TrackingResult()
+
+        # boxmot wants Nx6: x1, y1, x2, y2, conf, cls.
+        det_array = np.array(
+            [[d.x1, d.y1, d.x2, d.y2, d.confidence, d.class_id] for d in dets],
+            dtype=np.float32,
+        )
+
+        result = self._tracker.update(det_array, frame)
+
+        # boxmot returns Nx7 or Nx8 depending on version: x1, y1, x2, y2,
+        # id, conf, cls, [ind]. Read the first 7 columns; treat missing
+        # rows as no-tracks-this-frame.
+        if result is None or len(result) == 0:
+            return TrackingResult()
+
+        result = np.asarray(result)
+        label_map: Dict[int, str] = {d.class_id: d.label for d in dets}
+
+        tracks: list[TrackedObject] = []
+        for row in result:
+            x1, y1, x2, y2 = float(row[0]), float(row[1]), float(row[2]), float(row[3])
+            tid = int(row[4])
+            conf = float(row[5]) if len(row) > 5 else 0.0
+            cls = int(row[6]) if len(row) > 6 else 0
+            tracks.append(
+                TrackedObject(
+                    track_id=tid,
+                    x1=x1, y1=y1, x2=x2, y2=y2,
+                    confidence=conf,
+                    class_id=cls,
+                    label=label_map.get(cls, str(cls)),
+                )
+            )
+
+        return TrackingResult(tracks=tracks, active_ids=len(tracks))
+
+    def reset(self) -> None:
+        """Reset tracker state. boxmot trackers expose .reset() in
+        recent versions; older ones are reset by re-instantiation."""
+        if self._tracker is None:
+            return
+        if hasattr(self._tracker, "reset"):
+            self._tracker.reset()
+        else:
+            # Re-init from scratch; the original parameters are still
+            # held on this instance.
+            self.init()

--- a/hydra_detect/tracker.py
+++ b/hydra_detect/tracker.py
@@ -276,18 +276,35 @@ class ReIDTracker:
             )
 
         dets = detection_result.detections
-        if not dets:
-            # Some boxmot versions accept an empty Nx6; others reject it.
-            # Skip the call entirely to keep behaviour deterministic.
-            return TrackingResult()
+        # Always call boxmot.update() — even with zero detections — so the
+        # tracker ages out missed tracks during dropouts and occlusions.
+        # Returning early here freezes internal time counters and lets
+        # stale IDs persist or reassociate incorrectly when detections
+        # resume, which directly degrades re-ID quality in cluttered
+        # Follow scenarios.
+        if dets:
+            # boxmot wants Nx6: x1, y1, x2, y2, conf, cls.
+            det_array = np.array(
+                [[d.x1, d.y1, d.x2, d.y2, d.confidence, d.class_id] for d in dets],
+                dtype=np.float32,
+            )
+        else:
+            det_array = np.empty((0, 6), dtype=np.float32)
 
-        # boxmot wants Nx6: x1, y1, x2, y2, conf, cls.
-        det_array = np.array(
-            [[d.x1, d.y1, d.x2, d.y2, d.confidence, d.class_id] for d in dets],
-            dtype=np.float32,
-        )
-
-        result = self._tracker.update(det_array, frame)
+        try:
+            result = self._tracker.update(det_array, frame)
+        except (ValueError, IndexError) as exc:
+            # Defensive: a handful of older boxmot releases reject empty
+            # arrays. Log once and fall back to an empty result rather
+            # than crashing the pipeline. This is strictly an old-version
+            # safety net; modern boxmot (>=10.0) handles empty Nx6 fine.
+            if not dets:
+                logger.debug(
+                    "boxmot update() rejected empty detections (%s); "
+                    "falling back to empty TrackingResult.", exc,
+                )
+                return TrackingResult()
+            raise
 
         # boxmot returns Nx7 or Nx8 depending on version: x1, y1, x2, y2,
         # id, conf, cls, [ind]. Read the first 7 columns; treat missing

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,0 +1,15 @@
+# Optional dependencies. NOT installed by default — base requirements.txt
+# omits these so deployed units that do not need them pay zero install
+# weight.
+#
+# Install when enabling specific opt-in features:
+#
+#   pip install -r requirements-extra.txt
+#
+# Then flip the corresponding flag in config.ini.
+
+# ── Re-ID layer for cluttered-scene Follow-mode tracking ────────────────────
+# Activates with [tracker] reid_enabled = true. Pulls in BoT-SORT and the
+# OSNet appearance embedding. OSNet weights (~10 MB) are downloaded on
+# first use via gdown.
+boxmot>=12.0.0

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -10,6 +10,15 @@
 
 # ── Re-ID layer for cluttered-scene Follow-mode tracking ────────────────────
 # Activates with [tracker] reid_enabled = true. Pulls in BoT-SORT and the
-# OSNet appearance embedding. OSNet weights (~10 MB) are downloaded on
-# first use via gdown.
-boxmot>=12.0.0
+# OSNet appearance embedding. Default OSNet weights (osnet_x0_25_msmt17.pt,
+# ~1.1 MB) are auto-downloaded on first use; cache the file in the deployed
+# image so Jetsons running offline do not need network access at start.
+#
+# Upper bound is intentional. boxmot v16.0.0 (2025-12-19) was a major
+# repo refactor that changed the BoTSORT class signature — the tracker
+# now expects a pre-built ReID backend object (reid_model=) instead of
+# reid_weights=/half=/device=. ReIDTracker.init() in this repo still
+# uses the v10-v15 create_tracker() signature, so unpinning above v16
+# will silently break the wrapper. Re-evaluate the pin when porting the
+# wrapper to the v18+ Boxmot() Python API.
+boxmot>=12.0.0,<16

--- a/tests/test_config_migrate.py
+++ b/tests/test_config_migrate.py
@@ -293,19 +293,75 @@ class TestV2ToV3Migration:
         assert cfg.get("guidance", "gimbal_stabilized") == "false"
 
     def test_v0_chains_through_all_migrations(self, tmp_config):
-        """A v0 config must walk through 001 then 002 then 003 to reach
-        current. Verifies the chain is contiguous."""
+        """A v0 config must walk every migration step in order to reach the
+        current schema version. Verifies the chain is contiguous."""
         p = tmp_config(GOLDEN_V0)
         result = run_migrations(p)
 
         assert result.from_version == 0
         assert result.to_version == CURRENT_SCHEMA_VERSION
         assert len(result.applied) == CURRENT_SCHEMA_VERSION
-        # Final state has both predictor and attitude keys.
+        # Final state should hold every key inserted along the chain.
         cfg = configparser.ConfigParser()
         cfg.read(p)
         assert cfg.has_option("guidance", "predictor_enabled")
         assert cfg.has_option("guidance", "attitude_compensation_enabled")
+        assert cfg.has_option("tracker", "reid_enabled")
+
+
+class TestV3ToV4Migration:
+    """Migration 004: re-ID keys are inserted into [tracker]."""
+
+    def test_v3_picks_up_reid_keys(self, tmp_config):
+        v3 = textwrap.dedent("""\
+            [meta]
+            schema_version = 3
+
+            [tracker]
+            track_thresh = 0.5
+        """)
+        p = tmp_config(v3)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.get("tracker", "reid_enabled") == "false"
+        assert cfg.get("tracker", "reid_tracker_type") == "botsort"
+        # Existing keys preserved.
+        assert cfg.get("tracker", "track_thresh") == "0.5"
+
+    def test_v3_existing_reid_value_preserved(self, tmp_config):
+        v3 = textwrap.dedent("""\
+            [meta]
+            schema_version = 3
+
+            [tracker]
+            reid_enabled = true
+        """)
+        p = tmp_config(v3)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.get("tracker", "reid_enabled") == "true"
+        # Missing key still gets filled in.
+        assert cfg.get("tracker", "reid_tracker_type") == "botsort"
+
+    def test_v3_no_tracker_section_creates_one(self, tmp_config):
+        v3 = textwrap.dedent("""\
+            [meta]
+            schema_version = 3
+        """)
+        p = tmp_config(v3)
+        run_migrations(p)
+
+        cfg = configparser.ConfigParser()
+        cfg.read(p)
+
+        assert cfg.has_section("tracker")
+        assert cfg.get("tracker", "reid_enabled") == "false"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -127,8 +127,14 @@ class TestReIDTrackerWiring:
         assert result.tracks[0].track_id == 7
         assert result.tracks[0].confidence == pytest.approx(0.85)
 
-    def test_empty_detections_returns_empty_result_without_calling_boxmot(self, monkeypatch):
+    def test_empty_detections_still_calls_boxmot_update(self, monkeypatch):
+        """Even with zero detections, boxmot.update() must be invoked so
+        the tracker ages missed tracks during dropouts/occlusions. Skipping
+        the call freezes internal counters and breaks re-ID continuity."""
         fake_tracker, _ = self._install_boxmot_stub(monkeypatch)
+        # Configure the stub to return an empty result for empty input.
+        fake_tracker.update.return_value = np.empty((0, 7), dtype=np.float32)
+
         rt = ReIDTracker(tracker_type="botsort")
         rt.init()
 
@@ -136,9 +142,30 @@ class TestReIDTrackerWiring:
         frame = np.zeros((100, 100, 3), dtype=np.uint8)
         result = rt.update(empty, frame=frame)
 
+        # boxmot.update() WAS called — that's the bug fix.
+        assert fake_tracker.update.called
+        call_args = fake_tracker.update.call_args.args
+        dets_arg = call_args[0]
+        assert dets_arg.shape == (0, 6), "empty detections must be passed as 0x6 ndarray"
+        assert call_args[1] is frame
+        # Tracking result is empty (no IDs to report this frame).
         assert len(result) == 0
-        # Boxmot's update may still be invoked with an empty array — that's
-        # also fine. We just check no crash and an empty result.
+
+    def test_empty_detections_old_boxmot_falls_back_gracefully(self, monkeypatch):
+        """Older boxmot versions can raise ValueError on empty input.
+        The fallback path should swallow that and return empty."""
+        fake_tracker, _ = self._install_boxmot_stub(monkeypatch)
+        fake_tracker.update.side_effect = ValueError("empty input not supported")
+
+        rt = ReIDTracker(tracker_type="botsort")
+        rt.init()
+
+        empty = DetectionResult(detections=[])
+        frame = np.zeros((100, 100, 3), dtype=np.uint8)
+        result = rt.update(empty, frame=frame)
+
+        assert fake_tracker.update.called
+        assert len(result) == 0
 
     def test_update_requires_frame(self, monkeypatch):
         """Re-ID needs the actual image for appearance embedding; an

--- a/tests/test_tracker.py
+++ b/tests/test_tracker.py
@@ -1,6 +1,22 @@
 """Smoke tests for tracker data classes."""
 
-from hydra_detect.tracker import TrackedObject, TrackingResult
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from hydra_detect.tracker import (
+    ByteTracker,
+    ReIDTracker,
+    TrackedObject,
+    TrackingResult,
+    reid_dependency_available,
+)
+from hydra_detect.detectors.base import Detection, DetectionResult
 
 
 def test_tracked_object_center():
@@ -11,3 +27,130 @@ def test_tracked_object_center():
 def test_tracking_result_empty():
     tr = TrackingResult()
     assert len(tr) == 0
+
+
+# ---------------------------------------------------------------------------
+# ByteTracker forward compatibility — accepts optional frame kwarg
+# ---------------------------------------------------------------------------
+
+class TestByteTrackerFrameKwarg:
+    """Existing callers must keep working; new callers may pass a frame."""
+
+    def test_update_accepts_optional_frame(self):
+        bt = ByteTracker()
+        # Tracker is uninitialised — falls through to passthrough mode.
+        det_result = DetectionResult(detections=[
+            Detection(x1=0, y1=0, x2=10, y2=10, confidence=0.9, class_id=0, label="person"),
+        ])
+        result_no_frame = bt.update(det_result)
+        result_with_frame = bt.update(det_result, frame=np.zeros((100, 100, 3), dtype=np.uint8))
+        # Both code paths produce the same shape of result.
+        assert isinstance(result_no_frame, TrackingResult)
+        assert isinstance(result_with_frame, TrackingResult)
+
+
+# ---------------------------------------------------------------------------
+# ReIDTracker — boxmot-backed re-ID layer (gated by [tracker] reid_enabled)
+# ---------------------------------------------------------------------------
+
+class TestReIDTrackerImportGate:
+    """When boxmot is missing, ReIDTracker.init() must raise an actionable
+    error pointing at requirements-extra.txt."""
+
+    def test_init_raises_with_install_hint_when_boxmot_missing(self, monkeypatch):
+        # Force the lazy import inside ReIDTracker.init() to fail.
+        monkeypatch.setitem(sys.modules, "boxmot", None)
+        rt = ReIDTracker(tracker_type="botsort")
+        with pytest.raises(ImportError) as exc:
+            rt.init()
+        msg = str(exc.value)
+        assert "boxmot" in msg
+        assert "requirements-extra.txt" in msg or "pip install" in msg
+
+    def test_dependency_probe_returns_false_when_missing(self, monkeypatch):
+        monkeypatch.setitem(sys.modules, "boxmot", None)
+        assert reid_dependency_available() is False
+
+
+class TestReIDTrackerWiring:
+    """With a stubbed boxmot module, ReIDTracker delegates correctly."""
+
+    def _install_boxmot_stub(self, monkeypatch):
+        """Drop a fake boxmot module into sys.modules and return the mock
+        tracker instance create_tracker() will return."""
+        fake_tracker = MagicMock()
+        # boxmot returns Nx8 numpy array: x1,y1,x2,y2,id,conf,cls,detection_idx
+        fake_tracker.update.return_value = np.array([
+            [10.0, 20.0, 30.0, 40.0, 7, 0.85, 0, 0],
+        ])
+        fake_module = types.ModuleType("boxmot")
+        fake_module.create_tracker = MagicMock(return_value=fake_tracker)
+        monkeypatch.setitem(sys.modules, "boxmot", fake_module)
+        return fake_tracker, fake_module
+
+    def test_init_calls_boxmot_create_tracker(self, monkeypatch):
+        _, fake_module = self._install_boxmot_stub(monkeypatch)
+        rt = ReIDTracker(tracker_type="botsort")
+        rt.init()
+        fake_module.create_tracker.assert_called_once()
+        kwargs = fake_module.create_tracker.call_args.kwargs
+        # tracker_type is plumbed through verbatim.
+        args = fake_module.create_tracker.call_args.args
+        assert (
+            "botsort" in args
+            or kwargs.get("tracker_type") == "botsort"
+        )
+
+    def test_update_translates_detections_to_numpy(self, monkeypatch):
+        fake_tracker, _ = self._install_boxmot_stub(monkeypatch)
+        rt = ReIDTracker(tracker_type="botsort")
+        rt.init()
+
+        det_result = DetectionResult(detections=[
+            Detection(x1=10, y1=20, x2=30, y2=40, confidence=0.85,
+                      class_id=0, label="person"),
+        ])
+        frame = np.zeros((480, 640, 3), dtype=np.uint8)
+
+        result = rt.update(det_result, frame=frame)
+
+        # boxmot was called with (Nx6 array, frame).
+        call_args = fake_tracker.update.call_args.args
+        dets_arg = call_args[0]
+        assert dets_arg.shape == (1, 6)
+        assert dets_arg[0, 4] == pytest.approx(0.85)
+        assert int(dets_arg[0, 5]) == 0
+
+        # Result wraps the boxmot output as TrackingResult with the assigned id.
+        assert isinstance(result, TrackingResult)
+        assert len(result) == 1
+        assert result.tracks[0].track_id == 7
+        assert result.tracks[0].confidence == pytest.approx(0.85)
+
+    def test_empty_detections_returns_empty_result_without_calling_boxmot(self, monkeypatch):
+        fake_tracker, _ = self._install_boxmot_stub(monkeypatch)
+        rt = ReIDTracker(tracker_type="botsort")
+        rt.init()
+
+        empty = DetectionResult(detections=[])
+        frame = np.zeros((100, 100, 3), dtype=np.uint8)
+        result = rt.update(empty, frame=frame)
+
+        assert len(result) == 0
+        # Boxmot's update may still be invoked with an empty array — that's
+        # also fine. We just check no crash and an empty result.
+
+    def test_update_requires_frame(self, monkeypatch):
+        """Re-ID needs the actual image for appearance embedding; an
+        attempt to update without a frame should raise a clear error
+        rather than silently degrading to ID-swap-prone tracking."""
+        self._install_boxmot_stub(monkeypatch)
+        rt = ReIDTracker(tracker_type="botsort")
+        rt.init()
+
+        det_result = DetectionResult(detections=[
+            Detection(x1=0, y1=0, x2=10, y2=10, confidence=0.9, class_id=0, label="person"),
+        ])
+        with pytest.raises(ValueError) as exc:
+            rt.update(det_result, frame=None)
+        assert "frame" in str(exc.value).lower()


### PR DESCRIPTION
## Summary

Adds `ReIDTracker`, a boxmot-backed motion + appearance tracker (BoT-SORT by default) that survives full occlusions and target crossings in cluttered scenes — the documented ByteTrack failure mode that makes Follow mode smoothly fly to the wrong person.

Cost is bounded by being **opt-in everywhere**:
- `[tracker] reid_enabled = false` by default — units that do not flip the flag run unchanged ByteTrack.
- boxmot is in a new `requirements-extra.txt`, **not** in `requirements.txt` — deployed units that do not need re-ID never pull it.
- The `import boxmot` is lazy (only inside `ReIDTracker.init()`), so even if the package is installed, runtime cost on units with the flag off is zero.

When the flag is on:
- Pipeline picks `ReIDTracker` instead of `ByteTracker` at both init sites (boot + runtime profile reload).
- Hot-loop call site passes the raw frame to `update()` so appearance embeddings can be extracted; `ByteTracker.update()` accepts the new kwarg and ignores it.
- `ReIDTracker.update(frame=None)` raises `ValueError` rather than silently degrading.

## Why now

From the May 2026 prior-art note: `Pure ByteTrack swaps IDs on full occlusion and in groups. Follow mode will smoothly fly to the wrong person in any cluttered scene... For "follow that specific person" you need re-ID or geofenced lock.` This PR puts the re-ID option behind a config flag so SORCC instructors can flip it for the high-clutter Follow scenarios (group dynamics, occluded targets) without affecting other operating modes.

## Files touched

| File | Change |
|---|---|
| `hydra_detect/tracker.py` | New `ReIDTracker` class, new `reid_dependency_available()` helper, optional `frame` kwarg on `ByteTracker.update()` for forward-compat |
| `hydra_detect/pipeline/facade.py` | Tracker selection at both init sites; `frame` plumbed into the existing `update()` call |
| `hydra_detect/config_schema.py` | Two new FieldSpec entries in `[tracker]` |
| `hydra_detect/migrations/004_tracker_reid.py` | Idempotent insertion of the two new keys; preserves user overrides |
| `hydra_detect/config_migrate.py` | `CURRENT_SCHEMA_VERSION` 3 → 4 |
| `config.ini` | New keys defaulted off plus a comment explaining the opt-in install |
| `requirements-extra.txt` | **New file** holding boxmot. Documented as the install path for opt-in features |
| `tests/test_tracker.py` | 7 new tests — forward-compat kwarg, import-gate ImportError, dep probe, boxmot wiring (stubbed module) |
| `tests/test_config_migrate.py` | `TestV3ToV4Migration` (3 tests) + chain assertion now walks v0 → v4 |

`tracker.py` and `pipeline/facade.py` are not on the flagged-paths list; no flagging needed beyond the explicit re-ID gate.

## Test plan

`TestByteTrackerFrameKwarg`:
- [x] Existing callers passing no frame still work
- [x] New callers passing a frame still work

`TestReIDTrackerImportGate`:
- [x] `init()` with boxmot missing raises ImportError pointing at requirements-extra.txt
- [x] `reid_dependency_available()` returns False when boxmot missing

`TestReIDTrackerWiring` (boxmot stubbed via `sys.modules`):
- [x] `init()` calls `boxmot.create_tracker(tracker_type="botsort")`
- [x] `update()` translates `DetectionResult` to the Nx6 numpy array boxmot expects
- [x] Empty detections short-circuit (no boxmot call required)
- [x] `update(frame=None)` raises ValueError

`TestV3ToV4Migration`:
- [x] Predictor + attitude keys preserved, re-ID keys inserted on v3 → v4
- [x] Pre-existing user `reid_enabled = true` survives
- [x] Missing `[tracker]` section is created

Local results:
- Tracker + migration: **33/33 pass**
- 13-module Windows-runnable subset: **302/302 pass**
- `flake8` clean on touched code (two unrelated pre-existing E501 warnings on `config_schema.py` lines 54 and 1210)
- v0 → v4 migration smoke test: walks 001 → 002 → 003 → 004 cleanly with all expected keys present

## What this does NOT do

- No quality test (e.g. two-person crossing). That requires the actual boxmot install + an OSNet weights download. Will run in field once Kyle approves the install on a dev unit.
- No exposure of further boxmot knobs (re-ID weights path, device, half-precision toggle). The defaults are sensible and adding more knobs prematurely is noise. Easy to expose later.
- No vehicle-profile override forcing `reid_enabled` on or off per platform. Open question — likely belongs in a follow-up that sets it true on `[vehicle.drone]` for Follow-heavy scenarios.

## Reviewer asks

1. **Per-platform default.** Right now every profile starts with `reid_enabled = false`. Drone Follow is the highest-leverage use case; want me to flip drone-profile to true in a follow-up after you approve the dep install on a dev unit?
2. **boxmot version pin.** I pinned `boxmot>=12.0.0` (current major). If you want a tighter pin (e.g. `==12.0.5`) to reduce surprise on upgrades, easy fix.
3. **OSNet weights bootstrap.** Default behaviour: boxmot's `gdown` fetches OSNet-x0_25 weights from Google Drive on first use. Network-dependency at first run. If you'd rather pre-bake the weights into the Docker image, that's a Dockerfile change in a follow-up.