### PR TITLE
feat(streaming): add mediamtx sidecar for WebRTC viewing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,10 @@ HYDRA_API_TOKEN=your-token-here
 # HYDRA_SPECTRUM_PATH=/tmp/hydra_spectrum.json  # path the daemon writes and server reads
 # HYDRA_SPECTRUM_TIMEOUT=60                     # seconds before rtl_power sweep is killed
 # HYDRA_SPECTRUM_MAX_AGE_S=10                   # stale threshold — older files return enabled=false
+
+# Streaming sidecar (mediamtx) — flips the docker-compose profile so the
+# WebRTC sidecar starts (`on`) or stays down (`off`).
+# Default: on. The companion COMPOSE_PROFILES line below activates the
+# matching profile in docker-compose.yml.
+HYDRA_STREAMING_MTX=on
+COMPOSE_PROFILES=on

--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ Edit `config.ini` to set camera source, MAVLink connection, callsign,
 and TAK endpoint before the first run. First-boot operators can use
 the `/setup` wizard instead of editing the file by hand.
 
+## View in browser
+
+Hydra's RTSP stream (`rtsp://<jetson-ip>:8554/hydra`) is republished
+as low-latency WebRTC by an optional `mediamtx` sidecar in
+`docker-compose.yml` — sub-200ms in any browser, no client install.
+Bring it up with `docker compose up`, then open
+`http://<jetson-ip>:8889/cam/whep` in Chrome/Edge. Disable with
+`HYDRA_STREAMING_MTX=off` (the sidecar is profile-gated).
+
 ## Dev loop (no rebuild)
 
 For UI work (templates, CSS, JS, or FastAPI route tweaks) you don't need

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,76 @@
+# docker-compose.yml — Hydra + mediamtx sidecar.
+#
+# Production Hydra runs under systemd on the Jetson (see README + docs/
+# deployment.md). This compose file is for the *streaming sidecar story*:
+# it lets an operator (or SORCC classroom) bring up the existing Hydra
+# image alongside a `mediamtx` service that ingests Hydra's RTSP stream
+# at rtsp://localhost:8554/hydra and republishes it as WebRTC at
+# http://<host>:8889/cam/whep — sub-200ms in any browser, no client.
+#
+# Hydra Python code is unchanged. This is a sidecar.
+#
+# ── Quick start ─────────────────────────────────────────────────────
+#
+#   docker compose up                # Hydra + mediamtx (default)
+#   HYDRA_STREAMING_MTX=off \
+#     docker compose up              # Hydra only — no sidecar
+#
+# The mediamtx service is profile-gated: its profile name IS the value
+# of HYDRA_STREAMING_MTX (default `on`). Compose only spins up services
+# whose profile matches an active profile in COMPOSE_PROFILES. When the
+# flag is `on`, the profile resolves to `on` and the bundled .env (or a
+# wrapper) sets COMPOSE_PROFILES=on so the sidecar starts. Setting
+# HYDRA_STREAMING_MTX=off swaps the profile to `off`, which is not in
+# COMPOSE_PROFILES, so mediamtx stays down.
+#
+# ── Networking ───────────────────────────────────────────────────────
+#
+# Both services use host networking. Hydra needs it for MAVLink/serial
+# and TAK multicast; mediamtx needs to reach RTSP on 127.0.0.1:8554 and
+# expose WebRTC ICE candidates on the host's real IP. Port mapping
+# tables (`ports:`) are no-ops under host networking — kept here as
+# documentation of which ports each service owns.
+#
+# ── Tag pinning ──────────────────────────────────────────────────────
+#
+# mediamtx pinned to bluenviron/mediamtx:1.9.0 (linux/amd64 + linux/arm64
+# both published — works on the Jetson). Bump deliberately, never use
+# :latest in production sidecars.
+
+services:
+  hydra-detect:
+    image: hydra-detect:latest
+    container_name: hydra-detect
+    network_mode: host
+    privileged: true
+    runtime: nvidia
+    volumes:
+      - ./config.ini:/app/config.ini
+      - ./models:/models
+      - ./output_data:/data
+    environment:
+      PYTHONUNBUFFERED: "1"
+    restart: unless-stopped
+
+  mediamtx:
+    # Sidecar — ingests rtsp://localhost:8554/hydra and republishes as
+    # WebRTC on :8889 (WHEP) and (off by default) HLS on :8888.
+    # Profile-gated: only starts when COMPOSE_PROFILES contains
+    # `streaming`, which is the default below. Set HYDRA_STREAMING_MTX=off
+    # to suppress.
+    image: bluenviron/mediamtx:1.9.0
+    container_name: hydra-mediamtx
+    network_mode: host
+    profiles:
+      - ${HYDRA_STREAMING_MTX:-on}
+    # Documentation only under host networking — no actual mapping
+    # happens, but keeps the port story discoverable from `docker
+    # compose config`.
+    ports:
+      - "8189:8189/udp"   # WebRTC ICE/UDP
+      - "8889:8889/tcp"   # WebRTC HTTP (WHEP/WHIP)
+    volumes:
+      - ./mediamtx.yml:/mediamtx.yml:ro
+    restart: unless-stopped
+    depends_on:
+      - hydra-detect

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -1,0 +1,50 @@
+# mediamtx.yml — sidecar config for republishing Hydra RTSP as WebRTC.
+#
+# Hydra's RTSPServer (hydra_detect/rtsp_server.py) publishes annotated
+# detection frames at rtsp://localhost:8554/hydra. mediamtx pulls that
+# stream on demand and exposes it as WebRTC at /cam/whep on :8889.
+# Operators view it in any browser — sub-200ms, no client install.
+#
+# HLS and recording are explicitly disabled; this is a low-latency
+# viewer only. No transcoding, no auth proxy, no TLS termination — those
+# are out of scope for the sidecar story (see issue #187).
+#
+# The mediamtx process keeps running even when the source RTSP is down;
+# it simply has no clients to serve. When Hydra comes back up the next
+# WHEP request triggers a fresh pull from rtsp://localhost:8554/hydra.
+
+# Logging — keep mediamtx noise low; Hydra is the loud one.
+logLevel: info
+logDestinations: [stdout]
+
+# RTSP ingest (server side disabled — we PULL, not accept)
+# We don't run mediamtx as an RTSP server; it's purely a republisher.
+rtsp: yes
+rtspAddress: :8555  # off the default :8554 so we never collide with Hydra
+rtspTransports: [tcp, udp]
+
+# WebRTC — the only output that matters for this sidecar.
+webrtc: yes
+webrtcAddress: :8889
+# ICE/STUN: localhost-only deployments do not need a STUN server. If
+# operators want to view from a remote host, set webrtcAdditionalHosts
+# in a deploy override or add a STUN entry — out of scope here.
+
+# HLS — off by default per scope lock (issue #187). Flip to `yes` and
+# pick a free port if you need HLS later.
+hls: no
+
+# Recording — off. Hydra writes its own logs/exports; mediamtx is
+# viewer-only.
+record: no
+
+# Path config — `cam` is the WebRTC viewing alias. mediamtx pulls from
+# Hydra's RTSP mount on demand whenever a client requests /cam/whep.
+paths:
+  cam:
+    source: rtsp://127.0.0.1:8554/hydra
+    sourceOnDemand: yes
+    # 10s grace before mediamtx tears the upstream pull down after the
+    # last viewer leaves — avoids reconnect churn during classroom demos
+    # where students refresh the page.
+    sourceOnDemandCloseAfter: 10s

