### PR TITLE
fix(ci): unbreak workflow startup — drop curly braces in shell vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,8 +171,8 @@ jobs:
           if [ -n "$HITS" ]; then
             echo "touched=true" >> "$GITHUB_OUTPUT"
             # Write hits to $GITHUB_ENV (not $GITHUB_OUTPUT) so later steps
-            # read via env, avoiding shell-injection via ${{ }} template
-            # interpolation of attacker-controlled filenames.
+            # read via env, avoiding shell-injection via workflow-expression
+            # template interpolation of attacker-controlled filenames.
             {
               echo 'HITS<<HITS_EOF'
               echo "$HITS"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,10 +126,10 @@ jobs:
           set -euo pipefail
           # Fail loud if base is unreachable (rebase + force-push on the base
           # branch can leave base.sha absent even after fetch-depth=0).
-          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+          if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
             git fetch --no-tags origin "${BASE_SHA}" || true
           fi
-          if ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+          if ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
             echo "::error::base.sha ${BASE_SHA} not reachable — cannot compute diff"
             exit 2
           fi


### PR DESCRIPTION
## Diagnosis

Every CI run on every branch (including `main`) has been failing with `conclusion=failure`, `latest_check_runs_count=0`, and zero logs since **2026-04-23**. Triaged the live page UI on dead run [25283516354](https://github.com/rmeadomavic/Hydra/actions/runs/25283516354) and surfaced the GitHub annotation:

> **Invalid workflow file: `.github/workflows/ci.yml#L1` (Line: 125, Col: 14): An expression was expected**

GitHub's workflow validator scans `run:` blocks looking for `${{ }}` expressions. It chokes on the pattern `"${BASE_SHA}^{commit}"` introduced in PR #144 (`review: close framework self-review blockers on PR #144`, commit `dc4ae7c`) — bash variable expansion immediately adjacent to git's rev-parse `^{commit}` selector. The validator sees `${...}^{...}` and reports "expression expected" — it's not actually a workflow expression but the parser can't tell.

Net effect: every workflow since `dc4ae7c` was rejected at validation time. No jobs ran. No logs were produced. PRs #181 through #190 all merged with **zero CI signal** because of this.

## Fix

Drop the curly braces. `$BASE_SHA^{commit}` parses correctly in bash because `^` is not a valid identifier character and terminates the variable name. Two-line change.

The other `${BASE_SHA}` / `${HEAD_SHA}` usages in the same block (lines 130, 133, 138) are NOT followed by `^{...}` so they don't trip the validator. Left them alone — minimal diff, minimal risk.

## Verification

- Local YAML parse: clean
- Bash semantics: `$BASE_SHA^{commit}` and `${BASE_SHA}^{commit}` are equivalent; `^` is not an identifier char
- Once this merges, the next push to any branch should produce real CI runs with actual jobs

## Risk

Tiny — two-character change in a workflow file that was already broken and producing no signal. Worst case: this PR's own CI also fails to start, in which case nothing changed. Best case: CI is back.

## Related

- Caused by: #144 (`dc4ae7c`)
- Affected merges (no CI signal): #178, #179, #180, #181, #182, #183, #184, #185, #186, #189, #190