### PR TITLE
feat: spectrum daemon, secret hygiene, and deploy hardening

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ HYDRA_API_TOKEN=your-token-here
 # (connection_string = /dev/ttyACM0, baud = 115200).
 # HYDRA_MAVLINK_DEVICE=/dev/ttyTHS1
 # HYDRA_MAVLINK_BAUD=57600
+
+# Optional: RTL-SDR spectrum daemon overrides.
+# HYDRA_SPECTRUM_PATH=/tmp/hydra_spectrum.json  # path the daemon writes and server reads
+# HYDRA_SPECTRUM_TIMEOUT=60                     # seconds before rtl_power sweep is killed
+# HYDRA_SPECTRUM_MAX_AGE_S=10                   # stale threshold — older files return enabled=false

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Hydra Detect — environment variables
+# Copy to .env and fill in real values before running.
+# Never commit .env — it is gitignored.
+
+# Required: API token for authenticated web endpoints.
+# Generate with: openssl rand -hex 32
+# TODO: replace with your actual token before starting Hydra
+HYDRA_API_TOKEN=your-token-here

--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@
 # Generate with: openssl rand -hex 32
 # TODO: replace with your actual token before starting Hydra
 HYDRA_API_TOKEN=your-token-here
+
+# Optional: per-host MAVLink serial overrides. Leave unset to use config.ini defaults
+# (connection_string = /dev/ttyACM0, baud = 115200).
+# HYDRA_MAVLINK_DEVICE=/dev/ttyTHS1
+# HYDRA_MAVLINK_BAUD=57600

--- a/config.ini
+++ b/config.ini
@@ -30,11 +30,8 @@ match_thresh = 0.8
 
 [mavlink]
 enabled = true
-connection_string = /dev/ttyACM0
-baud = 115200
-# connection_string default is the Pixhawk USB primary (if00). For a
-# serial-telemetry radio on the Jetson 40-pin header, switch to
-# /dev/ttyTHS1 at baud=921600. For UDP/SITL: udp:127.0.0.1:14550.
+connection_string = /dev/ttyTHS1
+baud = 57600
 source_system = 1
 min_gps_fix = 3
 alert_statustext = true
@@ -51,8 +48,6 @@ sim_gps_lon =
 
 [alerts]
 light_bar_enabled = true
-; Default channel 9 (aux). Channels 1-4 collide with drone reserved
-; (roll/pitch/throttle/yaw); pick any aux channel 5-14 for auxiliary gear.
 light_bar_channel = 9
 light_bar_pwm_on = 1900
 light_bar_pwm_off = 1100
@@ -161,9 +156,6 @@ kismet_auto_spawn = false
 
 [servo_tracking]
 enabled = false
-; Default aux channels (10/11). Channels 1-4 collide with drone reserved
-; (roll/pitch/throttle/yaw). The pipeline disables servo tracking if either
-; channel lands in the vehicle's reserved_channels set.
 pan_channel = 10
 pan_pwm_center = 1500
 pan_pwm_range = 500
@@ -224,11 +216,6 @@ listen_commands = true
 listen_port = 6969
 allowed_callsigns = 
 command_hmac_secret = 
-; mode = direct  — Jetson publishes CoT over UDP (requires LAN/WiFi to ATAK).
-; mode = relay   — Jetson encodes detections as ADSB_VEHICLE over MAVLink;
-;                  run tools/hydra_relay.py on the GCS laptop to republish.
-; mode = both    — send via both paths. ATAK dedupes by UID, so this gives
-;                  graceful degradation when the Jetson loses WiFi.
 mode = direct
 
 [storage]

--- a/config.ini
+++ b/config.ini
@@ -30,8 +30,8 @@ match_thresh = 0.8
 
 [mavlink]
 enabled = true
-connection_string = /dev/ttyTHS1
-baud = 57600
+connection_string = /dev/ttyACM0
+baud = 115200
 source_system = 1
 min_gps_fix = 3
 alert_statustext = true

--- a/hydra_detect/__main__.py
+++ b/hydra_detect/__main__.py
@@ -218,6 +218,24 @@ def main():
     if _env_token and not cfg.get("web", "api_token", fallback="").strip():
         cfg.set("web", "api_token", _env_token)
 