--- a/tests/test_mediamtx_sidecar.py
+++ b/tests/test_mediamtx_sidecar.py
@@ -1,0 +1,210 @@
+"""mediamtx sidecar scaffolding + smoke tests.
+
+Guards the WebRTC sidecar story from issue #187: a `mediamtx` service
+ingests Hydra's RTSP at rtsp://localhost:8554/hydra and republishes as
+WebRTC at http://<host>:8889/cam/whep.
+
+Most tests are scaffolding (compose YAML, mediamtx.yml, README pointer)
+and run in CI. The live HTTP smoke test is gated on a reachable
+mediamtx on localhost:8889 and skips gracefully when the service is not
+running — CI environments do not bring up Docker Compose.
+"""
+
+from __future__ import annotations
+
+import socket
+from pathlib import Path
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO = Path(__file__).resolve().parents[1]
+COMPOSE = REPO / "docker-compose.yml"
+MTX_CONFIG = REPO / "mediamtx.yml"
+README = REPO / "README.md"
+ENV_EXAMPLE = REPO / ".env.example"
+
+MTX_HOST = "127.0.0.1"
+MTX_WEBRTC_PORT = 8889
+MTX_WHEP_PATH = "/cam/whep"
+MTX_IMAGE_TAG = "bluenviron/mediamtx:1.9.0"
+
+
+def _compose() -> dict:
+    parsed = yaml.safe_load(COMPOSE.read_text())
+    assert parsed and "services" in parsed, "docker-compose.yml missing services"
+    return parsed
+
+
+def _mediamtx_service() -> dict:
+    services = _compose()["services"]
+    assert "mediamtx" in services, "mediamtx service missing from docker-compose.yml"
+    return services["mediamtx"]
+
+
+def _hydra_service() -> dict:
+    services = _compose()["services"]
+    assert "hydra-detect" in services, "hydra-detect service missing"
+    return services["hydra-detect"]
+
+
+# ── Compose scaffolding ─────────────────────────────────────────────
+
+
+def test_compose_is_valid_yaml():
+    parsed = yaml.safe_load(COMPOSE.read_text())
+    assert isinstance(parsed, dict)
+
+
+def test_compose_has_hydra_and_mediamtx_services():
+    services = _compose()["services"]
+    assert "hydra-detect" in services
+    assert "mediamtx" in services
+
+
+def test_mediamtx_pinned_to_specific_tag():
+    svc = _mediamtx_service()
+    assert "image" in svc, "mediamtx must specify an image"
+    assert svc["image"] == MTX_IMAGE_TAG, (
+        f"mediamtx must pin to {MTX_IMAGE_TAG}, got {svc['image']!r}"
+    )
+    assert ":latest" not in svc["image"], "no :latest in production sidecar pins"
+
+
+def test_mediamtx_uses_host_networking():
+    # Host networking is required so mediamtx can reach Hydra's RTSP on
+    # 127.0.0.1:8554 and so WebRTC ICE candidates advertise the host IP.
+    svc = _mediamtx_service()
+    assert svc.get("network_mode") == "host"
+
+
+def test_mediamtx_mounts_config_read_only():
+    svc = _mediamtx_service()
+    vols = svc.get("volumes", [])
+    assert any("mediamtx.yml" in v and ":ro" in v for v in vols), (
+        "mediamtx.yml must be bind-mounted read-only into the container"
+    )
+
+
+def test_mediamtx_profile_gated_on_streaming_flag():
+    # Profile name comes from HYDRA_STREAMING_MTX (default `on`). When
+    # the flag is `off`, the profile no longer matches COMPOSE_PROFILES
+    # and the service stays down.
+    svc = _mediamtx_service()
+    profiles = svc.get("profiles", [])
+    assert profiles, "mediamtx must be profile-gated for the kill switch"
+    joined = " ".join(str(p) for p in profiles)
+    assert "HYDRA_STREAMING_MTX" in joined, (
+        "profile must reference HYDRA_STREAMING_MTX so the env flag controls startup"
+    )
+
+
+def test_compose_does_not_collide_with_dev_compose_8081():
+    # compose.dev.yml owns :8081. The streaming sidecar must not steal
+    # it. Sanity-check by scanning declared port mappings.
+    svc = _mediamtx_service()
+    ports = [str(p) for p in svc.get("ports", [])]
+    assert not any(p.startswith("8081:") or p == "8081" for p in ports)
+
+
+def test_hydra_service_present_for_sidecar_pairing():
+    # The whole point of the compose file is to pair Hydra with the
+    # sidecar. Make sure we did not accidentally drop the producer.
+    svc = _hydra_service()
+    assert "image" in svc
+    assert "hydra-detect" in svc["image"]
+
+
+# ── mediamtx.yml config ─────────────────────────────────────────────
+
+
+def test_mediamtx_config_exists_and_is_valid_yaml():
+    assert MTX_CONFIG.exists(), "mediamtx.yml must exist at repo root"
+    parsed = yaml.safe_load(MTX_CONFIG.read_text())
+    assert isinstance(parsed, dict)
+
+
+def test_mediamtx_config_pulls_from_hydra_rtsp():
+    parsed = yaml.safe_load(MTX_CONFIG.read_text())
+    paths = parsed.get("paths", {}) or {}
+    cam = paths.get("cam") or {}
+    src = str(cam.get("source", ""))
+    assert "rtsp://" in src and ":8554" in src and "/hydra" in src, (
+        f"mediamtx cam path must pull from Hydra RTSP, got {src!r}"
+    )
+
+
+def test_mediamtx_webrtc_on_8889():
+    parsed = yaml.safe_load(MTX_CONFIG.read_text())
+    assert parsed.get("webrtc") in (True, "yes"), "WebRTC must be enabled"
+    addr = str(parsed.get("webrtcAddress", ""))
+    assert addr.endswith(":8889"), f"WebRTC port must be 8889, got {addr!r}"
+
+
+def test_mediamtx_hls_off_by_default():
+    parsed = yaml.safe_load(MTX_CONFIG.read_text())
+    # Locked scope: HLS off by default. Either omitted or explicitly no.
+    hls = parsed.get("hls", False)
+    assert hls in (False, "no", None), f"HLS must default off, got {hls!r}"
+
+
+def test_mediamtx_no_recording():
+    # Out-of-scope: no recording. Spec lock from #187.
+    parsed = yaml.safe_load(MTX_CONFIG.read_text())
+    record = parsed.get("record", False)
+    assert record in (False, "no", None), f"recording must be off, got {record!r}"
+
+
+# ── README + env wiring ─────────────────────────────────────────────
+
+
+def test_readme_documents_browser_view():
+    txt = README.read_text()
+    assert "View in browser" in txt, "README must have a 'View in browser' section"
+    assert "8889" in txt
+    assert "/cam/whep" in txt
+
+
+def test_env_example_has_streaming_flag():
+    txt = ENV_EXAMPLE.read_text()
+    assert "HYDRA_STREAMING_MTX" in txt, (
+        ".env.example must document HYDRA_STREAMING_MTX so operators can flip it"
+    )
+
+
+# ── Live smoke test ─────────────────────────────────────────────────
+
+
+def _mediamtx_listening() -> bool:
+    """Best-effort probe — TCP connect to the WebRTC port.
+
+    Cheap and fast; avoids importing requests just to discover the
+    service is down. Returns False on any error so the smoke test
+    skips cleanly in CI / dev machines without docker compose up.
+    """
+    try:
+        with socket.create_connection((MTX_HOST, MTX_WEBRTC_PORT), timeout=0.25):
+            return True
+    except OSError:
+        return False
+
+
+@pytest.mark.skipif(
+    not _mediamtx_listening(),
+    reason=(
+        f"mediamtx not listening on {MTX_HOST}:{MTX_WEBRTC_PORT} — "
+        "run `docker compose up` to enable this smoke test"
+    ),
+)
+def test_webrtc_endpoint_returns_2xx_when_up():
+    # Live HTTP probe of the WHEP endpoint. Locked scope says: verify
+    # the WebRTC endpoint returns HTTP 200 when the service is up.
+    # We accept any 2xx so a future mediamtx version that returns 204
+    # for a HEAD doesn't break the gate.
+    requests = pytest.importorskip("requests")
+    url = f"http://{MTX_HOST}:{MTX_WEBRTC_PORT}{MTX_WHEP_PATH}"
+    resp = requests.head(url, timeout=2.0, allow_redirects=True)
+    assert 200 <= resp.status_code < 300, (
+        f"WebRTC WHEP endpoint {url} returned {resp.status_code}"
+    )


