### PR TITLE
docs: add /api/config/effective + /api/rf/spectrum to api-reference

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -173,6 +173,11 @@ curl -sX POST <HOST>/api/config/prompts \
 ### `POST /api/config/alert-classes`
 **Auth:** bearer · `{"classes": ["person","car"]}` or `[]` for all.
 
+### `GET /api/config/effective`
+**Auth:** none · Effective (post-profile-merge) runtime config. Returns
+`{vehicle_profile, runtime_config}` reflecting any `[vehicle.<name>]`
+overrides applied at startup.
+
 ### `GET /api/config/full`
 **Auth:** same-origin · All `config.ini` sections as JSON with
 sensitive fields redacted (`api_token`, `kismet_pass`).
@@ -421,6 +426,14 @@ ticker. Shape:
  "window_seconds": 60,
  "max_rssi": -42}
 ```
+
+### `GET /api/rf/spectrum`
+**Auth:** none · Latest `rtl_power` spectrum sweep from
+`/tmp/hydra_spectrum.json` (written by an external rtl_power daemon).
+Returns `{enabled, file_age_s, bins, peaks, ...}`. `enabled=false`
+when the daemon is not running, the file is missing, or the file is
+older than `_SPECTRUM_MAX_AGE_S` (`status: stale_data`). Dashboard
+SDR overlay treats `enabled=false` as no live SDR and skips rendering.
 
 ### `GET /api/rf/devices`
 **Auth:** none · Current Kismet device feed, normalized. Payload:


### PR DESCRIPTION
Closes the `test_docs_present::test_every_route_is_documented` failure surfaced when CI came back online (PR #191).

Two server routes shipped without doc entries:

| Route | Origin |
|---|---|
| `GET /api/config/effective` | vehicle-profile work — returns post-merge runtime config + active profile name |
| `GET /api/rf/spectrum` | spectrum daemon (PR #185) — reads `/tmp/hydra_spectrum.json` written by external rtl_power |

Doc-only change. `hydra_detect/web/server.py` is untouched (so no adversarial-gate trigger).

## Testing

\`\`\`
$ python -m pytest tests/test_docs_present.py -x
13 passed in 0.17s
\`\`\`

## Risk

Zero — text in a markdown file. No code paths touched.

## Remaining test-job failure

`test_rf_hunt_geofence_advance::test_advance_bails_on_state_transition_to_converged` is still red on main (verified before this PR). That's a real test/code bug in `hydra_detect/rf/hunt.py` — adversarial-gated path, needs a separate PR with a Round-3 report. Not in scope here.