### PR TITLE
chore(repo): add CHANGELOG, SECURITY, dependabot, issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,85 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: Step-by-step to reproduce. Include commands, inputs, and expected output.
+      placeholder: |
+        1. Run `...`
+        2. Observe `...`
+        3. Expected `...`, got `...`
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: Hydra version / commit
+      description: Tag (e.g. v2.1.0) or commit hash where this was observed.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: subsystem
+    attributes:
+      label: Affected subsystem
+      multiple: true
+      options:
+        - Detection / tracking pipeline
+        - RF / Kismet integration
+        - TAK / CoT output
+        - GeoChat / inbound
+        - Operator dashboard (web)
+        - Autonomy gates (geofence / vehicle_mode / etc.)
+        - Vehicle control (Follow / Drop / Cue / Pixel-Lock)
+        - MAVLink / pymavlink
+        - Audit log / chain of custody
+        - Build / CI / Docker
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Severity
+      options:
+        - "Critical — flight safety / unsafe vehicle behavior"
+        - "High — payload crashes or produces wrong output"
+        - "Medium — feature broken but workaround exists"
+        - "Low — cosmetic, docs, dev ergonomics"
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Jetson model, JetPack version, ArduPilot vehicle/version, network setup.
+      placeholder: |
+        - Jetson: Orin Nano 8GB
+        - JetPack: 6.x
+        - Vehicle: ArduCopter 4.5 / ArduRover / etc.
+        - Camera: ...
+        - Network: ...
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots / dashboard state
+      description: Paste any relevant output. Use code blocks. Audit log JSONL excerpts welcome.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,63 @@
+name: Feature request
+description: Propose a new capability, control mode, or improvement.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What operational problem does this solve? Why does it matter?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed
+    attributes:
+      label: Proposed capability
+      description: What should the feature do? Sketch the interface (CLI, config, dashboard tab, vehicle control mode, etc.).
+    validations:
+      required: true
+
+  - type: dropdown
+    id: subsystem
+    attributes:
+      label: Affected subsystem
+      multiple: true
+      options:
+        - Detection / tracking pipeline
+        - RF / Kismet integration
+        - TAK / CoT output
+        - GeoChat / inbound
+        - Operator dashboard (web)
+        - Autonomy gates
+        - Vehicle control modes
+        - MAVLink integration
+        - Post-mission review / replay
+        - Build / CI / Docker
+        - New subsystem
+    validations:
+      required: true
+
+  - type: textarea
+    id: safety
+    attributes:
+      label: Safety considerations
+      description: Could this affect flight safety, operator authority, or audit integrity? What gates apply?
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: What else did you think about? Why is this the right approach?
+    validations:
+      required: false
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: What is in scope, what is explicitly out of scope?
+    validations:
+      required: false

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Python deps (uses requirements.txt + requirements-dev.txt + requirements-extra.txt)
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(deps)"
+    # Skip major-version bumps automatically — Hydra pins for stability.
+    # Major bumps will surface as security-only when CVEs require them.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(ci)"
+
+  # Docker (Dockerfile present)
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(docker)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+All notable changes to Hydra Detect are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Repository baseline scaffolding: SECURITY.md, ISSUE_TEMPLATE forms, dependabot config.
+
+### Changed
+-
+
+### Fixed
+- Bumped pytest to >=9.0.3 to resolve Dependabot CVE alert (medium, test-only).
+
+### Security
+- Enabled GitHub Dependabot vulnerability alerts and automated security update PRs.
+- Enabled GitHub secret scanning + push protection.
+
+## [2.1.0]
+
+Current production release. See git history for details:
+[2.0-rc1...v2.1.0](https://github.com/rmeadomavic/Hydra/compare/v2.0-rc1...v2.1.0)
+
+## [2.0-rc1]
+
+Initial v2 release candidate. See git history for details.
+
+[Unreleased]: https://github.com/rmeadomavic/Hydra/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/rmeadomavic/Hydra/releases/tag/v2.1.0
+[2.0-rc1]: https://github.com/rmeadomavic/Hydra/releases/tag/v2.0-rc1

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,42 @@
+# Security Policy
+
+## Supported versions
+
+The latest tagged release on `main` (currently v2.1.0) is supported. Earlier versions receive no fixes.
+
+## Reporting a software vulnerability
+
+Email **kyle.adomavicius@gmail.com** with:
+- a description of the issue
+- reproduction steps if you have them
+- the affected version, tag, or commit hash
+
+I will acknowledge within 7 days and aim to issue a fix or mitigation within 30 days for confirmed issues.
+
+Please do **not** open a public GitHub issue for security reports — use email so the fix can ship before disclosure.
+
+## Reporting a flight-safety / autonomy issue
+
+Hydra is a payload that interacts with autonomous vehicles (drones, rovers, boats). Bugs that could cause unsafe vehicle behavior are treated as the highest priority.
+
+If you discover a defect that could result in:
+- loss of operator control,
+- bypass of the autonomy gates (geofence, vehicle_mode, operator_lock, gps_fresh, cooldown),
+- unintended Drop / Cue / Pixel-Lock actuation,
+- incorrect TAK/CoT output to a tactical network,
+- or any failure mode with risk to people, aircraft, vessels, or terrain,
+
+**email immediately** with subject prefix `[FLIGHT-SAFETY]`. These reports take precedence over routine security reports.
+
+## Scope
+
+This policy covers:
+- The `hydra_detect` Python package and ancillary scripts in this repository.
+- The TAK/CoT pipeline, GeoChat input handling, and audit log integrity.
+- The autonomy gate stack and dry-run/shadow/live mode transitions.
+
+This policy does **not** cover:
+- Vulnerabilities in third-party Python dependencies (report those upstream).
+- ArduPilot firmware itself (report to https://github.com/ArduPilot/ardupilot/security).
+- The host operating system on the Jetson Orin Nano.
+- Physical hardware vulnerabilities in the camera, MAVLink link, or network stack.


### PR DESCRIPTION
## Summary
Brings Hydra up to a professional repo baseline. No code changes; all additive scaffolding.

- `CHANGELOG.md` (keep-a-changelog format, seeded with v2.1.0 and v2.0-rc1).
- `SECURITY.md` with a separate flight-safety reporting channel for autonomy/control bugs.
- `.github/dependabot.yml` — weekly pip, github-actions, and docker updates, with major-version bumps ignored to respect Hydra's pin discipline.
- `.github/ISSUE_TEMPLATE/bug.yml` and `feature.yml` — subsystem dropdowns, severity scale, Jetson/ArduPilot environment fields.

LICENSE (AGPL-3) and existing `.github/pull_request_template.md` (adversarial-review hooks) are unchanged.

## Test plan
- [ ] CI passes
- [ ] Visit Issues tab and confirm bug + feature templates render with dropdowns
- [ ] Confirm Dependabot opens its first PRs on next Monday

## Risk
None — no code, no config that affects runtime. Only repo metadata files.