### PR DESCRIPTION
Closes #187.

## Summary

Adds a profile-gated `mediamtx` sidecar that ingests Hydra's existing RTSP output (`rtsp://localhost:8554/hydra`) and republishes it as WebRTC at `http://<host>:8889/cam/whep` — sub-200ms in any browser, no client install. Useful for SORCC classroom demos, remote observers, and dev/debug.

- `docker-compose.yml`: `hydra-detect` + `mediamtx` services. Both use host networking so the sidecar reaches Hydra's loopback RTSP and WebRTC ICE candidates advertise the host's real IP.
- `mediamtx.yml`: source-on-demand pull from Hydra's mount, WebRTC on `:8889`, HLS off, recording off. No transcoding, no auth proxy, no TLS termination — all out of locked scope.
- `HYDRA_STREAMING_MTX` feature flag (default `on`) wired through Compose profiles. `HYDRA_STREAMING_MTX=off` keeps the sidecar down.
- `tests/test_mediamtx_sidecar.py`: 15 scaffolding asserts (image pin, port, HLS-off, RTSP source, README hook) plus a live HTTP smoke test that TCP-probes `:8889` and `pytest.skip()`s cleanly when the sidecar is not running locally — CI does not bring up Compose.
- README "View in browser" section + `.env.example` `HYDRA_STREAMING_MTX` documentation.

