### PR TITLE
fix(rf): bail rf-hunt advance loop on CONVERGED state transition

### DIFF
--- a/docs/adversarial/194.md
+++ b/docs/adversarial/194.md
@@ -1,0 +1,202 @@
+# Adversarial Report — PR #194 (rf-hunt advance loop, CONVERGED bail)
+
+**Target:** `hydra_detect/rf/hunt.py` — `_advance_to_next_sendable_wp`
+**Change scope:** one method body, ~10 lines edited. No public API change,
+no new fields, no schema change. Behavior changes only inside the search
+waypoint advance loop when `_geofence_waypoint` returns True after a clip.
+
+This PR fixes a pre-existing latent bug surfaced by
+`tests/test_rf_hunt_geofence_advance.py::test_advance_bails_on_state_transition_to_converged`.
+The advance loop's docstring already documented the intended behavior
+("bails if `_geofence_waypoint` pushes to CONVERGED after
+`_MAX_CONSECUTIVE_CLIPS`") but the implementation never iterated more
+than once when the geofence clipped and sent — so the consecutive-clip
+counter could never reach the threshold inside a single advance call,
+and CONVERGED never fired mid-loop.
+
+`hydra_detect/rf/hunt.py` is on the ADVERSARIAL_PATHS list. Report is
+short by design — the change is small, behavior-localized, and the
+existing 20-test geofence corpus pins the contract.
+
+## Diff under review
+
+The advance loop previously treated any True return from
+`_geofence_waypoint` as a successful send and returned immediately. New
+logic snapshots `_consecutive_clips` before the call; if the call
+returns True **and** the counter did not increase, the wp was a clean
+in-fence send → halt the loop (existing behavior). If the counter did
+increase (a clip happened), the loop now treats that wp the same way
+it already treats a False return — advance `_wp_index`, clear
+`_effective_wp`, and try the next wp. The state-check at the top of the
+next iteration handles the CONVERGED bail that
+`_geofence_waypoint` itself triggers on the third clip.
+
+`_geofence_waypoint` is unchanged. Its public contract (return True
+when sent, False when suppressed; trigger CONVERGED on the
+`_MAX_CONSECUTIVE_CLIPS`-th clip) is preserved exactly. Direct callers
+(`_do_homing`'s gradient steps, the best-position fallback) retain
+their existing semantics — they don't run inside the advance loop.
+
+## Round 1 — Pattern Match
+
+- **Behavioral equivalence in the in-fence path:** when
+  `_check_geofence` returns True (or no geofence is wired), the clip
+  branch never runs, `_consecutive_clips` does not change, the new
+  guard `self._consecutive_clips <= clips_before` holds, and the loop
+  returns just like before. All five tests in
+  `test_rf_hunt_geofence_advance.py` that don't exercise the clip
+  branch (`*_skips_suppressed_*`, `*_exhausts_without_sending_*`,
+  `*_sends_first_waypoint_when_all_inside`,
+  `*_no_geofence_configured_sends_first`, both misconfig-warn cases)
+  pass unchanged.
+- **No state mutation reordering:** `_geofence_waypoint` mutates
+  `_consecutive_clips` and `_effective_wp` and possibly invokes
+  `_set_state(CONVERGED)`. The advance loop now reads
+  `_consecutive_clips` after the call, but the loop is single-threaded
+  and `_lock` is not held across this section in either the old or new
+  code, so no new race window is introduced. The comparison is
+  `<=` against a snapshot integer — atomic.
+- **No new exception surface:** the call path can still raise from
+  `_check_geofence`, `_clip_to_geofence`, `_set_state`, or
+  `command_guided_to`; same as before.
+- **Logging unchanged on the clean-send path:** the
+  `logger.debug("Search WP %d/%d", ...)` line still fires when a
+  waypoint is cleanly sent. Only the clipped path now skips that debug
+  line — which is correct, because the wp was clipped to the boundary,
+  not "sent at the requested position."
+- R1 finds nothing actionable.
+
+## Round 2 — Counter-Critique
+
+R1 said behavior in the in-fence path is identical. Could R1 be wrong?
+
+- **Counter: does `_consecutive_clips` ever change on a non-clip call
+  path?** Yes — in the else branch of `_geofence_waypoint`
+  (`_check_geofence` returns True), it is reset to 0. So the snapshot
+  comparison `self._consecutive_clips <= clips_before` could be
+  affected. Walked the cases:
+  - `clips_before == 0`, in-fence call → counter reset to 0
+    → `0 <= 0` → loop halts. Correct.
+  - `clips_before == 2`, in-fence call → counter reset to 0
+    → `0 <= 2` → loop halts. Correct.
+  - `clips_before == 0`, out-of-fence call with clip → counter becomes
+    1 → `1 <= 0` is False → loop advances. Correct.
+  - `clips_before == 2`, out-of-fence call with clip → counter becomes
+    3 → `_set_state(CONVERGED)` fires inside `_geofence_waypoint`,
+    returns False → `sent` is False → loop advances → next iteration's
+    state check returns. Correct.
+  - In-fence call after a clip streak (counter resets to 0): wp gets
+    sent, loop halts. Counter starts fresh on the next call. Matches
+    `test_consecutive_clip_counter_resets_on_valid_waypoint` semantics.
+- **Counter: could the new behavior ever send the same wp twice in
+  one tick?** `_geofence_waypoint` calls `command_guided_to` once per
+  invocation. The loop calls `_geofence_waypoint` at most once per
+  `_wp_index` value (we increment after the call), so no wp is sent
+  twice. Multiple wps may be sent in one tick now — see Round 3 for
+  whether that's an operator concern.
+- **Counter: does the snapshot drift if the GIL gives up the loop?**
+  `_consecutive_clips` is read once into `clips_before`, the
+  `_geofence_waypoint` call runs, and the post-comparison reads it
+  once. No external thread mutates `_consecutive_clips`
+  (`_lock`-guarded ring buffer is separate). A SIGINT / `_stop_evt`
+  during the call would not corrupt the integer snapshot.
+- **Independent finding:** the `_MAX_CONSECUTIVE_CLIPS = 3` threshold
+  is a per-instance attribute set in `__init__`, not a class const. It
+  could be mutated at runtime by a misbehaving caller. Pre-existing.
+  Not in scope; flagging only as a reminder for a follow-up issue if
+  hardening is ever requested.
+
+## Round 3 — Orthogonal Sweep
+
+The framing R1 and R2 shared: "the change preserves contracts; the new
+loop iterates correctly through clipped waypoints." Stepping outside:
+
+- **No-sim coverage:** This is the relevant orthogonal category. The
+  bug fix changes how many `command_guided_to` calls land per
+  `_do_search` tick when the entire pattern is outside the fence. In
+  production, this means: instead of one boundary-clipped guided wp
+  per tick (and three ticks to converge), we now command up to three
+  guided wps in one tick before triggering CONVERGED. ArduPilot guided
+  mode replaces the active target with each new GUIDED waypoint
+  command; the vehicle effectively sees only the last-commanded wp.
+  This is benign in the steady-state geofenced scenario this code
+  guards (signal beyond fence → converge near boundary), but it is
+  measurably different from prior behavior on the wire. **No SITL
+  test asserts MAVLink wire shape under this regime.** Gate: `gate`
+  unless verified by SITL replay or tagged `accepted` because the
+  CONVERGED bail makes the wire churn bounded (≤ `_MAX_CONSECUTIVE_CLIPS`
+  guided commands per CONVERGED transition).
+- **Emergent coupling:** does any caller rely on
+  `_advance_to_next_sendable_wp` returning after exactly one
+  `command_guided_to`? Searched callers: only `_do_search`. Both call
+  sites (the arrival branch and the no-effective-wp branch) already
+  tolerate the loop exhausting the pattern without sending — that's
+  what the existing
+  `test_advance_exhausts_without_sending_when_all_suppressed` pins.
+  The "send N then converge" pattern is bounded by the existing
+  `_MAX_CONSECUTIVE_CLIPS` guard and the wp-list length. No infinite
+  loop risk: `_wp_index` is incremented every iteration that doesn't
+  return.
+- **Operator-adversarial:** can a malformed pattern + degenerate
+  geofence wedge the controller? The test stub
+  `clip_fn=lambda la, lo: (la, lo)` is the ultimate operator-
+  adversarial geofence — clip to self, perpetually outside. New
+  behavior: loop iterates, counter climbs, CONVERGED fires on the
+  third clip, loop bails on the next iteration's state check. Bounded
+  even under hostile config. Old behavior: one wp clipped and sent
+  per tick; CONVERGED fires across three ticks. Both bounded; new
+  path converges faster, which is operator-friendly.
+- **Consistency-bias signal:** R1 and R2 both reached "low risk."
+  This is a small, well-isolated change with explicit test coverage,
+  so consensus is appropriate; flagging it would be theatre. The
+  one finding promoted to `gate` is the SITL/wire-shape concern,
+  which neither R1 nor R2 raised — so the orthogonal sweep did its
+  job.
+
+## Consolidated register
+
+| # | Finding | Severity | Gate |
+|---|---|---|---|
+| 1 | New code may emit up to `_MAX_CONSECUTIVE_CLIPS` (3) `command_guided_to` MAVLink commands within a single `_do_search` tick when the entire remaining pattern is outside the geofence. Old code emitted one per tick. Bounded; ArduPilot guided mode handles target replacement; converges faster. No SITL replay confirms wire-level behavior. | info | accepted (bounded by `_MAX_CONSECUTIVE_CLIPS`; CONVERGED bail terminates within one tick; existing geofence test corpus covers state transitions) |
+| 2 | `_MAX_CONSECUTIVE_CLIPS` is a per-instance attribute, mutable at runtime by careless callers. Pre-existing on `main`; not introduced by this PR. | info | follow-up (file separately if hardening becomes a goal) |
+
+**Recommendation:** merge after CI green. The single finding is
+`accepted` because the wire-shape change is bounded (≤3 commands per
+CONVERGED transition), the state-transition contract is pinned by
+`test_three_consecutive_clips_triggers_converged` and
+`test_advance_bails_on_state_transition_to_converged`, and the failure
+mode it replaces (CONVERGED never fires inside one advance call) was
+worse — not better — for ops.
+
+## Edge cases tested
+
+The full 20-test geofence corpus passes locally
+(`tests/test_rf_hunt_geofence_advance.py` + `tests/test_rf_geofence.py`).
+Pre-existing platform-specific collection errors (`fcntl`,
+`os.getpgid` on Windows) are unchanged from `main`. Coverage notes:
+
+- Clean in-fence send halts loop on first wp
+  (`*_sends_first_waypoint_when_all_inside`).
+- Suppressed wp (no clip) advances to next sendable
+  (`*_skips_suppressed_*`).
+- All-suppressed pattern exhausts without send
+  (`*_exhausts_without_sending_*`).
+- Three consecutive clips inside one advance call → CONVERGED, loop
+  bails, `_wp_index < len(_waypoints)`
+  (`*_bails_on_state_transition_to_converged` — the regression this
+  PR fixes).
+- Counter resets after an in-fence wp following clips
+  (`test_consecutive_clip_counter_resets_on_valid_waypoint`).
+- Misconfig (check without clip) still warns at construction
+  (`test_misconfig_warn_on_check_without_clip`).
+
+## Notes on report scope
+
+The change is small enough that a longer report would invent risk
+where none exists. The orthogonal-sweep finding (wire-shape change
+under degenerate geofence) is real but bounded; documenting it here
+keeps the audit trail honest. If a future PR widens the scope of
+`_advance_to_next_sendable_wp` (e.g., adds a retry budget independent
+of `_consecutive_clips`, or unsticks `_geofence_waypoint`'s send-side
+effect from its validate-side effect), re-run `/adversarial` rather
+than reusing this template.

--- a/hydra_detect/rf/hunt.py
+++ b/hydra_detect/rf/hunt.py
@@ -554,19 +554,30 @@ class RFHuntController:
         Also bails if a mid-loop state transition (e.g.
         ``_geofence_waypoint`` pushing to CONVERGED after
         ``_MAX_CONSECUTIVE_CLIPS``) moves the controller out of
-        ``SEARCHING``.
+        ``SEARCHING``. A clipped (out-of-fence) waypoint counts as
+        "sent but degenerate" — the loop keeps advancing so the
+        consecutive-clip counter can climb to the CONVERGED threshold
+        within a single advance call when the entire remaining pattern
+        sits outside the fence. A clean (in-fence) send always halts
+        the loop.
         """
         while self._wp_index < len(self._waypoints):
             if self.state != HuntState.SEARCHING:
                 return
             wp = self._waypoints[self._wp_index]
-            if self._geofence_waypoint(wp[0], wp[1], wp[2]):
+            clips_before = self._consecutive_clips
+            sent = self._geofence_waypoint(wp[0], wp[1], wp[2])
+            if sent and self._consecutive_clips <= clips_before:
+                # Clean in-fence send — halt the loop on the commanded wp.
                 logger.debug(
                     "Search WP %d/%d",
                     self._wp_index + 1, len(self._waypoints),
                 )
                 return
-            # Waypoint suppressed — advance and retry with the next one.
+            # Waypoint suppressed (return False) or clipped to the fence
+            # boundary (return True with clip counter incremented). Either
+            # way, advance and try the next one so MAX_CONSECUTIVE_CLIPS
+            # can fire within this call when the whole pattern is OOF.
             self._wp_index += 1
             self._effective_wp = None
 


### PR DESCRIPTION
## Summary

`tests/test_rf_hunt_geofence_advance.py::test_advance_bails_on_state_transition_to_converged` was failing on `main` because `_advance_to_next_sendable_wp` returned after the first clipped-but-sent waypoint. The consecutive-clip counter could never reach `_MAX_CONSECUTIVE_CLIPS` inside a single advance call, so the CONVERGED bail the docstring promised never fired.

Fix: snapshot `_consecutive_clips` before calling `_geofence_waypoint`. If the call returns True and the counter increased (a clip happened), treat the wp the same way the loop already treats a False return — advance and try the next wp. A clean in-fence send still halts the loop. The third clip drives `_geofence_waypoint` to set CONVERGED itself; the next iteration's state check bails.

`_geofence_waypoint`'s public contract is unchanged.

## Failing test this fixes

```
tests/test_rf_hunt_geofence_advance.py::test_advance_bails_on_state_transition_to_converged
```

## Adversarial report

`hydra_detect/rf/hunt.py` is on `ADVERSARIAL_PATHS`. Round-3 report committed at [`docs/adversarial/194.md`](docs/adversarial/194.md). Single finding (wire-shape change under degenerate geofence) tagged `accepted` because it is bounded by `_MAX_CONSECUTIVE_CLIPS` (≤3 commands per CONVERGED transition) and the failure mode it replaces was worse for ops.

## Before / after pytest

Before (on `main`):

```
tests/test_rf_hunt_geofence_advance.py::test_advance_bails_on_state_transition_to_converged FAILED
E       AssertionError: assert <HuntState.SEARCHING: 'searching'> == <HuntState.CONVERGED: 'converged'>
```

After:

```
tests/test_rf_hunt_geofence_advance.py ........ 7 passed
tests/test_rf_geofence.py ........ 13 passed
============================== 20 passed in 1.21s ==============================
```

flake8 clean on `hydra_detect/rf/hunt.py`. mypy unchanged from `main` (17 pre-existing errors, 0 new). Pre-existing Windows-only collection errors in `test_web_api.py` etc. (`fcntl`, `os.getpgid`) are unchanged.

## Test plan

- [x] Failing test reproduces on `main`, passes on this branch
- [x] Full geofence corpus (20 tests) green
- [x] flake8 clean on changed file
- [x] mypy: zero new errors vs `main`
- [x] Adversarial Round-3 report committed (>500 bytes, has `## Round 3`)
- [ ] CI green (watch on push)