### PR TITLE
chore: ignore .tmp/ + fix SORCC plural drift in agent docs

### DIFF
--- a/.agents/skills/hydra/SKILL.md
+++ b/.agents/skills/hydra/SKILL.md
@@ -75,7 +75,7 @@ Hydra serves three audiences — tag features and ideas by which they serve:
 
 ## SORCC Course Context
 
-Hydra is built for **SORCC** (Special Operations Robotics Capabilities Course) —
+Hydra is built for **SORCC** (Special Operations Robotics Capability Course) —
 a 6-week SOF training program. 15 students in 5 teams operate drones, rovers,
 boats, and fixed-wing aircraft with Hydra payloads. Students interact only via
 the web dashboard (never SSH). Errors must be plain English. Up to 20 Hydra

--- a/.claude/skills/hydra/SKILL.md
+++ b/.claude/skills/hydra/SKILL.md
@@ -75,7 +75,7 @@ Hydra serves three audiences — tag features and ideas by which they serve:
 
 ## SORCC Course Context
 
-Hydra is built for **SORCC** (Special Operations Robotics Capabilities Course) —
+Hydra is built for **SORCC** (Special Operations Robotics Capability Course) —
 a 6-week SOF training program. 15 students in 5 teams operate drones, rovers,
 boats, and fixed-wing aircraft with Hydra payloads. Students interact only via
 the web dashboard (never SSH). Errors must be plain English. Up to 20 Hydra

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,12 @@ output_data/
 # Backup / temp files
 *.bak
 
+# Scratch workspace — bench scripts, throwaway configs, captured logs.
+# Contains hardcoded API tokens and operational data; must never be
+# committed. Currently kept untracked by convention; explicit ignore
+# closes the `git add -A` gap.
+.tmp/
+
 # Large reference material (not source — keep local only)
 docs/reference/
 docs/sorcc manuals/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Kismet (WiFi/SDR) → RF Hunt Controller → RSSI Gradient Ascent → MAVLink Na
 
 ## SORCC Course Context
 
-**SORCC** (Special Operations Robotics Capabilities Course) is a 6-week IQT
+**SORCC** (Special Operations Robotics Capability Course) is a 6-week IQT
 program at a military training facility. 15 students in 5 teams of 3,
 active-duty SOF operators. They are technically capable and mission-focused
 but most have never touched a Jetson, config file, or terminal before this course.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,7 @@ Kismet (WiFi/SDR) → RF Hunt Controller → RSSI Gradient Ascent → MAVLink Na
 
 ## SORCC Course Context
 
-**SORCC** (Special Operations Robotics Capabilities Course) is a 6-week IQT
+**SORCC** (Special Operations Robotics Capability Course) is a 6-week IQT
 program at a military training facility. 15 students in 5 teams of 3,
 active-duty SOF operators. They are technically capable and mission-focused
 but most have never touched a Jetson, config file, or terminal before this course.


### PR DESCRIPTION
## Summary

Two small repo-hygiene fixes surfaced during overnight 2026-05-03 vault-vs-repo audit. Independent but related (both correct drift between the canonical truth and what's in the repo).

### 1. Explicitly ignore `.tmp/`

`.tmp/` holds bench scripts, captured configs, and throwaway scratch (e.g., `bench_results.json`, `phase_a.py`, `step_07_d_apply_config.py`). It is currently kept untracked by convention only — `.gitignore` does not list it. Three files in `.tmp/` contain a hardcoded API token (`690dcf69...`). One `git add -A` from any subdirectory ships them. Explicit ignore closes that gap.

The 2026-05-02 spectrum-daemon work caught a real plaintext `api_token` in `config.ini` that was about to ship; the gitignored `.env` pattern (PR #185) was the production fix. This PR closes the remaining scratch-directory hole.

### 2. Fix `Capabilities Course` (plural, wrong) → `Capability Course` (singular, canonical)

Per the 2026-04-30 SORCC logo audit (vault: `SORCC/sorcc-logo-audit-2026-04-30.md`), the canonical course name is **Special Operations Robotics Capability Course** — singular. Two bad logo variants are tracked in the wild for "CAPABILITIES COURSES" plural; the Hydra repo's agent-doc files were echoing the wrong spelling in four places:

- `AGENTS.md` line 54
- `CLAUDE.md` line 54
- `.agents/skills/hydra/SKILL.md` line 78
- `.claude/skills/hydra/SKILL.md` line 78

No customer-facing strings or operational data affected; just keeping the in-repo branding aligned with the canonical so future agent-generated text echoes the correct name.

## Test plan

- [x] `git check-ignore -v .tmp/container_config.ini` confirms `.tmp/` is now ignored.
- [x] `grep -r "Capabilities Course"` returns zero results in tracked files.
- [x] `grep -r "Capability Course"` confirms all four files now use singular.
- [ ] CI passes (no code changed, expected).