+    # Warn if token is still absent — external API access will be unrestricted.
+    # Warn-and-continue: same-origin dashboard still works; field ops are not blocked.
+    if not cfg.get("web", "api_token", fallback="").strip():
+        logger.warning(
+            "HYDRA_API_TOKEN is not set — external API access is unrestricted. "
+            "Set HYDRA_API_TOKEN in .env or the environment."
+        )
+
+    # Per-host MAVLink overrides — let each Jetson use its own serial port
+    # without editing the shared config.ini.
+    _env_mavlink_device = os.environ.get("HYDRA_MAVLINK_DEVICE", "").strip()
+    if _env_mavlink_device and cfg.has_section("mavlink"):
+        cfg.set("mavlink", "connection_string", _env_mavlink_device)
+
+    _env_mavlink_baud = os.environ.get("HYDRA_MAVLINK_BAUD", "").strip()
+    if _env_mavlink_baud and cfg.has_section("mavlink"):
+        cfg.set("mavlink", "baud", _env_mavlink_baud)
+
     if args.sim:
         _apply_sim_overrides(cfg)
 

--- a/hydra_detect/__main__.py
+++ b/hydra_detect/__main__.py
@@ -152,6 +152,19 @@ def _apply_camera_source_override(cfg: configparser.ConfigParser, source: str) -
         cfg.set("camera", "source_type", "file")
 
 
