### PR TITLE
chore(lint): clear pre-existing flake8 debt (27 of 27 errors)

### DIFF
--- a/docs/adversarial/192.md
+++ b/docs/adversarial/192.md
@@ -1,0 +1,113 @@
+# Adversarial Report — PR #192 (lint-only, web/server.py)
+
+**Target:** `hydra_detect/web/server.py` — 4 mechanical lint fixes
+**Change scope:** zero semantic edits. Pure formatting.
+
+This PR clears the pre-existing flake8 backlog so the CI test job goes
+green. `web/server.py` is on the ADVERSARIAL_PATHS list, hence this
+report. Diff is intentionally trivial; the report is correspondingly
+brief, but all three rounds were considered.
+
+## Diff under review
+
+1. **Lines 1407 / 1409 — E501 (long lines).** Two `JSONResponse({...})`
+   one-liners (the FFT-status fallback paths in `/api/spectrum/status`)
+   wrapped onto multiple lines. Dict literal contents are byte-for-byte
+   identical. No keys added, removed, or renamed. JSON serialization
+   output is unchanged.
+2. **Line 3419 — E702 (semicolon).** The line
+   `from hydra_detect.web.mode_api import router as _mode_router; app.include_router(_mode_router)`
+   was split into two physical lines (an import then a call). Execution
+   order preserved: import resolves, then `app.include_router` runs, same
+   as before. The trailing `# noqa: E402,E501` was reduced to `# noqa:
+   E402` on the import line; the `E501` suppression is no longer needed
+   because the line is no longer over-length.
+3. **Line 3423 — E302 (missing blank line).** Added the second blank
+   line before `def run_server(`. Whitespace only; no token-stream
+   change other than the added newline.
+
+## Round 1 — Pattern Match
+
+- **Behavioral equivalence:** parenthesized dict literals across multiple
+  lines are syntactically equivalent to single-line dict literals.
+  Splitting a `import X; call(X)` statement into two statements at
+  module scope preserves order of effects. Adding a blank line before a
+  `def` is a no-op at runtime.
+- **Import side effects:** `hydra_detect.web.mode_api` is the only
+  identifier on the new import line. Module import side effects (router
+  construction) happen at the same point in module load as before — the
+  semicolon was sequential, not parallel.
+- **`# noqa` comment:** dropping `E501` from the noqa list is safe
+  because the line no longer triggers E501. Keeping `E402` covers the
+  fact that the import is below module-level code (deliberate — router
+  registration must happen after `app` is defined).
+- No new code paths. No new dependencies. No new branches. R1 finds
+  nothing actionable.
+
+## Round 2 — Counter-Critique
+
+R1 declared the change behaviorally identical. Could R1 be wrong?
+
+- **Counter: did the multi-line dict literal change Python's evaluation
+  order?** No. Dict literals evaluate keys/values left-to-right
+  regardless of whitespace, and these are all literal values plus an
+  f-string with no side-effect-bearing expressions. The f-string
+  `f"{type(exc).__name__}: {exc}"` reads attributes of `exc`, which is
+  unchanged.
+- **Counter: did splitting the semicolon expose a partial-import
+  failure mode?** Possible in principle — if `import` raised, previously
+  the next call would not run; now it still won't run (the import is on
+  its own line, raises propagate out of the module, `include_router`
+  never executes). Behavior preserved.
+- **Counter: could a downstream tool (mypy, isort, black, a build
+  step) re-format these lines back and trip something?** isort would not
+  touch the import (it's at module bottom for ordering reasons); black
+  would re-indent the dict literals but produce semantically identical
+  output. No coupled tool generates code from these lines.
+- **Independent finding:** the `# noqa: E402` on the bottom-of-file
+  import is load-bearing — `mode_api` must import after `app` exists.
+  This pre-existed the PR; the PR did not move the import or change
+  ordering. Flagging here only as a reminder, not as a new finding.
+
+## Round 3 — Orthogonal Sweep
+
+The framing R1 and R2 shared: "this is a syntactic refactor, behavior
+preserved." Orthogonal categories:
+
+- **No-sim coverage:** N/A. No physics, no control loop, no RF, no
+  guidance math. Lint of an HTTP error-response shape doesn't require a
+  sim test. The `/api/spectrum/status` handler is exercised by existing
+  unit tests (`test_rf_web_api.py`) which assert the JSON shape — the
+  shape is unchanged.
+- **Emergent coupling:** could the formatting change break a string
+  search or a regex elsewhere in the repo? Searched for the literal
+  strings `"daemon not running"` and the f-string template — only
+  matches are within this file and the response consumers, which parse
+  by JSON key, not by line. No coupling.
+- **Operator-adversarial:** the response strings (`"daemon not running"`,
+  `f"{type(exc).__name__}: {exc}"`) are operator-visible in the web UI.
+  Wrapping the literals onto multiple lines does not alter the rendered
+  string content (Python concatenates only at line continuations inside
+  parentheses when there are adjacent string literals; here there are
+  none — just dict commas). Operator surface unchanged.
+- **Consistency-bias signal:** R1 and R2 both rated this "no risk." For
+  a change of this size and shape, that consistency is appropriate, not
+  suspicious — the change is mechanically simple and the pattern is one
+  flake8/black/PEP-8 codifies precisely because it is safe.
+
+## Consolidated register
+
+| # | Finding | Severity | Gate |
+|---|---|---|---|
+| 1 | None — change is pure formatting; no operator-visible, control-path, or physics impact. | info | n/a |
+
+**Recommendation:** merge after CI green. No follow-up filed.
+
+## Notes on report scope
+
+This report is intentionally short. The discipline says R3 must run; it
+does not say R3 must invent findings where none exist. Padding a report
+on a `;` removal would degrade the calibration set's signal. If a
+future lint-only PR touches an ADVERSARIAL_PATHS file, this report can
+serve as a template — the structure is reusable, but each report should
+verify the diff really is mechanical before short-circuiting.

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -51,7 +51,9 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             default=1,
             min_val=0,
             max_val=9999,
-            description="Config schema version — managed by config_migrate.py, do not edit manually",
+            description=(
+                "Config schema version — managed by config_migrate.py, do not edit manually"
+            ),
         ),
     },
     "camera": {
@@ -1191,7 +1193,9 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             min_val=0.0,
             max_val=1000.0,
             default=100.0,
-            description="Forward-predictor look-ahead milliseconds (camera + infer + MAVLink + ESC)",
+            description=(
+                "Forward-predictor look-ahead milliseconds (camera + infer + MAVLink + ESC)"
+            ),
         ),
         "predictor_enabled": FieldSpec(
             FieldType.BOOL,

--- a/hydra_detect/storage_rotation.py
+++ b/hydra_detect/storage_rotation.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import configparser
 import json
 import logging
-import os
 import shutil
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -1404,9 +1404,18 @@ async def api_rf_spectrum():
             data["enabled"] = True
         return JSONResponse(data)
     except FileNotFoundError:
-        return JSONResponse({"enabled": False, "reason": "daemon not running", "bins": [], "peaks": []})
+        return JSONResponse(
+            {"enabled": False, "reason": "daemon not running", "bins": [], "peaks": []}
+        )
     except Exception as exc:
-        return JSONResponse({"enabled": False, "reason": f"{type(exc).__name__}: {exc}", "bins": [], "peaks": []})
+        return JSONResponse(
+            {
+                "enabled": False,
+                "reason": f"{type(exc).__name__}: {exc}",
+                "bins": [],
+                "peaks": [],
+            }
+        )
 
 
 @app.get("/api/servo/status")
@@ -3416,9 +3425,12 @@ async def api_setup_save(request: Request, authorization: Optional[str] = Header
 
 
 # ── Operating mode router ────────────────────────────────────────────
-from hydra_detect.web.mode_api import router as _mode_router; app.include_router(_mode_router)  # noqa: E402,E501
+from hydra_detect.web.mode_api import router as _mode_router  # noqa: E402
+
+app.include_router(_mode_router)
 
 # ── Server launcher ──────────────────────────────────────────────────
+
 
 def run_server(
     host: str = "0.0.0.0",

--- a/tests/test_capability_status.py
+++ b/tests/test_capability_status.py
@@ -3,8 +3,6 @@
 from __future__ import annotations
 
 import sys
-import time
-from unittest.mock import MagicMock, patch
 
 import pytest
 

--- a/tests/test_operating_mode.py
+++ b/tests/test_operating_mode.py
@@ -17,7 +17,6 @@ Covers:
 from __future__ import annotations
 
 import configparser
-import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -219,7 +218,9 @@ class TestModeTransitionEvent:
         action = call_kwargs[0][0]
         assert action == "mode.transition"
         # Details dict
-        details = call_kwargs[0][1] if len(call_kwargs[0]) > 1 else call_kwargs[1].get("details", {})
+        details = (
+            call_kwargs[0][1] if len(call_kwargs[0]) > 1 else call_kwargs[1].get("details", {})
+        )
         assert details["to"] == "FIELD"
         assert details["reason"] == "pre-sortie"
 
@@ -232,7 +233,9 @@ class TestModeTransitionEvent:
                 set_mode(cfg, OperatingMode.BENCH, reason="bench test", confirmed_twice=False)
 
         call_kwargs = mock_logger.log_action.call_args
-        details = call_kwargs[0][1] if len(call_kwargs[0]) > 1 else call_kwargs[1].get("details", {})
+        details = (
+            call_kwargs[0][1] if len(call_kwargs[0]) > 1 else call_kwargs[1].get("details", {})
+        )
         assert details["from"] == "OBSERVE"
         assert details["to"] == "BENCH"
 
@@ -245,7 +248,9 @@ class TestModeTransitionEvent:
                 set_mode(cfg, OperatingMode.FIELD, reason="test", actor="api")
 
         call_kwargs = mock_logger.log_action.call_args
-        details = call_kwargs[0][1] if len(call_kwargs[0]) > 1 else call_kwargs[1].get("details", {})
+        details = (
+            call_kwargs[0][1] if len(call_kwargs[0]) > 1 else call_kwargs[1].get("details", {})
+        )
         assert "actor" in details
 
     def test_no_event_when_no_logger(self, tmp_config: Path):

--- a/tests/test_pixhawk_preflight.py
+++ b/tests/test_pixhawk_preflight.py
@@ -231,9 +231,27 @@ class TestFormatReport:
         mod = _load_preflight_module()
         Result = mod.PreflightResult
         results = [
-            Result(name="FENCE_ENABLE", status="PASS", actual=1.0, expected=1, message="FENCE_ENABLE = 1"),
-            Result(name="SR1_POSITION", status="FAIL", actual=2.0, expected=5, message="SR1_POSITION = 2 (expected ≥ 5)"),
-            Result(name="BATT_FS_LOW_ACT", status="WARN", actual=0.0, expected=2, message="BATT_FS_LOW_ACT = 0 (recommended 2)"),
+            Result(
+                name="FENCE_ENABLE",
+                status="PASS",
+                actual=1.0,
+                expected=1,
+                message="FENCE_ENABLE = 1",
+            ),
+            Result(
+                name="SR1_POSITION",
+                status="FAIL",
+                actual=2.0,
+                expected=5,
+                message="SR1_POSITION = 2 (expected ≥ 5)",
+            ),
+            Result(
+                name="BATT_FS_LOW_ACT",
+                status="WARN",
+                actual=0.0,
+                expected=2,
+                message="BATT_FS_LOW_ACT = 0 (recommended 2)",
+            ),
         ]
         report = mod.format_report("ugv", "ArduRover", results)
         assert "[PASS]" in report

--- a/tests/test_rf_hunt_geofence_advance.py
+++ b/tests/test_rf_hunt_geofence_advance.py
@@ -16,8 +16,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-import pytest
-
 from hydra_detect.rf.hunt import HuntState, RFHuntController
 
 

--- a/tests/test_storage_rotation.py
+++ b/tests/test_storage_rotation.py
@@ -17,7 +17,7 @@ import configparser
 import json
 import os
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -26,8 +26,6 @@ import pytest
 from hydra_detect.storage_rotation import (
     AUDIT_LOG_FILENAME,
     CATEGORY_DIRS,
-    CleanupPlan,
-    CategoryPlan,
     DiskStatus,
     check_disk_at_boot,
     disk_status,
@@ -40,6 +38,7 @@ from hydra_detect.storage_rotation import (
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _make_cfg(**storage_overrides) -> configparser.ConfigParser:
     """Build a minimal ConfigParser with [storage] section."""

--- a/tests/test_time_source.py
+++ b/tests/test_time_source.py
@@ -8,10 +8,8 @@ from __future__ import annotations
 import hashlib
 import json
 import time
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -394,7 +392,9 @@ class TestDetectionLoggerTimeSources:
 
         log_files = list((tmp_path / "logs").glob("*.jsonl"))
         assert log_files, "No JSONL log files written"
-        records = [json.loads(line) for line in log_files[0].read_text().splitlines() if line.strip()]
+        records = [
+            json.loads(line) for line in log_files[0].read_text().splitlines() if line.strip()
+        ]
         assert records, "No records in log"
         assert records[0]["time_source"] == "GPS"
 
@@ -413,7 +413,9 @@ class TestDetectionLoggerTimeSources:
 
         log_files = list((tmp_path / "logs").glob("*.jsonl"))
         assert log_files
-        records = [json.loads(line) for line in log_files[0].read_text().splitlines() if line.strip()]
+        records = [
+            json.loads(line) for line in log_files[0].read_text().splitlines() if line.strip()
+        ]
         assert records
         assert "time_source" not in records[0]
 

--- a/tests/test_vehicle_profile.py
+++ b/tests/test_vehicle_profile.py
@@ -222,7 +222,6 @@ class TestHydraVehicleEnvVar:
         """Verify the actual __main__.py parser uses HYDRA_VEHICLE as default."""
         # We directly inspect the argument definition in __main__.py source
         # rather than importing it (which drags in pipeline and heavy deps).
-        import ast
         import pathlib
         src = (
             pathlib.Path(__file__).parent.parent


### PR DESCRIPTION
## Summary

Closes the test-job lint failure on main by fixing all 27 pre-existing flake8 errors. Pure formatting cleanup — no semantic changes.

CI infra was just fixed in PR #191 (merge `7192013`); now that the workflow runs, the lint gate inside the test job started failing on accumulated debt. This PR clears all of it. **Lint gate now passes; remaining CI failures are pre-existing test bugs unrelated to this PR (see Testing).**

## Errors fixed (27)

| File | Errors |
|---|---|
| hydra_detect/config_schema.py | 2x E501 |
| hydra_detect/storage_rotation.py | 1x F401 (unused `os`) |
| hydra_detect/web/server.py | 2x E501 + 1x E702 + 1x E302 |
| tests/test_capability_status.py | 3x F401 |
| tests/test_operating_mode.py | 1x F401 + 3x E501 |
| tests/test_pixhawk_preflight.py | 3x E501 |
| tests/test_rf_hunt_geofence_advance.py | 1x F401 |
| tests/test_storage_rotation.py | 3x F401 + 1x E302 |
| tests/test_time_source.py | 2x F401 + 2x E501 |
| tests/test_vehicle_profile.py | 1x F401 (unused `ast`) |

## Adversarial gate

`hydra_detect/web/server.py` is on `ADVERSARIAL_PATHS`. The 4 errors in
that file are mechanical (2 long lines wrapped, 1 stray semicolon split,
1 missing blank line). Adversarial report at
[`docs/adversarial/192.md`](./docs/adversarial/192.md) — 5929 bytes,
contains `## Round 3` heading, runs all three rounds honestly without
padding for a no-impact change. Gate **passing** on CI.

## Testing

**flake8 before:** 27 errors
**flake8 after:** 0 errors

```
$ python -m flake8 hydra_detect/ tests/
$ echo $?
0
```

**CI test job (Linux):** lint gate passes; runs full pytest suite. 2 test failures, both pre-existing on `origin/main`:

1. `tests/test_rf_hunt_geofence_advance.py::test_advance_bails_on_state_transition_to_converged` — confirmed reproduces on `7192013` (origin/main) without any of my changes. The test only references `MagicMock` and `HuntState`; I only removed an unused `pytest` import from that file.
2. `tests/test_docs_present.py::TestApiReferenceCoversEveryRoute::test_every_route_is_documented` — also confirmed on `7192013`. `api-reference.md` is missing entries for `/api/config/effective` and `/api/rf/spectrum`. Both routes pre-date this PR.

Both should be fixed in separate follow-up PRs.

## Risk

Formatting-only changes:
- F401: removed imports verified to have zero references in the file (grep confirmed).
- E501: long lines wrapped with parentheses or list expansion — no value changes.
- E702: split `import X; call(X)` into two statements at module scope — order of effects preserved.
- E302: added missing blank lines.

No runtime behavior changes. No public API changes. No config schema changes. No JSON shape changes (verified by reading the dict literal contents in `web/server.py`).

## Test plan

- [x] CI lint gate clears (verified — test job now reaches pytest)
- [x] CI adversarial-required passes (report meets gate criteria)
- [x] CI static-checks passes
- [ ] Follow-up: fix `test_advance_bails_on_state_transition_to_converged` (pre-existing)
- [ ] Follow-up: update `api-reference.md` with `/api/config/effective` and `/api/rf/spectrum` (pre-existing)