### PR TITLE
chore(deps): bump pytest to 9.0.3 (CVE)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-pytest>=7.4,<9.0
+pytest>=9.0.3,<10.0
 pytest-cov>=4.1,<7.0
 hypothesis>=6.90,<7.0
 flake8>=6.0,<8.0


### PR DESCRIPTION
## Summary
- Bumps pytest from \`>=7.4,<9.0\` to \`>=9.0.3,<10.0\` to resolve the Dependabot vulnerability alert.
- CVE: pytest tmpdir handling vulnerability (medium severity, test-only impact).
- Closes Dependabot alert #1.

## Test plan
- [ ] CI passes (lint + test)
- [ ] Local: \`python -m pytest\` resolves new pytest, no breakage