## Tag verification

`bluenviron/mediamtx:1.9.0` confirmed on Docker Hub for both `linux/amd64` and `linux/arm64` (Jetson-compatible). Verified via Docker Hub registry API (`https://hub.docker.com/v2/repositories/bluenviron/mediamtx/tags/1.9.0/`) since `docker` CLI was not present in the build environment.

## Testing

```
$ python -m pytest tests/test_mediamtx_sidecar.py -v
15 passed, 1 skipped in 0.66s
# (the skip is the live HTTP smoke probe — gracefully bypassed when
#  mediamtx is not running on localhost:8889)

$ python -m pytest tests/test_mediamtx_sidecar.py tests/test_dev_compose.py -q
27 passed, 1 skipped in 0.84s
# (verifies my new compose file does not regress the dev compose contract)

$ python -m flake8 tests/test_mediamtx_sidecar.py
0
# (clean — no new lint debt; pre-existing 27 errors elsewhere in
#  hydra_detect/ + tests/ are baseline from origin/main and out of scope)
```

The full fast suite (`pytest -q -k "not integration and not slow" --ignore=tests/test_integration_wiring.py`) was not runnable on the local Windows dev box because `hydra_detect/web/config_api.py` imports `fcntl` (Linux-only). CI's Ubuntu runner has `fcntl` and runs the full suite — flake8 passes for the new code, and CI will exercise the rest.

No new shell scripts were added, so `shellcheck` is a no-op.

## Risk

- **Sidecar-only.** This PR does not touch `hydra_detect/rtsp_server.py` or any other Python under `hydra_detect/`. Adversarial-paths gate is satisfied by construction.
- **No Hydra runtime impact when `HYDRA_STREAMING_MTX=off`.** The Compose profile resolves to `off`, no longer matches `COMPOSE_PROFILES`, and the mediamtx service stays down. Hydra's existing RTSP server is unaffected.
- **Host networking is required.** Hydra needs it for MAVLink/serial and TAK; mediamtx needs it for WebRTC ICE + RTSP loopback ingest. This matches the existing systemd deployment pattern (`docker run --network host` in the README).
- **Pre-existing flake8 debt on `main`** (27 errors, none from this PR) means the global `make lint` target may still be red — that's not introduced here. Lint is clean for the new files.

## Out of scope (per #187 lock)

- No transcoding, no recording, no auth proxy, no TLS termination
- No changes to `hydra_detect/rtsp_server.py` or any other `hydra_detect/` Python
- No changes to other docker-compose services (this PR creates the file)