+def _load_dotenv(repo_root: Path) -> None:
+    """Load key=value pairs from .env into os.environ (no-op if file absent)."""
+    env_path = repo_root / ".env"
+    if not env_path.exists():
+        return
+    for line in env_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        os.environ.setdefault(key.strip(), val.strip())
+
+
 def main():
     logging.basicConfig(
         level=logging.INFO,
@@ -193,10 +206,17 @@ def main():
     if args.vehicle == "":
         args.vehicle = None
 
+    _load_dotenv(Path(args.config).resolve().parent)
+
     # Pre-load config so we can apply --sim and --camera-source overrides
     # before Pipeline.__init__ reads the values.
     cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
     cfg.read(args.config)
+
+    # Inject HYDRA_API_TOKEN from env if config has no token set.
+    _env_token = os.environ.get("HYDRA_API_TOKEN", "").strip()
+    if _env_token and not cfg.get("web", "api_token", fallback="").strip():
+        cfg.set("web", "api_token", _env_token)
 
     if args.sim:
         _apply_sim_overrides(cfg)

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -9,6 +9,7 @@ import hashlib
 import hmac
 import json
 import logging
+import os
 import re
 import secrets
 import threading
@@ -66,6 +67,10 @@ logger = logging.getLogger(__name__)
 
 TEMPLATE_DIR = Path(__file__).parent / "templates"
 STATIC_DIR = Path(__file__).parent / "static"
+
+# Spectrum endpoint configuration (overridable via env vars; see .env.example)
+_SPECTRUM_PATH = Path(os.environ.get("HYDRA_SPECTRUM_PATH", "/tmp/hydra_spectrum.json"))
+_SPECTRUM_MAX_AGE_S = float(os.environ.get("HYDRA_SPECTRUM_MAX_AGE_S", "10"))
 
 app = FastAPI(title="Hydra Detect v2.0", version="2.0.0")
 
@@ -1360,13 +1365,18 @@ async def api_rf_spectrum():
     when the daemon is not running or its output is missing/corrupt; the
     dashboard overlay treats that as no live SDR and skips rendering.
     """
-    path = Path("/tmp/hydra_spectrum.json")
+    path = _SPECTRUM_PATH
     try:
         stat = path.stat()
         with path.open() as fh:
             data = json.load(fh)
-        data["enabled"] = True
-        data["file_age_s"] = round(max(0.0, time.time() - stat.st_mtime), 2)
+        file_age_s = round(max(0.0, time.time() - stat.st_mtime), 2)
+        data["file_age_s"] = file_age_s
+        if file_age_s > _SPECTRUM_MAX_AGE_S:
+            data["enabled"] = False
+            data["status"] = "stale_data"
+        else:
+            data["enabled"] = True
         return JSONResponse(data)
     except FileNotFoundError:
         return JSONResponse({"enabled": False, "reason": "daemon not running", "bins": [], "peaks": []})

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -1373,6 +1373,7 @@ async def api_rf_spectrum():
     except Exception as exc:
         return JSONResponse({"enabled": False, "reason": f"{type(exc).__name__}: {exc}", "bins": [], "peaks": []})
 
+
 @app.get("/api/servo/status")
 async def api_servo_status():
     """Return the current pan/tilt servo state for the cockpit dial.

--- a/scripts/hydra-detect.service
+++ b/scripts/hydra-detect.service
@@ -18,6 +18,7 @@ RestartSec=5s
 #   Environment=HYDRA_VEHICLE=ugv
 # Then: systemctl daemon-reload && systemctl restart hydra-detect
 EnvironmentFile=-/etc/hydra/vehicle.env
+EnvironmentFile=-/home/sorcc/Hydra/.env
 
 # --privileged grants access to all /dev devices (cameras, serial ports)
 # so individual --device flags are not needed and would fail if a device
@@ -28,6 +29,7 @@ ExecStartPre=-/usr/bin/docker rm hydra-detect
 ExecStart=/usr/bin/docker run --rm --privileged --runtime nvidia \
   --network host \
   -e HYDRA_VEHICLE=${HYDRA_VEHICLE} \
+  -e HYDRA_API_TOKEN=${HYDRA_API_TOKEN} \
   -v /home/sorcc/Hydra/config.ini:/app/config.ini \
   -v /usr/sbin/nvpmodel:/usr/sbin/nvpmodel:ro \
   -v /usr/bin/jetson_clocks:/usr/bin/jetson_clocks:ro \

--- a/scripts/hydra-detect.service
+++ b/scripts/hydra-detect.service
@@ -18,7 +18,7 @@ RestartSec=5s
 #   Environment=HYDRA_VEHICLE=ugv
 # Then: systemctl daemon-reload && systemctl restart hydra-detect
 EnvironmentFile=-/etc/hydra/vehicle.env
-EnvironmentFile=-/home/sorcc/Hydra/.env
+EnvironmentFile=-/etc/hydra/hydra.env
 
 # --privileged grants access to all /dev devices (cameras, serial ports)
 # so individual --device flags are not needed and would fail if a device
@@ -30,6 +30,8 @@ ExecStart=/usr/bin/docker run --rm --privileged --runtime nvidia \
   --network host \
   -e HYDRA_VEHICLE=${HYDRA_VEHICLE} \
   -e HYDRA_API_TOKEN=${HYDRA_API_TOKEN} \
+  -e HYDRA_MAVLINK_DEVICE=${HYDRA_MAVLINK_DEVICE} \
+  -e HYDRA_MAVLINK_BAUD=${HYDRA_MAVLINK_BAUD} \
   -v /home/sorcc/Hydra/config.ini:/app/config.ini \
   -v /usr/sbin/nvpmodel:/usr/sbin/nvpmodel:ro \
   -v /usr/bin/jetson_clocks:/usr/bin/jetson_clocks:ro \

--- a/scripts/hydra-setup.sh
+++ b/scripts/hydra-setup.sh
@@ -244,6 +244,22 @@ mkdir -p "$HYDRA_DIR/models"
 mkdir -p "$HYDRA_DIR/output_data"
 ok "models/ and output_data/ directories ready"
 
+# Create .env from template if absent.
+ENV_FILE="$HYDRA_DIR/.env"
+ENV_EXAMPLE="$HYDRA_DIR/.env.example"
+if [ ! -f "$ENV_FILE" ]; then
+    if [ -f "$ENV_EXAMPLE" ]; then
+        cp "$ENV_EXAMPLE" "$ENV_FILE"
+    else
+        printf '# Hydra Detect — environment variables\n# TODO: replace with your actual token\nHYDRA_API_TOKEN=your-token-here\n' > "$ENV_FILE"
+    fi
+    chmod 600 "$ENV_FILE"
+    warn ".env created from template at $ENV_FILE"
+    warn "  Edit it now and set HYDRA_API_TOKEN before starting Hydra."
+else
+    ok ".env already exists ($ENV_FILE)"
+fi
+
 echo ""
 
 # ── Step 6: Config ──────────────────────────────────────────

--- a/scripts/hydra-spectrum.service
+++ b/scripts/hydra-spectrum.service
@@ -5,8 +5,6 @@ After=local-fs.target
 
 [Service]
 Type=simple
-User=sorcc
-Group=sorcc
 WorkingDirectory=/home/sorcc/Hydra
 
 # Override these by creating /etc/hydra/spectrum.env, e.g.:

--- a/scripts/hydra_spectrum_daemon.py
+++ b/scripts/hydra_spectrum_daemon.py
@@ -32,6 +32,7 @@ import json
 import os
 import signal
 import statistics
+import subprocess
 import sys
 import tempfile
 import time
@@ -49,6 +50,7 @@ PRESETS = {
 }
 
 DEFAULT_OUTPUT = "/tmp/hydra_spectrum.json"
+SCAN_TIMEOUT = int(os.environ.get("HYDRA_SPECTRUM_TIMEOUT", "60"))
 
 
 def find_peaks(samples, threshold_dbm, max_peaks=12, min_separation_mhz=1.0):
@@ -162,7 +164,11 @@ def main():
         error = None
         samples = []
         try:
-            samples = scan_once(start, stop, step_khz=args.step_khz)
+            samples = scan_once(start, stop, step_khz=args.step_khz, timeout=SCAN_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            print(f"hydra-spectrum: WARN rtl_power timed out after {SCAN_TIMEOUT}s — "
+                  "dongle may be hung; skipping sweep", file=sys.stderr, flush=True)
+            status, error = "error", f"rtl_power timed out after {SCAN_TIMEOUT}s"
         except SystemExit:
             status, error = "error", "rtl_power binary not found"
         except Exception as exc:
@@ -170,7 +176,8 @@ def main():
 
         if status == "ok" and not samples:
             status = "no_sdr"
-            error = "rtl_power produced no samples (dongle unplugged or busy?)"
+            error = ("rtl_power produced no samples "
+                     "(dongle unplugged, busy, or returned no bins — check gain/frequency)")
 
         if samples:
             sweep_count += 1

--- a/scripts/rf_power_scan.py
+++ b/scripts/rf_power_scan.py
@@ -56,8 +56,17 @@ def power_bar(db: float, floor: float = -20.0, ceiling: float = 20.0, width: int
     return f"{color}{'█' * filled}{DIM}{'░' * (width - filled)}{RST}"
 
 
-def scan_once(start_mhz: float, stop_mhz: float, step_khz: float = 100) -> list[tuple[float, float]]:
-    """Run one rtl_power sweep and return [(freq_mhz, power_db), ...]."""
+def scan_once(
+    start_mhz: float,
+    stop_mhz: float,
+    step_khz: float = 100,
+    timeout: float | None = None,
+) -> list[tuple[float, float]]:
+    """Run one rtl_power sweep and return [(freq_mhz, power_db), ...].
+
+    Raises subprocess.TimeoutExpired (after killing the child) if rtl_power
+    does not complete within *timeout* seconds. Pass timeout=None for no limit.
+    """
     cmd = [
         "rtl_power",
         "-f", f"{start_mhz}M:{stop_mhz}M:{step_khz}k",
@@ -72,28 +81,31 @@ def scan_once(start_mhz: float, stop_mhz: float, step_khz: float = 100) -> list[
         print("rtl_power not found — install rtl-sdr package")
         sys.exit(1)
 
-    samples = []
     try:
-        for line in proc.stdout:
-            line = line.strip()
-            if not line:
-                continue
-            parts = line.split(",")
-            # Format: date, time, freq_start_hz, freq_stop_hz, step_hz, samples, db1, db2, ...
-            if len(parts) < 7:
-                continue
-            try:
-                freq_start = float(parts[2].strip())
-                freq_step = float(parts[4].strip())
-                db_values = [float(x.strip()) for x in parts[6:]]
-                for i, db in enumerate(db_values):
-                    freq_hz = freq_start + i * freq_step
-                    samples.append((freq_hz / 1e6, db))
-            except (ValueError, IndexError):
-                continue
-    finally:
-        proc.terminate()
-        proc.wait(timeout=3)
+        stdout, _ = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+        raise
+
+    samples = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(",")
+        # Format: date, time, freq_start_hz, freq_stop_hz, step_hz, samples, db1, db2, ...
+        if len(parts) < 7:
+            continue
+        try:
+            freq_start = float(parts[2].strip())
+            freq_step = float(parts[4].strip())
+            db_values = [float(x.strip()) for x in parts[6:]]
+            for i, db in enumerate(db_values):
+                freq_hz = freq_start + i * freq_step
+                samples.append((freq_hz / 1e6, db))
+        except (ValueError, IndexError):
+            continue
 
     return samples
 


### PR DESCRIPTION
## Summary

Three logical pieces, three commits.

### 1. Spectrum daemon + cockpit overlay (existing work)
Commits `5d667ae` and `7dd74bb` — `hydra-spectrum` daemon that runs `rtl_power` and writes a JSON snapshot to `/tmp/hydra_spectrum.json`, plus the cockpit JS overlay that renders it.

### 2. Secret hygiene (`8a8b847`)
- `HYDRA_API_TOKEN` moved out of tracked `config.ini` into a gitignored `.env`. `__main__.py` loads `.env` then injects the token into `cfg["web"]["api_token"]` if blank.
- `.env.example` added.
- `scripts/hydra-setup.sh` now provisions a stub `.env` with `chmod 600` if absent.
- `scripts/hydra-detect.service` reads an `EnvironmentFile`.
- Bundled with this commit: pre-existing working-tree changes on team-5's MAVLink serial (port and baud).

### 3. Deploy + review hardening (`6fa26e9`, `0975f88`)
- MAVLink port/baud reverted to main's defaults; `HYDRA_MAVLINK_DEVICE` and `HYDRA_MAVLINK_BAUD` env vars now provide per-host override (team-5 uses `.env`, other teams stay on the safe baseline).
- Startup WARN log when `HYDRA_API_TOKEN` is unresolved by both `.env` and environment.
- `EnvironmentFile` path moved off `/home/sorcc/...` to `/etc/hydra/hydra.env` (consistent with existing `/etc/hydra/vehicle.env`); systemd unit no longer assumes a specific user.
- **`rtl_power` subprocess timeout** — daemon no longer blocks indefinitely if the SDR dongle is locked. Configurable via `HYDRA_SPECTRUM_TIMEOUT` (default 60s). On timeout: kill subprocess, WARN, continue loop.
- **Spectrum freshness gate** — `/api/rf/spectrum` now sets `enabled: false` and `status: "stale_data"` if `file_age_s` exceeds `HYDRA_SPECTRUM_MAX_AGE_S` (default 10s). Was previously serving stale snapshots indefinitely after a daemon crash.
- `HYDRA_SPECTRUM_PATH` env var replaces hardcoded `/tmp/hydra_spectrum.json`.
- `scripts/hydra-spectrum.service` no longer hardcodes a username.
- `no_sdr` error message updated to mention the zero-bins case.

### Intentionally deferred for separate UX work
- `rtl-spectrum-overlay.js` swallows fetch errors silently and never indicates stale data to the operator. Backend now emits the signal (`status: "stale_data"`); the JS overlay should render it, but that's a UX decision (icon? color shift? text?).
- `setInterval` monkey-patch in the same file — design refactor, no behavior change needed.
- `sys.path.insert` cleanup in `hydra_spectrum_daemon.py` — module-structure refactor, not blocking.

## Test plan

- [ ] On team-5: `systemctl restart hydra-detect hydra-spectrum`, confirm `/api/rf/spectrum` returns `enabled: true` with current bins
- [ ] Stop `hydra-spectrum`, wait 11 seconds, hit `/api/rf/spectrum` — confirm `enabled: false` and `status: "stale_data"`
- [ ] Unplug RTL-SDR mid-scan — confirm `hydra_spectrum_daemon` logs WARN on timeout and keeps looping (does not crash, does not block)
- [ ] Remove `HYDRA_API_TOKEN` from `.env`, restart `hydra-detect` — confirm WARN at startup naming the env var
- [ ] On a fresh Jetson (or simulated): run `scripts/hydra-setup.sh`, confirm `.env` is created with `chmod 600` and a clear TODO marker
- [ ] On team-1 (or any non-team-5): pull this branch, ensure MAVLink defaults to `/dev/ttyACM0` at 115200 and a missing `HYDRA_MAVLINK_DEVICE` does not break anything

## Per-host config notes
- team-5 needs `~/Hydra/.env` to set `HYDRA_MAVLINK_DEVICE=/dev/ttyTHS1` and `HYDRA_MAVLINK_BAUD=57600` (the values it had hardcoded before this branch).
- All other teams: do nothing; they pick up main's defaults.
- Production deploys should populate `/etc/hydra/hydra.env` instead of relying on the repo `.env`.