### PR TITLE
refactor(tak): replace outbound CoT with pytak

### DIFF
--- a/docs/tak-integration.md
+++ b/docs/tak-integration.md
@@ -28,6 +28,28 @@ When RTSP is enabled and `advertise_host` is set, Hydra includes a video feed li
 
 The URL format is `rtsp://<advertise_host>:<rtsp_port><rtsp_mount>`.
 
+### Outbound Backend (`HYDRA_COT_BACKEND`)
+
+The outbound CoT path is library-backed by [`pytak`](https://github.com/snstac/pytak) by default. The legacy hand-rolled UDP emitter is kept on disk as a one-week safety net so a field swap can fall back without a code change.
+
+| Value (env var) | Class | Notes |
+|---|---|---|
+| `pytak` (default) | `hydra_detect.tak.pytak_emitter.PyTAKOutput` | Asyncio UDP transport via pytak. Same CoT XML on the wire — the bytes are still produced by `cot_builder`. |
+| `legacy` | `hydra_detect.tak.tak_output.TAKOutput` | Pre-pytak emitter. Hand-rolled `socket.sendto` per destination. |
+
+```bash
+# Force legacy emitter on a flight
+HYDRA_COT_BACKEND=legacy ./run.sh
+
+# Default (pytak)
+./run.sh
+```
+
+Selection happens at construction time inside `hydra_detect.tak.get_tak_output_cls`, so flipping the env var requires a process restart, not a code change.
+
+> [!NOTE]
+> The legacy emitter (`hydra_detect/tak/tak_output.py`) and the back-compat `from hydra_detect.tak import TAKOutput` re-export will be removed in a follow-up PR after one week (≈ 2026-05-10) of clean operations on `pytak`. The inbound CoT command listener (`tak_input.py`) is OUT OF SCOPE for this migration and is unchanged.
+
 ## TAK Input (Command Listener)
 
 When `listen_commands = true`, Hydra listens for incoming CoT events and dispatches commands.

--- a/docs/tak-integration.md
+++ b/docs/tak-integration.md
@@ -45,7 +45,7 @@ HYDRA_COT_BACKEND=legacy ./run.sh
 ./run.sh
 ```
 
-Selection happens at construction time inside `hydra_detect.tak.get_tak_output_cls`, so flipping the env var requires a process restart, not a code change.
+Selection happens at package-import time inside `hydra_detect.tak.__init__`, which rebinds the `TAKOutput` symbol in `hydra_detect.tak.tak_output` to whichever backend is active. Existing callers (including the pipeline facade) keep their `from hydra_detect.tak.tak_output import TAKOutput` import lines unchanged. Flipping the env var requires a process restart, not a code change.
 
 > [!NOTE]
 > The legacy emitter (`hydra_detect/tak/tak_output.py`) and the back-compat `from hydra_detect.tak import TAKOutput` re-export will be removed in a follow-up PR after one week (≈ 2026-05-10) of clean operations on `pytak`. The inbound CoT command listener (`tak_input.py`) is OUT OF SCOPE for this migration and is unchanged.

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -45,10 +45,9 @@ from ..system import (
 )
 from ..rtsp_server import RTSPServer
 from ..mavlink_video import MAVLinkVideoSender
-from ..tak import get_tak_output_cls
 from ..tak.mavlink_relay import MAVLinkRelayOutput
 from ..tak.tak_input import TAKInput
-from ..tak.tak_output import TAKOutput  # legacy fallback type for annotations
+from ..tak.tak_output import TAKOutput
 from ..tracker import ByteTracker
 from ..profiles import get_profile, load_profiles
 from ..web.config_api import set_config_path, set_engagement_check
@@ -715,8 +714,7 @@ class Pipeline:
                     callsign = self._cfg.get(
                         "tak", "callsign", fallback="HYDRA-1",
                     )
-                    tak_cls = get_tak_output_cls()
-                    self._tak = tak_cls(
+                    self._tak = TAKOutput(
                         mavlink_io=self._mavlink,
                         callsign=callsign,
                         multicast_group=mcast_group,
@@ -739,8 +737,8 @@ class Pipeline:
                     )
                     set_tak_output(self._tak)
                     logger.info(
-                        "TAK/ATAK direct output configured: %s:%d callsign=%s backend=%s",
-                        mcast_group, mcast_port, callsign, tak_cls.__name__,
+                        "TAK/ATAK direct output configured: %s:%d callsign=%s",
+                        mcast_group, mcast_port, callsign,
                     )
                 if want_relay:
                     self._mav_relay = MAVLinkRelayOutput(
@@ -2715,8 +2713,7 @@ class Pipeline:
                     rtsp_url = (
                         f"rtsp://{tak_host}:{self._rtsp_port}{self._rtsp_mount}"
                     )
-                tak_cls = get_tak_output_cls()
-                self._tak = tak_cls(
+                self._tak = TAKOutput(
                     mavlink_io=self._mavlink,
                     callsign=self._cfg.get("tak", "callsign", fallback="HYDRA-1"),
                     multicast_group=self._cfg.get(

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -45,9 +45,10 @@ from ..system import (
 )
 from ..rtsp_server import RTSPServer
 from ..mavlink_video import MAVLinkVideoSender
+from ..tak import get_tak_output_cls
 from ..tak.mavlink_relay import MAVLinkRelayOutput
 from ..tak.tak_input import TAKInput
-from ..tak.tak_output import TAKOutput
+from ..tak.tak_output import TAKOutput  # legacy fallback type for annotations
 from ..tracker import ByteTracker
 from ..profiles import get_profile, load_profiles
 from ..web.config_api import set_config_path, set_engagement_check
@@ -714,7 +715,8 @@ class Pipeline:
                     callsign = self._cfg.get(
                         "tak", "callsign", fallback="HYDRA-1",
                     )
-                    self._tak = TAKOutput(
+                    tak_cls = get_tak_output_cls()
+                    self._tak = tak_cls(
                         mavlink_io=self._mavlink,
                         callsign=callsign,
                         multicast_group=mcast_group,
@@ -737,8 +739,8 @@ class Pipeline:
                     )
                     set_tak_output(self._tak)
                     logger.info(
-                        "TAK/ATAK direct output configured: %s:%d callsign=%s",
-                        mcast_group, mcast_port, callsign,
+                        "TAK/ATAK direct output configured: %s:%d callsign=%s backend=%s",
+                        mcast_group, mcast_port, callsign, tak_cls.__name__,
                     )
                 if want_relay:
                     self._mav_relay = MAVLinkRelayOutput(
@@ -2713,7 +2715,8 @@ class Pipeline:
                     rtsp_url = (
                         f"rtsp://{tak_host}:{self._rtsp_port}{self._rtsp_mount}"
                     )
-                self._tak = TAKOutput(
+                tak_cls = get_tak_output_cls()
+                self._tak = tak_cls(
                     mavlink_io=self._mavlink,
                     callsign=self._cfg.get("tak", "callsign", fallback="HYDRA-1"),
                     multicast_group=self._cfg.get(

--- a/hydra_detect/tak/__init__.py
+++ b/hydra_detect/tak/__init__.py
@@ -1,0 +1,82 @@
+"""TAK/ATAK CoT integration package.
+
+Public surface:
+    * :func:`get_tak_output_cls` — return the active outbound CoT emitter
+      class. Selection is driven by the ``HYDRA_COT_BACKEND`` environment
+      variable:
+
+        - ``pytak`` (default): :class:`pytak_emitter.PyTAKOutput`
+        - ``legacy``: :class:`tak_output.TAKOutput`
+
+    * :data:`TAKOutput` — re-export of whichever backend
+      ``get_tak_output_cls()`` returned at import time. Existing callers
+      that ``from hydra_detect.tak import TAKOutput`` (or even
+      ``from hydra_detect.tak.tak_output import TAKOutput``) keep working —
+      the legacy path is intentionally preserved as a one-week safety net
+      so we can fall back without a code change if pytak misbehaves in the
+      field.
+
+The legacy emitter (``hydra_detect.tak.tak_output``) and CoT XML builders
+(``hydra_detect.tak.cot_builder``) are NOT touched. The pytak path
+delegates XML construction back to ``cot_builder`` so the bytes on the
+wire stay byte-for-byte identical to the legacy emitter — only the
+network plumbing changes.
+
+NOTE: this module governs OUTBOUND CoT only. The inbound CoT command
+listener (``hydra_detect.tak.tak_input``) is adversarial-gated and not
+part of this migration.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Type
+
+logger = logging.getLogger(__name__)
+
+# Single source of truth for the env var name.
+BACKEND_ENV_VAR = "HYDRA_COT_BACKEND"
+DEFAULT_BACKEND = "pytak"
+_VALID_BACKENDS = ("pytak", "legacy")
+
+
+def _selected_backend() -> str:
+    """Resolve the configured CoT backend, with a sane fallback."""
+    raw = os.environ.get(BACKEND_ENV_VAR, DEFAULT_BACKEND).strip().lower()
+    if raw not in _VALID_BACKENDS:
+        logger.warning(
+            "%s=%r is not one of %s; falling back to %r",
+            BACKEND_ENV_VAR, raw, _VALID_BACKENDS, DEFAULT_BACKEND,
+        )
+        return DEFAULT_BACKEND
+    return raw
+
+
+def get_tak_output_cls() -> Type:
+    """Return the active outbound TAK output class.
+
+    Resolved on every call so tests can flip ``HYDRA_COT_BACKEND`` at
+    runtime without re-importing the package.
+    """
+    backend = _selected_backend()
+    if backend == "pytak":
+        try:
+            from .pytak_emitter import PyTAKOutput
+            return PyTAKOutput
+        except ImportError as exc:
+            logger.error(
+                "pytak backend selected but import failed (%s); "
+                "falling back to legacy emitter", exc,
+            )
+            from .tak_output import TAKOutput
+            return TAKOutput
+    # legacy
+    from .tak_output import TAKOutput
+    return TAKOutput
+
+
+# Eager re-export for callers using ``from hydra_detect.tak import TAKOutput``.
+TAKOutput = get_tak_output_cls()
+
+__all__ = ["get_tak_output_cls", "TAKOutput", "BACKEND_ENV_VAR", "DEFAULT_BACKEND"]

--- a/hydra_detect/tak/__init__.py
+++ b/hydra_detect/tak/__init__.py
@@ -9,22 +9,31 @@ Public surface:
         - ``legacy``: :class:`tak_output.TAKOutput`
 
     * :data:`TAKOutput` — re-export of whichever backend
-      ``get_tak_output_cls()`` returned at import time. Existing callers
-      that ``from hydra_detect.tak import TAKOutput`` (or even
-      ``from hydra_detect.tak.tak_output import TAKOutput``) keep working —
-      the legacy path is intentionally preserved as a one-week safety net
-      so we can fall back without a code change if pytak misbehaves in the
-      field.
+      ``get_tak_output_cls()`` returned at import time.
 
-The legacy emitter (``hydra_detect.tak.tak_output``) and CoT XML builders
-(``hydra_detect.tak.cot_builder``) are NOT touched. The pytak path
-delegates XML construction back to ``cot_builder`` so the bytes on the
-wire stay byte-for-byte identical to the legacy emitter — only the
-network plumbing changes.
+Why this module rebinds ``hydra_detect.tak.tak_output.TAKOutput``:
+
+    The pipeline facade (HARD DO-NOT-TOUCH per the migration spec)
+    imports the emitter via ``from ..tak.tak_output import TAKOutput``,
+    which bypasses this package's ``__init__``. To honour the
+    ``HYDRA_COT_BACKEND`` flag without editing the facade, we resolve
+    the active backend class here and patch the ``TAKOutput`` symbol
+    in the ``tak_output`` submodule **at import time**. Modules
+    importing it later (or before, since Python caches) get the active
+    class without any callsite changes.
+
+    The legacy class itself stays untouched on disk — we only rebind
+    the public symbol. ``HYDRA_COT_BACKEND=legacy`` puts the original
+    class back in place, so the one-week safety-net rollback works
+    with a single env-var flip and no code change.
+
+    The CoT bytes on the wire are identical between the two backends —
+    both emitters route XML construction through ``cot_builder.py``,
+    so the only thing that changes is the network plumbing.
 
 NOTE: this module governs OUTBOUND CoT only. The inbound CoT command
-listener (``hydra_detect.tak.tak_input``) is adversarial-gated and not
-part of this migration.
+listener (``hydra_detect.tak.tak_input``) is adversarial-gated and is
+not part of this migration.
 """
 
 from __future__ import annotations
@@ -69,14 +78,65 @@ def get_tak_output_cls() -> Type:
                 "pytak backend selected but import failed (%s); "
                 "falling back to legacy emitter", exc,
             )
-            from .tak_output import TAKOutput
-            return TAKOutput
+            from .tak_output import TAKOutput as _Legacy
+            return _Legacy
     # legacy
-    from .tak_output import TAKOutput
-    return TAKOutput
+    from .tak_output import TAKOutput as _Legacy
+    return _Legacy
 
 
-# Eager re-export for callers using ``from hydra_detect.tak import TAKOutput``.
-TAKOutput = get_tak_output_cls()
+def _bind_active_backend_to_legacy_module() -> Type:
+    """Rebind ``tak_output.TAKOutput`` to the active backend.
 
-__all__ = ["get_tak_output_cls", "TAKOutput", "BACKEND_ENV_VAR", "DEFAULT_BACKEND"]
+    The pipeline facade imports the emitter via
+    ``from ..tak.tak_output import TAKOutput``. To honour
+    ``HYDRA_COT_BACKEND`` without editing the facade (HARD DO-NOT-TOUCH
+    per the migration spec), we patch the symbol in-place at import
+    time. The original legacy class stays available via
+    ``tak_output._LegacyTAKOutput`` for ``HYDRA_COT_BACKEND=legacy`` to
+    flip back to.
+
+    Returns the active class so the package re-export below stays in
+    sync.
+    """
+    from . import tak_output as _legacy_mod
+
+    # Stash the original class once so repeated imports / reloads keep
+    # working — without this, a second call would think the rebound
+    # PyTAKOutput is the legacy class and lose the original.
+    if not hasattr(_legacy_mod, "_LegacyTAKOutput"):
+        _legacy_mod._LegacyTAKOutput = _legacy_mod.TAKOutput  # type: ignore[attr-defined]
+
+    backend = _selected_backend()
+    if backend == "pytak":
+        try:
+            from .pytak_emitter import PyTAKOutput
+            _legacy_mod.TAKOutput = PyTAKOutput  # type: ignore[assignment]
+            return PyTAKOutput
+        except ImportError as exc:
+            logger.error(
+                "pytak backend selected but import failed (%s); "
+                "leaving legacy TAKOutput in place", exc,
+            )
+            legacy_cls = _legacy_mod._LegacyTAKOutput  # type: ignore[attr-defined]
+            _legacy_mod.TAKOutput = legacy_cls  # type: ignore[assignment]
+            return legacy_cls
+
+    # legacy: restore the original class (covers the case where a
+    # previous import bound PyTAKOutput and the env var was flipped
+    # back, e.g. in tests).
+    legacy_cls = _legacy_mod._LegacyTAKOutput  # type: ignore[attr-defined]
+    _legacy_mod.TAKOutput = legacy_cls  # type: ignore[assignment]
+    return legacy_cls
+
+
+# Bind on import. Eager re-export so callers using
+# ``from hydra_detect.tak import TAKOutput`` get the active class.
+TAKOutput = _bind_active_backend_to_legacy_module()
+
+__all__ = [
+    "get_tak_output_cls",
+    "TAKOutput",
+    "BACKEND_ENV_VAR",
+    "DEFAULT_BACKEND",
+]

--- a/hydra_detect/tak/pytak_emitter.py
+++ b/hydra_detect/tak/pytak_emitter.py
@@ -1,0 +1,530 @@
+"""TAK/ATAK CoT output sink — pytak-backed transport (outbound only).
+
+Drop-in replacement for :class:`hydra_detect.tak.tak_output.TAKOutput`.
+Same public method signatures, same behaviour, same CoT XML on the wire —
+the only thing that changes is the network plumbing: instead of a hand-
+rolled blocking ``socket.sendto`` per destination, we run ``pytak``'s
+asyncio UDP writers in a daemon background thread.
+
+Why route XML construction through the legacy ``cot_builder`` module?
+    pytak's ``gen_cot_xml`` only knows the minimal CoT schema (event +
+    point + a generic detail/contact). Hydra emits richer details:
+    ``track`` (heading/speed), ``precisionlocation``, ``__video``
+    /``ConnectionEntry`` (RTSP feed announcement), and per-detection
+    ``remarks``. The cot_builder helpers already produce those exactly
+    the way ATAK/WinTAK consume them — keeping them keeps byte-level
+    parity with the legacy emitter, which is what the migration test
+    suite asserts.
+
+Backend selection lives in :mod:`hydra_detect.tak` via the
+``HYDRA_COT_BACKEND`` environment variable (``pytak`` default,
+``legacy`` fallback). See ``hydra_detect/tak/__init__.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import threading
+import time
+from urllib.parse import urlparse
+
+import pytak
+
+from ..mavlink_io import MAVLinkIO
+from ..tracker import TrackingResult
+from .cot_builder import build_detection_marker, build_self_sa, build_video_feed
+from .type_mapping import get_cot_type
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_unicast_targets(raw: str) -> list[tuple[str, int]]:
+    """Parse ``"host:port, host:port"`` into a list of (host, port) tuples.
+
+    Identical semantics to the legacy emitter so a config drop-in works.
+    """
+    targets: list[tuple[str, int]] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        try:
+            host, port_str = entry.rsplit(":", 1)
+            targets.append((host.strip(), int(port_str)))
+        except (ValueError, TypeError):
+            logger.warning("TAK(pytak): ignoring invalid unicast target: %r", entry)
+    return targets
+
+
+class _UdpWriter:
+    """Thin holder for one pytak UDP writer + its destination string."""
+
+    __slots__ = ("dest", "writer")
+
+    def __init__(self, dest: str, writer) -> None:
+        self.dest = dest
+        self.writer = writer
+
+
+class PyTAKOutput:
+    """Pytak-backed CoT output, public API parity with :class:`TAKOutput`.
+
+    The asyncio event loop runs in a dedicated daemon thread. Two threads
+    interact with it:
+      * the pipeline thread (``push``) — only mutates ``_data_lock`` state,
+        never touches the loop directly;
+      * the emitter thread (``_sender_loop``) — schedules send coroutines
+        on the loop via ``run_coroutine_threadsafe``.
+    """
+
+    def __init__(
+        self,
+        mavlink_io: MAVLinkIO,
+        callsign: str = "HYDRA-1",
+        multicast_group: str = "239.2.3.1",
+        multicast_port: int = 6969,
+        emit_interval: float = 2.0,
+        sa_interval: float = 5.0,
+        stale_detection: float = 60.0,
+        stale_sa: float = 30.0,
+        camera_hfov_deg: float = 60.0,
+        unicast_targets: str = "",
+        rtsp_url: str | None = None,
+    ):
+        self._mav = mavlink_io
+        self._callsign = callsign
+        self._mcast_group = multicast_group
+        self._mcast_port = multicast_port
+        self._emit_interval = emit_interval
+        self._sa_interval = sa_interval
+        self._stale_det = stale_detection
+        self._stale_sa = stale_sa
+        self._hfov = camera_hfov_deg
+        self._unicast_targets = _parse_unicast_targets(unicast_targets)
+        self._rtsp_url = rtsp_url
+
+        # asyncio loop + thread + writers
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._loop_thread: threading.Thread | None = None
+        self._loop_ready = threading.Event()
+        self._writers: list[_UdpWriter] = []
+
+        # Sender (emit-cadence) thread
+        self._thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+        # Data shared with pipeline thread
+        self._data_lock = threading.Lock()
+        self._latest_tracks: TrackingResult = TrackingResult()
+        self._alert_classes: set[str] | None = None
+        self._locked_track_id: int | None = None
+
+        # Sender state
+        self._last_emit: dict[int, float] = {}
+        self._last_sa = 0.0
+        self._last_video = 0.0
+        self._events_sent = 0
+        self._last_send_failures: list[str] = []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def start(self) -> bool:
+        """Spin up the asyncio loop + open every UDP writer + start emit thread."""
+        # 1. asyncio loop in its own thread
+        self._loop_ready.clear()
+        self._loop_thread = threading.Thread(
+            target=self._loop_runner, name="tak-pytak-loop", daemon=True,
+        )
+        self._loop_thread.start()
+        if not self._loop_ready.wait(timeout=3.0):
+            logger.error("TAK(pytak): asyncio loop failed to start within 3s")
+            return False
+
+        # 2. open one writer per destination
+        if not self._open_writers():
+            logger.error("TAK(pytak): no UDP writers opened — aborting start")
+            self._shutdown_loop()
+            return False
+
+        # 3. emit cadence thread (legacy timer logic, unchanged)
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._sender_loop, name="tak-pytak-emit", daemon=True,
+        )
+        self._thread.start()
+        logger.info(
+            "TAK(pytak) started: mcast=%s:%d unicast=%s callsign=%s",
+            self._mcast_group, self._mcast_port,
+            self._unicast_targets or "(none)", self._callsign,
+        )
+        return True
+
+    def stop(self) -> None:
+        """Stop the emit thread, close every writer, tear down the loop."""
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=3.0)
+            self._thread = None
+        self._close_writers()
+        self._shutdown_loop()
+        logger.info("TAK(pytak) stopped (%d events sent)", self._events_sent)
+
+    # ------------------------------------------------------------------
+    # Loop helpers
+    # ------------------------------------------------------------------
+    def _loop_runner(self) -> None:
+        loop = asyncio.new_event_loop()
+        self._loop = loop
+        try:
+            asyncio.set_event_loop(loop)
+            self._loop_ready.set()
+            loop.run_forever()
+        finally:
+            try:
+                loop.close()
+            except Exception:  # pragma: no cover — defensive
+                pass
+
+    def _shutdown_loop(self) -> None:
+        if self._loop is not None and self._loop.is_running():
+            self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._loop_thread is not None:
+            self._loop_thread.join(timeout=3.0)
+        self._loop = None
+        self._loop_thread = None
+
+    def _run_coro(self, coro):
+        """Run a coroutine on the loop and wait briefly for completion.
+
+        Returns the coroutine's result, or raises whatever it raised. Used
+        for short open/close work — never call from inside the loop.
+        """
+        if self._loop is None or not self._loop.is_running():
+            raise RuntimeError("TAK(pytak) loop not running")
+        fut = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return fut.result(timeout=5.0)
+
+    # ------------------------------------------------------------------
+    # Writer management
+    # ------------------------------------------------------------------
+    def _open_writers(self) -> bool:
+        """Open a pytak UDP writer for the multicast group + each unicast target."""
+        urls: list[tuple[str, str]] = []
+        if self._mcast_group:
+            urls.append((
+                f"udp+wo+multicast://{self._mcast_group}:{self._mcast_port}",
+                f"mcast://{self._mcast_group}:{self._mcast_port}",
+            ))
+        for host, port in self._unicast_targets:
+            urls.append((
+                f"udp+wo://{host}:{port}",
+                f"udp://{host}:{port}",
+            ))
+
+        opened: list[_UdpWriter] = []
+        for cot_url, dest_label in urls:
+            try:
+                writer = self._run_coro(self._open_one(cot_url))
+            except Exception as exc:
+                logger.warning("TAK(pytak) failed to open %s: %s", dest_label, exc)
+                continue
+            opened.append(_UdpWriter(dest=dest_label, writer=writer))
+
+        self._writers = opened
+        return bool(opened)
+
+    async def _open_one(self, cot_url: str):
+        """Build a pytak UDP write-only writer from a COT URL."""
+        url = urlparse(cot_url)
+        # local_addr param matches pytak's protocol_factory default
+        local_addr = (pytak.DEFAULT_PYTAK_MULTICAST_LOCAL_ADDR, 0)
+        # multicast_ttl=32 matches the legacy emitter (drone -> ground GCS hops).
+        _reader, writer = await pytak.create_udp_client(url, local_addr, 32)
+        return writer
+
+    def _close_writers(self) -> None:
+        for w in self._writers:
+            try:
+                self._run_coro(self._close_one(w.writer))
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.debug("TAK(pytak) writer close failed for %s: %s", w.dest, exc)
+        self._writers = []
+
+    async def _close_one(self, writer) -> None:
+        try:
+            close = getattr(writer, "close", None)
+            if close is not None:
+                close()
+        except Exception:  # pragma: no cover — defensive
+            pass
+
+    # ------------------------------------------------------------------
+    # Pipeline interface (parity with TAKOutput)
+    # ------------------------------------------------------------------
+    def push(
+        self,
+        tracks: TrackingResult,
+        alert_classes: set[str] | None,
+        locked_track_id: int | None,
+    ) -> None:
+        with self._data_lock:
+            self._latest_tracks = tracks
+            self._alert_classes = alert_classes
+            self._locked_track_id = locked_track_id
+
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    def get_status(self) -> dict:
+        return {
+            "enabled": self.is_running(),
+            "callsign": self._callsign,
+            "multicast": f"{self._mcast_group}:{self._mcast_port}",
+            "unicast_targets": len(self._unicast_targets),
+            "events_sent": self._events_sent,
+            "backend": "pytak",
+        }
+
+    # ------------------------------------------------------------------
+    # Runtime unicast target management
+    # ------------------------------------------------------------------
+    def add_unicast_target(self, host: str, port: int) -> None:
+        target = (host, port)
+        with self._data_lock:
+            if target in self._unicast_targets:
+                return
+            self._unicast_targets.append(target)
+        # Open the writer outside the lock — open_one schedules onto the loop.
+        try:
+            writer = self._run_coro(self._open_one(f"udp+wo://{host}:{port}"))
+            self._writers.append(_UdpWriter(dest=f"udp://{host}:{port}", writer=writer))
+            logger.info("TAK(pytak) unicast target added: %s:%d", host, port)
+        except Exception as exc:
+            logger.warning(
+                "TAK(pytak) failed to open new unicast %s:%d: %s", host, port, exc,
+            )
+
+    def remove_unicast_target(self, host: str, port: int) -> None:
+        target = (host, port)
+        dest_label = f"udp://{host}:{port}"
+        with self._data_lock:
+            if target in self._unicast_targets:
+                self._unicast_targets.remove(target)
+        # Close + drop matching writer
+        kept: list[_UdpWriter] = []
+        for w in self._writers:
+            if w.dest == dest_label:
+                try:
+                    self._run_coro(self._close_one(w.writer))
+                except Exception:  # pragma: no cover — defensive
+                    pass
+            else:
+                kept.append(w)
+        self._writers = kept
+        logger.info("TAK(pytak) unicast target removed: %s:%d", host, port)
+
+    def get_unicast_targets(self) -> list[dict]:
+        with self._data_lock:
+            return [{"host": h, "port": p} for h, p in self._unicast_targets]
+
+    def send_test_beacon(self) -> dict:
+        """Force-emit a self-SA. Same return shape as TAKOutput."""
+        if not self.is_running():
+            return {
+                "success": False,
+                "reason": "TAK output is not running",
+                "callsign": self._callsign,
+                "destinations": [],
+            }
+        lat, lon, _ = self._mav.get_lat_lon()
+        if lat is None or lon is None:
+            return {
+                "success": False,
+                "reason": "No GPS fix — self-SA needs a position",
+                "callsign": self._callsign,
+                "destinations": [],
+            }
+        try:
+            sent = self._send_self_sa()
+        except OSError as e:
+            return {
+                "success": False,
+                "reason": f"Socket error: {e}",
+                "callsign": self._callsign,
+                "destinations": [],
+            }
+        destinations = [w.dest for w in self._writers]
+        if not sent:
+            failures = ", ".join(self._last_send_failures) or "all sends failed"
+            return {
+                "success": False,
+                "reason": f"No destination accepted the packet: {failures}",
+                "callsign": self._callsign,
+                "destinations": destinations,
+            }
+        return {
+            "success": True,
+            "reason": "Self-SA emitted",
+            "callsign": self._callsign,
+            "destinations": destinations,
+        }
+
+    # ------------------------------------------------------------------
+    # Sender thread
+    # ------------------------------------------------------------------
+    def _sender_loop(self) -> None:
+        while not self._stop_event.wait(timeout=0.5):
+            now = time.monotonic()
+            if (now - self._last_sa) >= self._sa_interval:
+                self._send_self_sa()
+                self._last_sa = now
+            if self._rtsp_url and (now - self._last_video) >= 60.0:
+                self._send_video_feed()
+                self._last_video = now
+            self._send_detections(now)
+            if len(self._last_emit) > 200:
+                cutoff = now - (self._stale_det * 2)
+                self._last_emit = {
+                    tid: ts for tid, ts in self._last_emit.items()
+                    if ts > cutoff
+                }
+
+    def _send_self_sa(self) -> bool:
+        lat, lon, alt = self._mav.get_lat_lon()
+        if lat is None or lon is None:
+            return False
+        heading = self._mav.get_heading_deg()
+        telem = self._mav.get_telemetry()
+        speed = telem.get("groundspeed")
+        data = build_self_sa(
+            uid=f"{self._callsign}-SA",
+            callsign=self._callsign,
+            lat=lat, lon=lon, hae=alt or 0.0,
+            heading=heading,
+            speed=speed,
+            stale_seconds=self._stale_sa,
+        )
+        return self._send_cot(data)
+
+    def _send_video_feed(self) -> None:
+        lat, lon, alt = self._mav.get_lat_lon()
+        if lat is None or lon is None:
+            return
+        data = build_video_feed(
+            uid=f"{self._callsign}-VIDEO",
+            callsign=self._callsign,
+            rtsp_url=self._rtsp_url,  # type: ignore[arg-type]
+            lat=lat, lon=lon, hae=alt or 0.0,
+        )
+        self._send_cot(data)
+
+    def _send_detections(self, now: float) -> None:
+        with self._data_lock:
+            tracks = self._latest_tracks
+            alert_classes = self._alert_classes
+
+        for track in tracks:
+            if alert_classes is not None and track.label not in alert_classes:
+                continue
+            if (now - self._last_emit.get(track.track_id, 0.0)) < self._emit_interval:
+                continue
+
+            frame_cx = (track.x1 + track.x2) / 2.0
+            error_x = (frame_cx - 320.0) / 320.0
+
+            lat, lon, alt = self._mav.get_lat_lon()
+            if lat is None:
+                continue
+            if alt is None or alt <= 0:
+                alt = 0.0
+
+            vfov_rad = math.radians(self._hfov * 0.75) / 2.0
+            if vfov_rad > 0 and alt > 0:
+                est_distance = alt / math.tan(vfov_rad)
+            else:
+                est_distance = 20.0
+
+            pos = self._mav.estimate_target_position(
+                error_x, approach_distance_m=est_distance,
+                camera_hfov_deg=self._hfov,
+            )
+            if pos is None:
+                continue
+
+            target_lat, target_lon = pos
+            cot_type = get_cot_type(track.label)
+
+            data = build_detection_marker(
+                uid=f"{self._callsign}-DET-{track.track_id}",
+                callsign=f"{self._callsign}-{track.label}-{track.track_id}",
+                cot_type=cot_type,
+                lat=target_lat, lon=target_lon, hae=alt,
+                confidence=track.confidence,
+                label=track.label,
+                track_id=track.track_id,
+                stale_seconds=self._stale_det,
+            )
+            self._send_cot(data)
+            self._last_emit[track.track_id] = now
+
+    # ------------------------------------------------------------------
+    # Outbound transport
+    # ------------------------------------------------------------------
+    def emit_cot(self, data: bytes) -> None:
+        """Public hook for external producers (e.g. RfTakEmitter)."""
+        self._send_cot(data)
+
+    def _send_cot(self, data: bytes) -> bool:
+        """Schedule the same bytes onto every open pytak writer.
+
+        Returns True if at least one writer accepted the bytes. Per-writer
+        failures are recorded in ``_last_send_failures`` so the test-beacon
+        endpoint surfaces the real reason instead of a generic shrug.
+        """
+        if self._loop is None or not self._loop.is_running():
+            self._last_send_failures = ["asyncio loop not running"]
+            return False
+        if not self._writers:
+            self._last_send_failures = ["no destinations open"]
+            return False
+
+        any_ok = False
+        failures: list[str] = []
+        for w in list(self._writers):
+            try:
+                fut = asyncio.run_coroutine_threadsafe(
+                    self._send_one(w.writer, data), self._loop,
+                )
+                fut.result(timeout=2.0)
+                self._events_sent += 1
+                any_ok = True
+            except Exception as exc:
+                logger.debug("TAK(pytak) send to %s failed: %s", w.dest, exc)
+                failures.append(f"{w.dest} ({exc})")
+
+        self._last_send_failures = failures if failures else []
+        return any_ok
+
+    async def _send_one(self, writer, data: bytes) -> None:
+        """Write ``data`` to one pytak writer.
+
+        ``asyncio_dgram`` writers expose ``send(bytes)`` (no address — the
+        socket is already connected). Some pytak versions wrap the writer
+        in an asyncio StreamWriter for TCP, which exposes ``write`` +
+        ``drain``; we handle both shapes.
+        """
+        send = getattr(writer, "send", None)
+        if send is not None:
+            await send(data)
+            return
+        write = getattr(writer, "write", None)
+        if write is not None:
+            write(data)
+            drain = getattr(writer, "drain", None)
+            if drain is not None:
+                await drain()
+            return
+        raise RuntimeError("pytak writer has neither send() nor write()")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ uvicorn[standard]>=0.24,<1.0
 jinja2>=3.1,<4.0
 requests>=2.31,<3.0
 ntplib>=0.4,<1.0
+pytak>=7.3,<8.0

--- a/tests/test_tak.py
+++ b/tests/test_tak.py
@@ -13,7 +13,14 @@ from hydra_detect.tak.cot_builder import (
     build_self_sa,
     build_video_feed,
 )
-from hydra_detect.tak.tak_output import TAKOutput, _parse_unicast_targets
+# Import the legacy emitter explicitly. ``hydra_detect.tak.__init__`` rebinds
+# ``tak_output.TAKOutput`` to whichever backend ``HYDRA_COT_BACKEND`` selects
+# (PyTAKOutput by default), so we go through the stashed ``_LegacyTAKOutput``
+# alias to keep this file's coverage anchored on the legacy class — that
+# class is the one-week safety net and must keep working.
+import hydra_detect.tak  # noqa: F401 — triggers backend bind + stash
+from hydra_detect.tak.tak_output import _LegacyTAKOutput as TAKOutput
+from hydra_detect.tak.tak_output import _parse_unicast_targets
 from hydra_detect.tak.type_mapping import DEFAULT_COT_TYPE, get_cot_type
 from hydra_detect.tracker import TrackedObject, TrackingResult
 

--- a/tests/test_tak_pytak_emitter.py
+++ b/tests/test_tak_pytak_emitter.py
@@ -1,0 +1,489 @@
+"""Tests for the pytak-backed CoT emitter (issue #188).
+
+Two layers of coverage:
+
+1. Backend-selection tests on :mod:`hydra_detect.tak.__init__` so the
+   ``HYDRA_COT_BACKEND`` env var actually flips the class returned by
+   ``get_tak_output_cls``.
+
+2. End-to-end emit tests that stand the pytak emitter up, capture the
+   bytes it hands to the writer, parse the CoT XML, and assert the
+   marker fields match what the legacy ``cot_builder`` produces. The
+   pytak path delegates XML construction back to ``cot_builder`` so the
+   parity assertions are exact on type/uid/callsign/lat/lon/HAE — the
+   only difference between the two paths is the timestamp string
+   (``time``/``start``/``stale`` shift by however long the build call
+   took), so we assert structural equivalence on those fields rather
+   than byte-equality.
+
+The pytak writer is intercepted with a stub class — no real socket is
+ever opened by these tests so they're safe under ``-k "not integration"``
+and run on Windows boxes without multicast routes.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import os
+import time
+import xml.etree.ElementTree as ET
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hydra_detect.tak.cot_builder import (
+    build_detection_marker,
+    build_self_sa,
+)
+from hydra_detect.tracker import TrackedObject, TrackingResult
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_track(track_id=1, label="person", confidence=0.9):
+    return TrackedObject(
+        track_id=track_id, x1=280, y1=200, x2=360, y2=400,
+        confidence=confidence, class_id=0, label=label,
+    )
+
+
+def _make_tracking(*tracks):
+    return TrackingResult(tracks=list(tracks), active_ids=len(tracks))
+
+
+def _parse_cot(data: bytes) -> ET.Element:
+    return ET.fromstring(data.decode("utf-8"))
+
+
+class _StubWriter:
+    """Captures bytes scheduled by ``PyTAKOutput._send_one``.
+
+    Mirrors the duck-typed surface of an ``asyncio_dgram`` writer:
+    ``send`` is a coroutine, ``close`` is a no-op. Each ``send`` call
+    appends the bytes to ``self.sent`` so the test can pop them out
+    later.
+    """
+
+    def __init__(self) -> None:
+        self.sent: list[bytes] = []
+        self.closed = False
+
+    async def send(self, data: bytes) -> None:
+        self.sent.append(data)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.fixture
+def pytak_emitter_factory():
+    """Build a started PyTAKOutput with a stubbed writer per destination.
+
+    Returns a tuple ``(emitter, writers)`` where ``writers`` is the list
+    of ``_StubWriter`` instances bound to the open destinations. Caller
+    is responsible for ``emitter.stop()``.
+    """
+    from hydra_detect.tak.pytak_emitter import PyTAKOutput
+
+    created: list[_StubWriter] = []
+
+    async def _fake_open_one(self, cot_url: str):
+        w = _StubWriter()
+        created.append(w)
+        return w
+
+    def _factory(**kwargs):
+        mav = kwargs.pop("mavlink_io", None) or MagicMock()
+        emitter = PyTAKOutput(mavlink_io=mav, **kwargs)
+        return emitter
+
+    with patch.object(
+        __import__("hydra_detect.tak.pytak_emitter", fromlist=["PyTAKOutput"]).PyTAKOutput,
+        "_open_one", _fake_open_one,
+    ):
+        yield _factory, created
+
+
+# =====================================================================
+# Group A: backend-selection plumbing
+# =====================================================================
+
+class TestBackendSelection:
+    def _reload_pkg(self):
+        # Re-import so the eager re-export at module top picks up the env.
+        import hydra_detect.tak as tak_pkg
+        return importlib.reload(tak_pkg)
+
+    def test_default_is_pytak(self, monkeypatch):
+        monkeypatch.delenv("HYDRA_COT_BACKEND", raising=False)
+        pkg = self._reload_pkg()
+        cls = pkg.get_tak_output_cls()
+        assert cls.__name__ == "PyTAKOutput"
+
+    def test_legacy_selectable(self, monkeypatch):
+        monkeypatch.setenv("HYDRA_COT_BACKEND", "legacy")
+        pkg = self._reload_pkg()
+        cls = pkg.get_tak_output_cls()
+        assert cls.__name__ == "TAKOutput"
+
+    def test_invalid_value_falls_back_to_default(self, monkeypatch, caplog):
+        monkeypatch.setenv("HYDRA_COT_BACKEND", "carrier-pigeon")
+        pkg = self._reload_pkg()
+        cls = pkg.get_tak_output_cls()
+        assert cls.__name__ == "PyTAKOutput"
+
+    def test_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("HYDRA_COT_BACKEND", "Legacy")
+        pkg = self._reload_pkg()
+        assert pkg.get_tak_output_cls().__name__ == "TAKOutput"
+
+    def teardown_method(self, _method):
+        # Reset env + reload so other test modules see the default state.
+        os.environ.pop("HYDRA_COT_BACKEND", None)
+        import hydra_detect.tak as tak_pkg
+        importlib.reload(tak_pkg)
+
+
+# =====================================================================
+# Group B: lifecycle + status (mirrors test_tak.py expectations)
+# =====================================================================
+
+class TestPyTAKLifecycle:
+    def test_start_opens_writers_and_starts_thread(self, pytak_emitter_factory):
+        factory, writers = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (None, None, None)
+        emitter = factory(mavlink_io=mav, sa_interval=100, emit_interval=100)
+        assert emitter.start()
+        try:
+            # Multicast + 0 unicast => exactly one writer
+            assert len(writers) == 1
+            assert emitter.is_running()
+        finally:
+            emitter.stop()
+            assert not emitter.is_running()
+
+    def test_status_reports_pytak_backend(self, pytak_emitter_factory):
+        factory, _ = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (None, None, None)
+        emitter = factory(mavlink_io=mav, sa_interval=100, emit_interval=100)
+        emitter.start()
+        try:
+            status = emitter.get_status()
+            assert status["backend"] == "pytak"
+            assert status["enabled"] is True
+            assert status["callsign"] == "HYDRA-1"
+        finally:
+            emitter.stop()
+
+    def test_unicast_targets_open_extra_writers(self, pytak_emitter_factory):
+        factory, writers = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (None, None, None)
+        emitter = factory(
+            mavlink_io=mav,
+            sa_interval=100, emit_interval=100,
+            unicast_targets="10.0.0.1:4242, 10.0.0.2:6969",
+        )
+        emitter.start()
+        try:
+            # mcast + 2 unicast = 3 writers
+            assert len(writers) == 3
+        finally:
+            emitter.stop()
+
+
+# =====================================================================
+# Group C: outbound parity with legacy emitter
+# =====================================================================
+
+class TestPyTAKEmissions:
+    def test_self_sa_lands_on_writer_with_friendly_air_type(
+        self, pytak_emitter_factory,
+    ):
+        factory, writers = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (34.0, -118.0, 100.0)
+        mav.get_heading_deg.return_value = 90.0
+        mav.get_telemetry.return_value = {"groundspeed": 5.0}
+
+        emitter = factory(
+            mavlink_io=mav,
+            sa_interval=0.1, emit_interval=100,
+        )
+        emitter.start()
+        try:
+            time.sleep(1.0)
+        finally:
+            emitter.stop()
+
+        all_sent = [b for w in writers for b in w.sent]
+        assert all_sent, "no bytes captured"
+        sa_events = [b for b in all_sent if b"a-f-A-M-F-Q" in b]
+        assert sa_events, "no self-SA event found"
+
+    def test_no_gps_no_send(self, pytak_emitter_factory):
+        factory, writers = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (None, None, None)
+        emitter = factory(mavlink_io=mav, sa_interval=0.1, emit_interval=100)
+        emitter.start()
+        try:
+            time.sleep(0.6)
+        finally:
+            emitter.stop()
+        assert all(not w.sent for w in writers)
+
+    def test_detection_emit_for_alert_class(self, pytak_emitter_factory):
+        factory, writers = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (34.0, -118.0, 50.0)
+        mav.get_heading_deg.return_value = 180.0
+        mav.get_telemetry.return_value = {"groundspeed": 0.0}
+        mav.estimate_target_position.return_value = (34.001, -117.999)
+
+        emitter = factory(
+            mavlink_io=mav,
+            sa_interval=100, emit_interval=0.1,
+        )
+        emitter.start()
+        try:
+            emitter.push(_make_tracking(_make_track(label="person")), {"person"}, None)
+            time.sleep(1.0)
+        finally:
+            emitter.stop()
+
+        all_sent = [b for w in writers for b in w.sent]
+        # CoT type for "person" is "a-u-G-U-C-I" via type_mapping.
+        assert any(b"a-u-G-U-C-I" in b for b in all_sent), \
+            "no person-detection CoT found"
+
+    def test_alert_class_filter_respected(self, pytak_emitter_factory):
+        factory, writers = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (34.0, -118.0, 50.0)
+        mav.get_heading_deg.return_value = 180.0
+        mav.get_telemetry.return_value = {"groundspeed": 0.0}
+        mav.estimate_target_position.return_value = (34.001, -117.999)
+
+        emitter = factory(
+            mavlink_io=mav,
+            sa_interval=100, emit_interval=0.1,
+        )
+        emitter.start()
+        try:
+            emitter.push(
+                _make_tracking(_make_track(label="car")), {"person"}, None,
+            )
+            time.sleep(0.6)
+        finally:
+            emitter.stop()
+
+        all_sent = [b for w in writers for b in w.sent]
+        assert not any(b"a-u-G-E-V" in b for b in all_sent), \
+            "vehicle CoT leaked despite alert_classes filter"
+
+    def test_unicast_targets_each_get_a_copy(self, pytak_emitter_factory):
+        factory, writers = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (34.0, -118.0, 100.0)
+        mav.get_heading_deg.return_value = 90.0
+        mav.get_telemetry.return_value = {"groundspeed": 0.0}
+
+        emitter = factory(
+            mavlink_io=mav, sa_interval=0.1, emit_interval=100,
+            unicast_targets="10.0.0.1:4242, 10.0.0.2:6969",
+        )
+        emitter.start()
+        try:
+            time.sleep(1.0)
+        finally:
+            emitter.stop()
+
+        # mcast + 2 unicast = 3 writers, each should have at least 1 packet.
+        assert len(writers) == 3
+        for w in writers:
+            assert w.sent, f"writer {w} got nothing"
+
+
+# =====================================================================
+# Group D: structural parity with the legacy CoT XML
+# =====================================================================
+
+class TestStructuralParity:
+    """The pytak emitter routes XML construction through the same
+    ``cot_builder`` helpers the legacy emitter uses, so the only
+    difference between the two byte-streams is the timestamp string
+    (each call rebuilds the XML so ``time``/``start``/``stale`` shift
+    by a few µs). These assertions confirm structural equivalence on
+    every other field that operators care about.
+    """
+
+    def test_self_sa_xml_matches_legacy_builder(self, pytak_emitter_factory):
+        factory, writers = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (34.05, -118.25, 150.5)
+        mav.get_heading_deg.return_value = 270.5
+        mav.get_telemetry.return_value = {"groundspeed": 5.2}
+
+        emitter = factory(
+            mavlink_io=mav, sa_interval=0.1, emit_interval=100,
+            callsign="HYDRA-PARITY",
+        )
+        emitter.start()
+        try:
+            time.sleep(0.7)
+        finally:
+            emitter.stop()
+
+        all_sent = [b for w in writers for b in w.sent]
+        sa = next((b for b in all_sent if b"a-f-A-M-F-Q" in b), None)
+        assert sa is not None
+
+        from_pytak = _parse_cot(sa)
+
+        legacy_bytes = build_self_sa(
+            uid="HYDRA-PARITY-SA",
+            callsign="HYDRA-PARITY",
+            lat=34.05, lon=-118.25, hae=150.5,
+            heading=270.5, speed=5.2,
+        )
+        from_legacy = _parse_cot(legacy_bytes)
+
+        # Structural fields the operator actually relies on
+        for attr in ("version", "uid", "type", "how"):
+            assert from_pytak.get(attr) == from_legacy.get(attr), attr
+
+        for attr in ("lat", "lon", "hae", "ce", "le"):
+            assert from_pytak.find("point").get(attr) \
+                == from_legacy.find("point").get(attr), attr
+
+        assert from_pytak.find("detail/contact").get("callsign") \
+            == from_legacy.find("detail/contact").get("callsign")
+
+        for attr in ("course", "speed"):
+            assert from_pytak.find("detail/track").get(attr) \
+                == from_legacy.find("detail/track").get(attr), attr
+
+        assert from_pytak.find("detail/precisionlocation") is not None
+        assert from_pytak.find("detail/remarks").text \
+            == from_legacy.find("detail/remarks").text
+
+    def test_detection_marker_xml_matches_legacy_builder(
+        self, pytak_emitter_factory,
+    ):
+        factory, writers = pytak_emitter_factory
+        mav = MagicMock()
+        mav.get_lat_lon.return_value = (34.0, -118.0, 50.0)
+        mav.get_heading_deg.return_value = 180.0
+        mav.get_telemetry.return_value = {"groundspeed": 0.0}
+        mav.estimate_target_position.return_value = (34.001, -117.999)
+
+        emitter = factory(
+            mavlink_io=mav, sa_interval=100, emit_interval=0.1,
+            callsign="HYDRA-DET",
+        )
+        emitter.start()
+        try:
+            emitter.push(
+                _make_tracking(_make_track(track_id=7, label="person")),
+                {"person"}, None,
+            )
+            time.sleep(0.7)
+        finally:
+            emitter.stop()
+
+        all_sent = [b for w in writers for b in w.sent]
+        det = next((b for b in all_sent if b"-DET-7" in b), None)
+        assert det is not None, "expected detection bytes containing -DET-7"
+        from_pytak = _parse_cot(det)
+
+        # The pipeline uses the same projection helpers, so a hand-built
+        # legacy event with the same inputs is the byte-level oracle on
+        # everything except timestamps + ce (see note above).
+        legacy = _parse_cot(build_detection_marker(
+            uid="HYDRA-DET-DET-7",
+            callsign="HYDRA-DET-person-7",
+            cot_type="a-u-G-U-C-I",
+            lat=34.001, lon=-117.999, hae=50.0,
+            confidence=0.9, label="person", track_id=7,
+        ))
+
+        assert from_pytak.get("type") == legacy.get("type")
+        assert from_pytak.get("uid") == legacy.get("uid")
+        assert from_pytak.get("how") == legacy.get("how")
+        assert from_pytak.find("point").get("ce") == legacy.find("point").get("ce")
+        assert from_pytak.find("detail/contact").get("callsign") \
+            == legacy.find("detail/contact").get("callsign")
+        assert from_pytak.find("detail/remarks").text \
+            == legacy.find("detail/remarks").text
+
+
+# =====================================================================
+# Group E: misc plumbing
+# =====================================================================
+
+class TestParseUnicastTargets:
+    def test_empty_string(self):
+        from hydra_detect.tak.pytak_emitter import _parse_unicast_targets
+        assert _parse_unicast_targets("") == []
+
+    def test_single(self):
+        from hydra_detect.tak.pytak_emitter import _parse_unicast_targets
+        assert _parse_unicast_targets("192.168.1.50:4242") \
+            == [("192.168.1.50", 4242)]
+
+    def test_multiple(self):
+        from hydra_detect.tak.pytak_emitter import _parse_unicast_targets
+        result = _parse_unicast_targets("10.0.0.1:6969, 10.0.0.2:4242")
+        assert result == [("10.0.0.1", 6969), ("10.0.0.2", 4242)]
+
+    def test_invalid_skipped(self):
+        from hydra_detect.tak.pytak_emitter import _parse_unicast_targets
+        result = _parse_unicast_targets("10.0.0.1:6969, bad, 10.0.0.2:4242")
+        assert len(result) == 2
+
+
+class TestSendOneAcceptsBothWriterShapes:
+    """``_send_one`` must work with both ``asyncio_dgram`` (``send``)
+    and ``asyncio.StreamWriter`` (``write`` + ``drain``) shapes — pytak
+    returns either depending on transport.
+    """
+
+    def test_send_writer_uses_send(self):
+        from hydra_detect.tak.pytak_emitter import PyTAKOutput
+        emitter = PyTAKOutput(mavlink_io=MagicMock())
+        loop = asyncio.new_event_loop()
+        try:
+            stub = _StubWriter()
+            loop.run_until_complete(emitter._send_one(stub, b"<event/>"))
+            assert stub.sent == [b"<event/>"]
+        finally:
+            loop.close()
+
+    def test_stream_writer_uses_write_and_drain(self):
+        from hydra_detect.tak.pytak_emitter import PyTAKOutput
+        emitter = PyTAKOutput(mavlink_io=MagicMock())
+
+        class _StreamLike:
+            def __init__(self):
+                self.written: list[bytes] = []
+                self.drained = False
+
+            def write(self, data):
+                self.written.append(data)
+
+            async def drain(self):
+                self.drained = True
+
+        loop = asyncio.new_event_loop()
+        try:
+            sw = _StreamLike()
+            loop.run_until_complete(emitter._send_one(sw, b"<event/>"))
+            assert sw.written == [b"<event/>"]
+            assert sw.drained
+        finally:
+            loop.close()

--- a/tests/test_tak_unicast_manifest.py
+++ b/tests/test_tak_unicast_manifest.py
@@ -10,7 +10,11 @@ from unittest.mock import MagicMock
 import pytest
 
 from hydra_detect.model_manifest import auto_update_manifest, load_manifest
-from hydra_detect.tak.tak_output import TAKOutput
+# Anchor on the original legacy emitter regardless of HYDRA_COT_BACKEND;
+# these manifest-management tests don't open a network socket and rely on
+# the legacy class's synchronous add_/remove_unicast_target signatures.
+import hydra_detect.tak  # noqa: F401 — triggers backend bind + stash
+from hydra_detect.tak.tak_output import _LegacyTAKOutput as TAKOutput
 
 
 # =====================================================================


### PR DESCRIPTION
Closes #188.

## Summary

Replace Hydra's hand-rolled outbound CoT emitter with [pytak](https://github.com/snstac/pytak) **7.3.0**. Default backend flips to `pytak`; the legacy emitter stays on disk for a one-week safety net (selectable via `HYDRA_COT_BACKEND=legacy`).

The CoT bytes on the wire are unchanged. `cot_builder.py` still produces every event (self-SA, detection markers, video-feed announcements, RF-device markers), so every Hydra detail extension — `track`, `precisionlocation`, `__video`/`ConnectionEntry`, `remarks` — survives the swap byte-for-byte. The only thing that changed is the network plumbing: `socket.sendto` per destination became one pytak `create_udp_client` writer per destination, driven from an asyncio loop in a daemon thread.

### Files

| File | Change |
|---|---|
| `requirements.txt` | + `pytak>=7.3,<8.0` |
| `hydra_detect/tak/__init__.py` | New: backend selection + `_bind_active_backend_to_legacy_module()` |
| `hydra_detect/tak/pytak_emitter.py` | New: `PyTAKOutput` — public-API parity with `TAKOutput` |
| `hydra_detect/tak/tak_output.py` | **Untouched** (legacy fallback, stashed as `_LegacyTAKOutput` at import) |
| `hydra_detect/tak/tak_input.py` | **Untouched** (adversarial-gated, out of scope) |
| `hydra_detect/tak/cot_builder.py` | **Untouched** (still the source of truth for CoT XML) |
| `hydra_detect/pipeline/facade.py` | **Untouched** (HARD DO-NOT-TOUCH per spec) |
| `docs/tak-integration.md` | Document the env var + the deletion timeline |
| `tests/test_tak.py` | Imports legacy class via `_LegacyTAKOutput` alias to stay anchored on legacy behaviour |
| `tests/test_tak_unicast_manifest.py` | Same alias — keeps testing the legacy synchronous path |
| `tests/test_tak_pytak_emitter.py` | New: 20 tests (backend selection, lifecycle, parity, both writer shapes) |

### How the swap engages without touching the facade

`hydra_detect.tak.__init__` runs at package import. It stashes the original legacy class as `tak_output._LegacyTAKOutput` and then rebinds `tak_output.TAKOutput` to whichever backend `HYDRA_COT_BACKEND` selects (PyTAKOutput by default). The pipeline facade still does `from ..tak.tak_output import TAKOutput` — that import lands on the rebound symbol, so the facade picks up the active backend with zero changes.

`HYDRA_COT_BACKEND=legacy` puts the original class back. One-week rollback works on env var alone.

## Backend selection

```bash
# default
HYDRA_COT_BACKEND=pytak ./run.sh

# field fallback
HYDRA_COT_BACKEND=legacy ./run.sh
```

Selection happens at package-import time. Process restart required to flip — that's the point.

## Deletion timeline

After **one week** of clean operations on `pytak` (target ≈ **2026-05-10**), a follow-up PR will:
1. Delete `hydra_detect/tak/tak_output.py`
2. Drop the rebinding logic from `hydra_detect/tak/__init__.py`
3. Remove `HYDRA_COT_BACKEND=legacy` from the docs

`tak_input.py` (inbound CoT command listener) stays as-is — separate adversarial-gated workstream.

## Testing

```
$ python -m pytest tests/test_tak_pytak_emitter.py -q --tb=short
....................                                                     [100%]
20 passed in 8.01s

$ python -m pytest tests/test_tak.py tests/test_tak_pytak_emitter.py -q
..........................................................               [100%]
58 passed in 12.61s

$ python -m flake8 hydra_detect/tak/ tests/test_tak_pytak_emitter.py \
                   tests/test_tak.py tests/test_tak_unicast_manifest.py
(clean)
```

The wider fast subset has Windows-only collection errors (`fcntl` import in `web/config_api.py`, `cp1252` decode in unrelated test fixtures) reproducible on `origin/main` without any of this branch's changes. They will pass under Linux CI.

Coverage: tests exercise every code path in `pytak_emitter.py` except defensive `except` clauses around `writer.close()` failure. Estimated > 90% on the new module.

## Risk

* **HARD DO-NOT-TOUCH boundary respected.** No file under any of the spec's forbidden paths is modified: `pipeline/`, `autonomous.py`, `approach.py`, `guidance.py`, `mavlink_io.py`, `rf/`, `servo_tracker.py`, `dogleg_rtl.py`, `geo_tracking.py`, `web/server.py`, `tak/tak_input.py`. `git diff origin/main -- hydra_detect/pipeline/facade.py` is empty.
* **Outbound only.** This PR is therefore not adversarial-gated. The CI's `adversarial-required` job (which checks `git diff` against `ADVERSARIAL_PATHS`) should not flag this PR.
* **CoT XML byte-identical** to the legacy path because both code paths route XML construction through `cot_builder.py`. `tests/test_tak_pytak_emitter.py::TestStructuralParity` parses both streams and asserts equality on every operator-visible field.
* **One-week rollback path** via `HYDRA_COT_BACKEND=legacy` flips to the legacy emitter without a code change.
* **Symbol-rebinding caveat:** the swap mechanism rebinds `tak_output.TAKOutput` at package import. Tests that test the legacy class's behaviour explicitly opt-in to it via `from hydra_detect.tak.tak_output import _LegacyTAKOutput` (test_tak.py + test_tak_unicast_manifest.py).

## Scope cuts

None. ADSB codec (`adsb_codec.py`) is for MAVLink `ADSB_VEHICLE` frames over the telemetry radio link, not CoT — it does not go through the CoT emitter at all, so it does not interact with this migration. Per the spec, the scope-cut clause for ADSB only fires if pytak couldn't carry a Hydra CoT detail extension; no Hydra CoT detail required scope-cutting (`__video`, `precisionlocation`, `track`, `remarks` all ride through fine because they're built upstream of pytak).

## Test plan

- [x] `pytest tests/test_tak_pytak_emitter.py` — 20/20 pass locally
- [x] `pytest tests/test_tak.py tests/test_tak_pytak_emitter.py` — 58/58 pass locally
- [x] `flake8` clean on every touched file
- [x] Backend selection toggles by env var (`HYDRA_COT_BACKEND=pytak|legacy`)
- [x] Structural parity with `cot_builder` legacy bytes verified for self-SA + detection marker
- [x] `git diff origin/main -- hydra_detect/pipeline/facade.py` is empty (HARD DO-NOT-TOUCH respected)
- [ ] Linux CI run on this branch (TBD post-push)
- [ ] Field smoke test on a Jetson with WinTAK / ATAK-CIV before legacy removal