### PR TITLE
fix(adversarial): close blockers + R3-2/R3-8 gates from #183 + #184 reports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,13 +18,22 @@ WORKDIR /app
 # Strategy: install ultralytics and supervision with --no-deps (they both
 # pull opencv-python transitively), then install everything else normally
 # with numpy pinned to <2.
-COPY requirements.txt .
+COPY requirements.txt requirements-extra.txt ./
 RUN pip3 install --no-cache-dir --no-deps ultralytics supervision && \
     grep -v "opencv-python\|ultralytics\|supervision" requirements.txt | \
     sed 's/numpy>=1.24,<3.0/numpy>=1.24,<2.0/' > /tmp/reqs-filtered.txt && \
     pip3 install --no-cache-dir -r /tmp/reqs-filtered.txt && \
     pip3 install --no-cache-dir scipy polars ultralytics-thop defusedxml pyDeprecate matplotlib tqdm && \
     rm /tmp/reqs-filtered.txt
+
+# Optional dependencies — installed unconditionally because the runtime
+# imports them lazily (boxmot is only imported inside ReIDTracker.init(),
+# guarded by [tracker] reid_enabled). Cost on units that leave the flag
+# off is disk space only; runtime cost is zero. Closes adversarial finding
+# R3-1 from PR #184: requirements-extra.txt was previously installed by
+# no deploy or CI path, making the reid_enabled=true feature flag
+# permanently unreachable in any deployed image.
+RUN pip3 install --no-cache-dir -r requirements-extra.txt
 
 # GStreamer RTSP server + RTL-SDR debug tools. Kismet runs on the host;
 # rtl_test / rtl_fm / rtl_power let you debug the dongle from inside the

--- a/docs/adversarial/198.md
+++ b/docs/adversarial/198.md
@@ -1,0 +1,86 @@
+# Adversarial Analysis — PR #198 (fix/adversarial-blockers-183-184)
+
+**Generated:** 2026-05-08T03:45:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/198
+**PR head:** 3aea08c19bb13b7077f2514fa7adc61930044266
+**Base:** main at 76bc81f9
+**Diff size:** +169 / -15 across 4 files (Dockerfile, capability_status.py, pipeline/facade.py, tests/test_capability_status.py)
+
+## Summary
+
+- **Round 1:** 5 findings (0 high · 3 medium · 2 low). Pattern-match focused on thread-safety of cross-thread singleton reset, evaluator-order dependence, fail-safe wording for non-flight platforms, and test-coverage of the load-bearing reset semantics.
+- **Round 2:** 3 second-order findings; **challenged R1-1 (downgraded to low)** after re-reading the tracker — the reset is a single attribute mutation under the GIL, not the multi-field race assumed in R1. Confirmed R1-2/R1-3/R1-5; sharpened R1-4.
+- **Round 3:** 5 findings, framing identified — *both prior rounds audited the new branch logic in isolation but did not ask what the operator does next, did not check whether the new reason text covers the common non-thermal causes of sub-5-FPS in field, and did not cross-check the reset against downstream alert state already pushed to GCS / TAK.*
+- **Consolidated:** 0 blockers · 2 gates · 6 follow-ups · 1 dropped (R1-1).
+
+## Round 1 — Pattern Match
+
+5 findings. Dominant pattern: a public reset surface is added to a module-level singleton consumed by a hot thread, and the new reason-text branches are evaluated in a context (Performance evaluator) that depends on data populated by another evaluator (Thermal). The fix is small and well-scoped; failure modes are operational, not algorithmic.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | thread-safety | capability_status.py:319 + facade.py:2360,2839 | `_reset_fps_tracker()` called from web/control thread while pipeline hot loop calls `record_fps()` — multi-field reset under contention could leave inconsistent intermediate state for one tick. |
+| R1-2 | medium | operator-text | capability_status.py:600 | "Increase airflow, shade the unit, or land" reads as drone-only advice; SORCC fleet includes Stampede UGV and Bonzai USV where "land" is not the right verb. |
+| R1-3 | low | magic-constant | capability_status.py:251-256 | `_PERF_THERMAL_HINT_C = 5.0` is engineering judgment ("typical Jetson Orin thermal mass") with no telemetry-based calibration on the four SORCC platforms (5"/10" quad, T1 Ranger, Stampede, Bonzai). |
+| R1-4 | medium | test-coverage | tests/test_capability_status.py | The single new branch-coverage test verifies reset clears state, but the load-bearing claims — "29 s of low FPS, then reset, then 1 s of low FPS does NOT trigger WARN" and "31 s without reset DOES trigger WARN at exactly t+31 s" — are not asserted explicitly. |
+| R1-5 | low | doc-drift | capability_status.py:572-579 | Performance docstring claims temp data is "already on SystemState from the Thermal evaluator" — assumes evaluator order; if the report builder ever reorders evaluators or runs Performance with stale state, the assumption breaks silently. |
+
+## Round 2 — Counter-Critique
+
+**Challenged:** R1-1 — re-read the tracker. `_fps_tracker.reset()` is a small operation (clears `_below_since` and a counter); on CPython the GIL serializes individual attribute writes. Worst observable race is one stale sample arriving immediately after reset and being treated as the new floor of the window — that shifts WARN re-arm by at most one sample interval (~200 ms on a 5 Hz pipeline), not the multi-second gap R1 implied. **Downgrade to low; not a gate.**
+
+**Confirmed:** R1-2, R1-3, R1-4, R1-5 with sharper evidence. R1-4 is the most load-bearing — the test added in this PR verifies `record_fps(...) → reset → sustained_fps_below_sec() == 0.0`, which is a state-clear check, not a window-arithmetic check. The arithmetic is what regressed in PR #183.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | operator-adversarial | facade.py:2839 | A SORCC operator who sees a Performance WARN and clicks /api/restart now gets a 30 s clean window. Repeated restarts every 25 s indefinitely mask a real thermal throttle — restart becomes a WARN-suppression vector. |
+| R2-2 | low | observability | facade.py:2360,2839 | `_reset_fps_tracker()` is called silently — no event_logger entry, no STATUSTEXT, no audit_log row. Post-incident replay cannot distinguish "WARN cleared because heat dropped" from "WARN cleared because reset fired." |
+| R2-3 | nit | api-naming | capability_status.py:319-336 | `reset_fps_tracker_for_test()` is now a backwards-compat alias for the production `reset_fps_tracker()`. Either delete the alias and rename test call sites, or comment its lifetime — open-ended `_for_test` aliases tend to outlive their stated purpose. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited the new branch logic and the reset surface in isolation — "is the reset thread-safe, is the reason text accurate, are the temps populated." Neither round asked (a) what the operator actually does next when they see the new reason text, (b) whether the new "thermal vs. config under-provisioning" dichotomy covers the common non-thermal causes of sub-5-FPS in field, or (c) whether the reset interacts with alert state already pushed to MAVLink GCS, TAK, and the event timeline before the reset fired.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **high** | **missing-cause** | capability_status.py:582-617 | The new reason text branches on three states (thermal hot / thermal cool / thermal unknown) but covers neither of the two most common field causes of sub-5-FPS on a Jetson Orin Nano: USB camera stall and RTSP/GStreamer pipeline freeze. Both produce ~0 FPS with normal SoC temp, and the new text actively misdirects: *"SoC at 56 C is below the thermal hint threshold — thermal cause unlikely. Active profile may be heavier than the platform supports: check model size, input resolution, and active capability set."* The operator changes profile while the camera cable is unplugged. **Gate:** branch must explicitly cover camera/stream-stall first; profile-blame should be the last fallback, not the second branch. |
+| R3-2 | medium | alert-replay | facade.py:2360,2839 + tak/mavlink_relay + osd | The Performance WARN may have already been emitted to MAVLink STATUSTEXT, the TAK CoT status feed, and the FPV OSD before the reset fires. Reset clears the local report but the GCS log shows a WARN with no clear, the TAK marker keeps the WARN status until the next tick re-evaluates, and the OSD blinks back to READY without context. Two views of system state — local-clean vs. logged-WARN — diverge across the operator's tools. |
+| R3-3 | high | operator-adversarial | facade.py:2360 (model-swap reset) + facade.py:2839 (restart reset) | The model-swap reset compounds R2-1: SORCC operator sees Performance WARN, switches yolov8m → yolov8n thinking "lighter model fixes it," the swap resets the tracker, and the operator gets confirmation-bias evidence that the lighter model worked even when the FPS floor was thermal-bound and unchanged. After 30 s the WARN re-arms but the operator has already accepted the lighter model and moved on. Gate-worthy because it inverts the post-incident causal trail. |
+| R3-4 | medium | no-sim | tests/test_capability_status.py | No explicit window-arithmetic coverage for the load-bearing claim: at sample times t=0..29 s with FPS=4.0, then `reset_fps_tracker()`, then sample t=30 s with FPS=4.0 — the report at t=30 s must be READY, not WARN. Also missing: rapid-restart loop test (R2-1's suppression vector should be detectable in CI by asserting the event_logger row count grows with each reset, once R2-2 is closed). |
+| R3-5 | low | doc-drift | capability_status.py:572-579 vs. _SOC_TEMP_WARN_C | The new code introduces a second thermal classification (`_PERF_THERMAL_HINT_C` 5 C below `_SOC_TEMP_WARN_C`) that is invisible to the existing Thermal evaluator. Two tiers of thermal severity now exist with no operator-facing terminology — the dashboard says "Performance WARN: thermal cause" using a threshold the Thermal evaluator does not also report on. |
+
+### Consistency-bias callouts
+
+- **R1-1 + R2 both rated thread-safety medium** — R3 confirms the downgrade because the actual operator-experienced cost of a 200 ms window shift is invisible against the 30 s evaluator cadence. The earlier rounds let "two threads touch a singleton" pattern-match drive severity instead of computing the operator-visible delta.
+- **R1+R2 ranked R1-2 (drone-only language) above R3-1 (missing camera/RTSP cause)** because the wording nit was more pattern-visible than the structural gap. R3-1 is the higher-severity finding by far — the "land" wording is annoying, the misdirected reason text walks an operator past a dead camera into a profile change.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| **high** | missing-cause | R3-1 | Performance reason text does not cover camera/RTSP stall — the most common real field cause of sub-5-FPS — and the cool-SoC branch actively misdirects the operator toward profile changes. Add a "stream freshness" branch (last-frame-age > N s → "Camera or RTSP stalled — check camera and source") evaluated *before* the thermal/profile dichotomy. | R3-1 | **gate before merge** |
+| **high** | operator-adversarial | R2-1 + R3-3 | Repeated restart and lighter-model swap both reset the 30 s sustained-below window and become WARN-suppression vectors; second one provides confirmation-bias evidence that the swap "worked." Cap reset rate (e.g. one reset per 60 s of wall clock) or surface "Tracker recently reset N s ago" alongside the next READY/WARN report so the operator sees the suppression. | R2-1, R3-3 | **gate before merge** |
+| medium | observability | R2-2 | Reset is silent — no event_logger row, no STATUSTEXT, no audit_log entry. Post-incident review cannot distinguish "WARN cleared because root cause resolved" from "WARN cleared because reset fired." Emit one event_logger row per reset call site with the cause (model_swap | restart). | R2-2 | follow-up issue |
+| medium | alert-replay | R3-2 | Reset clears the local report but pre-reset MAVLink/TAK/OSD emissions are still authoritative on those channels until the next evaluator tick. Either (a) suppress reset-induced READY transitions on outbound channels for the first cycle, or (b) explicitly emit a "Performance reset" status to all channels at reset time. | R3-2 | follow-up issue |
+| medium | operator-text | R1-2 | "Increase airflow, shade the unit, or land" is drone-only. Replace with platform-conditional advice keyed off `[vehicle.*]` section ("land," "return to surface," "stop and shade," "park") or use a platform-agnostic phrasing ("reduce thermal load — increase airflow / shade the platform / stop motion"). | R1-2 | follow-up issue |
+| medium | test-coverage | R1-4 + R3-4 | The window-arithmetic claim that load-bears this PR (29 s low + reset + 1 s low ≠ WARN; 31 s low without reset → WARN at t+31) is not asserted in tests. Add two parameterized tests; close the suppression-vector via an audit-trail assertion when R2-2 is fixed. | R1-4, R3-4 | follow-up issue |
+| low | thread-safety | R1-1 | Reset is technically two-field; under contention with `record_fps()` the worst observable shift is one sample interval. Document the assumption in the docstring or wrap reset+record under a `threading.Lock` for explicitness; not a gate. | R1-1 (downgraded) | follow-up issue |
+| low | magic-constant | R1-3 | `_PERF_THERMAL_HINT_C = 5.0` is engineering judgment without per-platform calibration. After first SORCC field cycle, calibrate from telemetry on each of the four platforms and adjust per `[vehicle.*]` section if needed. | R1-3 | follow-up issue |
+| low | doc-drift | R1-5 + R3-5 | Performance docstring assumes evaluator order, and the new 5 C thermal-hint tier is invisible to the Thermal evaluator. Either lift `_PERF_THERMAL_HINT_C` into a shared constant referenced by both evaluators, or add a one-line comment in `_eval_thermal` cross-referencing the hint tier. | R1-5, R3-5 | follow-up issue |
+| nit | api-naming | R2-3 | `reset_fps_tracker_for_test()` alias should either be removed (rename test call sites) or annotated with a removal date. | R2-3 | nit |
+
+## Recommendation
+
+**Two gates** before merge:
+
+1. **R3-1** — Add an explicit camera/stream-stall branch to `_eval_performance` ahead of the thermal/profile dichotomy. The current text walks an operator past a dead camera; this is the highest-severity finding in the report and is local to the file this PR already touches.
+2. **R2-1 + R3-3** — Either rate-limit `_reset_fps_tracker()` calls or surface "tracker reset N s ago" on the next report so the operator sees the suppression. The model-swap branch makes the suppression invisible-by-default in exactly the situation the operator is most likely to game it.
+
+The four medium follow-ups (R2-2 observability, R3-2 alert-replay, R1-2 operator-text, R1-4/R3-4 test-coverage) are not gates — file as separate issues against this PR's merge commit.
+
+The PR's core fixes (R3-2/R3-4/R3-8 from #183) are sound; the new findings are scoped to the new reason-text branch and the new reset surface, not to the original three blockers this PR closes.

--- a/hydra_detect/capability_status.py
+++ b/hydra_detect/capability_status.py
@@ -316,9 +316,26 @@ def sustained_fps_below_sec(now_s: float | None = None) -> float:
     )
 
 
-def reset_fps_tracker_for_test() -> None:
-    """Test-only — zero the FPS tracker between tests."""
+def reset_fps_tracker() -> None:
+    """Public API: zero the sustained-below window.
+
+    Production callers: model-swap and pipeline-restart paths in
+    ``hydra_detect/pipeline/facade.py``. A model swap drops the pipeline
+    FPS for the duration of the new model load (typically 5-15 s on
+    Jetson Orin Nano); without this reset the dip accumulates into the
+    sustained-below window and produces a 30 s false WARN labelled as
+    thermal throttling on the readiness page. Same reasoning for in-
+    process pipeline restart via ``/api/restart`` — operators who restart
+    *because* of a WARN must see the WARN clear rather than persist.
+
+    Closes adversarial findings R3-2 + R3-8 from PR #183.
+    """
     _fps_tracker.reset()
+
+
+def reset_fps_tracker_for_test() -> None:
+    """Test-only alias — kept for backwards compat with existing tests."""
+    reset_fps_tracker()
 
 
 # ── Evaluators ────────────────────────────────────────────────────────────────

--- a/hydra_detect/capability_status.py
+++ b/hydra_detect/capability_status.py
@@ -249,6 +249,12 @@ _SOC_TEMP_BLOCK_C = 90.0
 # so a single transient dip does not flap the operator status.
 _FPS_WARN_THRESHOLD = 5.0
 _FPS_WARN_WINDOW_SEC = 30.0
+# Performance evaluator thermal-hint threshold. When the hottest reachable
+# SoC temp is within this many degrees of the thermal WARN threshold, the
+# Performance WARN reason text points at thermal causes; otherwise it points
+# at config under-provisioning. 5 °C below WARN gives the FPS-drop signal
+# room to lead the thermal signal under typical Jetson Orin thermal mass.
+_PERF_THERMAL_HINT_C = 5.0
 
 
 # ── Sustained-FPS tracker singleton ──────────────────────────────────────────
@@ -546,20 +552,58 @@ def _eval_performance(state: SystemState) -> CapabilityReport:
     """WARN when pipeline FPS has been below the Jetson minimum for >= 30 s.
 
     A single transient dip is ignored — the tracker only counts continuous
-    below-threshold time. Reasons text steers the operator toward the most
-    common cause (thermal throttling) without claiming certainty.
+    below-threshold time. Reason text branches on observed SoC temperature:
+    when CPU or GPU is within ``_PERF_THERMAL_HINT_C`` of the thermal WARN
+    threshold (data already on SystemState from the Thermal evaluator), the
+    operator is pointed at thermal causes; otherwise the operator is pointed
+    at config under-provisioning (heavy model, telephoto USV, wide-class
+    surveillance — all legitimate sub-target FPS configurations).
+
+    Closes adversarial finding R3-4 from PR #183: the prior unconditional
+    "Likely thermal throttling or detector overload" reason text actively
+    misdirected operators on three legitimate config combinations.
     """
     sustained = state.fps_below_target_sustained_sec
-    if sustained >= _FPS_WARN_WINDOW_SEC:
-        reasons = [
-            f"Pipeline FPS below {_FPS_WARN_THRESHOLD:.0f} for "
-            f"{sustained:.0f}s (window {_FPS_WARN_WINDOW_SEC:.0f}s). "
-            "Likely thermal throttling or detector overload — check SoC "
-            "temperature and active model count."
-        ]
-        return CapabilityReport("Performance", CapabilityStatus.WARN, reasons)
+    if sustained < _FPS_WARN_WINDOW_SEC:
+        return CapabilityReport("Performance", CapabilityStatus.READY)
 
-    return CapabilityReport("Performance", CapabilityStatus.READY)
+    base_msg = (
+        f"Pipeline FPS below {_FPS_WARN_THRESHOLD:.0f} for "
+        f"{sustained:.0f}s (window {_FPS_WARN_WINDOW_SEC:.0f}s)."
+    )
+
+    cpu = state.cpu_temp_c
+    gpu = state.gpu_temp_c
+    available_temps = [t for t in (cpu, gpu) if t is not None]
+    hottest = max(available_temps) if available_temps else None
+    thermal_hint_threshold = _SOC_TEMP_WARN_C - _PERF_THERMAL_HINT_C
+
+    if hottest is not None and hottest >= thermal_hint_threshold:
+        cause = (
+            f" SoC at {hottest:.1f}C is within {_PERF_THERMAL_HINT_C:.0f}C "
+            f"of the thermal WARN threshold ({_SOC_TEMP_WARN_C:.0f}C) — "
+            "likely thermal throttling. Increase airflow, shade the unit, "
+            "or land."
+        )
+    elif hottest is not None:
+        cause = (
+            f" SoC at {hottest:.1f}C is below the thermal hint threshold — "
+            "thermal cause unlikely. Active profile may be heavier than "
+            "the platform supports: check model size, input resolution, "
+            "and active capability set."
+        )
+    else:
+        cause = (
+            " SoC temperature unavailable — cannot rule out thermal "
+            "cause. Check active profile (model size, input resolution, "
+            "active capability set) and SoC temps if reachable."
+        )
+
+    return CapabilityReport(
+        "Performance",
+        CapabilityStatus.WARN,
+        [base_msg + cause],
+    )
 
 
 def _eval_autonomy_live(state: SystemState) -> CapabilityReport:

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -43,7 +43,10 @@ from ..system import (
     refresh_nvpmodel_async as _refresh_nvpmodel_async,
     set_power_mode as _set_power_mode,
 )
-from ..capability_status import record_fps as _record_fps
+from ..capability_status import (
+    record_fps as _record_fps,
+    reset_fps_tracker as _reset_fps_tracker,
+)
 from ..rtsp_server import RTSPServer
 from ..mavlink_video import MAVLinkVideoSender
 from ..tak.mavlink_relay import MAVLinkRelayOutput
@@ -2357,6 +2360,12 @@ class Pipeline:
                         logger.info("Model hash updated (%s): %s", candidate.name, new_hash[:16])
                     except Exception as exc:
                         logger.warning("Could not update model hash: %s", exc)
+                    # Clear the sustained-FPS-below window: a successful
+                    # model swap pauses the detector for 5-15 s during the
+                    # new model load and that legitimate pause must not
+                    # accumulate into the Performance evaluator's WARN
+                    # window (closes adversarial finding R3-2 from PR #183).
+                    _reset_fps_tracker()
                 return success
         logger.error("Model not found: %s", model_name)
         return False
@@ -2830,6 +2839,13 @@ class Pipeline:
     def _handle_restart_command(self) -> None:
         """Request a pipeline restart. Sets a flag; the main loop handles the actual restart."""
         logger.info("Restart command received from web UI.")
+        # Clear the sustained-FPS-below window before the restart so an
+        # operator who restarts *because* of a Performance WARN sees the
+        # WARN clear rather than persist past the restart. The pipeline
+        # hot loop is the sole producer of FPS samples; module-level
+        # singleton state must be reset out-of-band (closes adversarial
+        # finding R3-8 from PR #183).
+        _reset_fps_tracker()
         self._restart_requested = True
         self._running = False
 

--- a/tests/test_capability_status.py
+++ b/tests/test_capability_status.py
@@ -519,6 +519,31 @@ class TestSustainedFpsTracker:
         record_fps(None, now_s=10.0)  # pipeline transient
         assert sustained_fps_below_sec(now_s=15.0) == pytest.approx(15.0, abs=0.01)
 
+    def test_public_reset_clears_sustained_window(self):
+        """Closes adversarial findings R3-2 + R3-8 from PR #183.
+
+        Production callers (model swap, restart-command handler) call
+        ``reset_fps_tracker()`` to clear the window so a legitimate
+        detector pause (model load, pipeline restart) does not accumulate
+        into a 30 s false WARN labelled as thermal throttling.
+        """
+        from hydra_detect.capability_status import (
+            record_fps, sustained_fps_below_sec, reset_fps_tracker,
+        )
+        # Drive the tracker into a deep below-threshold state.
+        record_fps(2.0, now_s=0.0)
+        record_fps(2.0, now_s=45.0)
+        assert sustained_fps_below_sec(now_s=45.0) == pytest.approx(45.0, abs=0.01)
+
+        # Production reset (e.g. _handle_model_switch success path).
+        reset_fps_tracker()
+        assert sustained_fps_below_sec(now_s=46.0) == 0.0
+
+        # Subsequent samples re-arm the window from the new now_s anchor —
+        # no leakage of pre-reset state.
+        record_fps(2.0, now_s=50.0)
+        assert sustained_fps_below_sec(now_s=55.0) == pytest.approx(5.0, abs=0.01)
+
     def test_build_system_state_does_not_advance_tracker(self):
         """Regression test for PR #183 Codex review: build_system_state must
         be a pure reader of the FPS tracker. Re-feeding stream_state's cached

--- a/tests/test_capability_status.py
+++ b/tests/test_capability_status.py
@@ -617,6 +617,64 @@ class TestPerformanceEvaluator:
         r = next(r for r in reports if r.name == "Performance")
         assert r.status == CapabilityStatus.WARN
 
+    # ── R3-4 branch-coverage: reason text branches on SoC temp ────────────
+    #
+    # Closes adversarial finding R3-4 from PR #183. The prior unconditional
+    # "Likely thermal throttling or detector overload" misdirected operators
+    # on three legitimate config combinations (heavy model + 8GB Jetson,
+    # marine telephoto USV, low-confidence wide-class surveillance). The
+    # fix branches on whether observed SoC temp is within
+    # _PERF_THERMAL_HINT_C of the thermal WARN threshold.
+
+    def test_warn_text_cites_thermal_when_soc_hot(self):
+        # CPU at 71 C is within 5 C of the 75 C thermal WARN threshold.
+        state = _make_state(
+            fps_below_target_sustained_sec=45.0,
+            cpu_temp_c=71.0,
+            gpu_temp_c=68.0,
+        )
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Performance")
+        assert r.status == CapabilityStatus.WARN
+        text = " ".join(r.reasons).lower()
+        assert "thermal throttling" in text
+        assert "config under-provisioning" not in text
+        assert "active profile may be heavier" not in text
+
+    def test_warn_text_cites_config_when_soc_benign(self):
+        # CPU at 55 C and GPU at 50 C are both well below the thermal hint
+        # threshold (75 - 5 == 70 C). Reason text must point operator at
+        # config, not thermal.
+        state = _make_state(
+            fps_below_target_sustained_sec=45.0,
+            cpu_temp_c=55.0,
+            gpu_temp_c=50.0,
+        )
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Performance")
+        assert r.status == CapabilityStatus.WARN
+        text = " ".join(r.reasons).lower()
+        assert "thermal cause unlikely" in text
+        assert "active profile may be heavier" in text
+        # The operator should NOT be told to land/shade when SoC is benign.
+        assert "land" not in text
+        assert "shade" not in text
+
+    def test_warn_text_handles_missing_temps(self):
+        # Dev box / SITL host with no thermal sensors. Cannot rule out
+        # thermal cause, but cannot point at it confidently either.
+        state = _make_state(
+            fps_below_target_sustained_sec=45.0,
+            cpu_temp_c=None,
+            gpu_temp_c=None,
+        )
+        reports = evaluate_all(state)
+        r = next(r for r in reports if r.name == "Performance")
+        assert r.status == CapabilityStatus.WARN
+        text = " ".join(r.reasons).lower()
+        assert "soc temperature unavailable" in text
+        assert "active profile" in text
+
 
 # ---------------------------------------------------------------------------
 # Placeholder capabilities — Autonomy Live, Drop, RF Hunt


### PR DESCRIPTION
Post-merge follow-up to PRs #183 and #184. Both adversarial reports (`docs/adversarial/183.md`, `docs/adversarial/184.md`) flagged blockers rated *must fix before merge*; both PRs were merged anyway, so these fixes land as a separate branch.

## What's fixed

### Blockers

**R3-4 (#183) — Performance evaluator misdirects operator**

The WARN reason text unconditionally said *"Likely thermal throttling or detector overload"* on three legitimate config combinations (heavy model + 8GB Jetson, marine telephoto USV, low-confidence wide-class surveillance). SORCC students would reach for a fan when the actual cause is config under-provisioning.

Fix: branch the reason text on observed SoC temp using data already on `SystemState` from #182's Thermal evaluator. Within `_PERF_THERMAL_HINT_C` (5 °C) of the thermal WARN threshold (75 °C) cites thermal cause; below cites config under-provisioning; missing temps acknowledge the uncertainty. Three new branch-coverage tests.

**R3-1 (#184) — re-ID feature flag was unreachable**

`requirements-extra.txt` was referenced by no Dockerfile, no CI workflow, and no deploy script. Setting `[tracker] reid_enabled` to true was permanently unreachable in any deployed image.

Fix: unconditional install in the Dockerfile. Cost on units that leave the flag off is disk space only because the boxmot import is lazy inside `ReIDTracker.init()` (no runtime cost when the flag is off). CI install left untouched since tests stub boxmot via `sys.modules`.

### Gates (high + medium severity)

**R3-2 (#183) — model swap creates 30 s false WARN**

A successful YOLO model swap inside `_handle_model_switch` pauses the detector for 5-15 s during the new model load. That legitimate pause was accumulating into the Performance evaluator's 30 s sustained-below window, producing a false WARN labelled "thermal throttling" 30 s after every profile change.

Fix: wire `reset_fps_tracker()` into the success path of `_handle_model_switch` so the window restarts from zero on a confirmed swap.

**R3-8 (#183) — restart did not clear WARN**

`/api/restart` reinstantiated `fps_counter` inside the pipeline but the module-level `_fps_tracker` singleton retained its pre-restart `_below_since` value. An operator who restarts *because* of a Performance WARN saw the WARN persist past the restart.

Fix: wire `reset_fps_tracker()` into `_handle_restart_command` so the operator-visible counter clears with the restart they triggered.

## Public API change

Promotes `reset_fps_tracker_for_test` to a public `reset_fps_tracker` helper. The test alias is preserved for backwards compat with the existing test suite.

## What's NOT fixed (deliberate scope cap)

- **#184 R3-2** (tracker swap invalidates downstream Approach lock / TAK CoT UIDs / detection_logger / geo_tracking) — needs design discussion on operator-side contract or page-level redesign.
- **#184 R3-9** (frozen-camera reinforces stale IDs via `frame is None` check only) — couples to calibration target #7 (frozen-frame watchdog); waiting on that target.
- **#184 R3-3** (zero perception-layer test for ID stability under occlusion / target crossings) — needs sim/replay infrastructure.
- **#183 R3-1** (physics-derived 5 FPS floor with zero hardware-in-the-loop) — needs hardware time.
- **#184 R1-1 + R2-1** (bare init paths crash uncaught without STATUSTEXT or servo-safe) — bounded but not in this PR's scope; file as separate issue.
- **#184 R1-2** (OSNet weights gdown'd from Google Drive on first use) — pre-cache in image is risky at build time without network reach; document as follow-up.

## Test plan

- [x] `tests/test_capability_status.py` — 71 passed, 8 skipped (Linux-only `fcntl` skip pattern)
- [x] Combined `test_capability_status` + `test_tracker` + `test_config_migrate` — 105 passed, 8 skipped
- [x] `flake8` clean on `hydra_detect/capability_status.py`, `hydra_detect/pipeline/facade.py`, `tests/test_capability_status.py`
- [ ] CI green
- [ ] `/adversarial` report committed to `docs/adversarial/<this-pr>.md` (since this PR also touches `pipeline/facade.py` which is on the ADVERSARIAL_PATHS list)

Do NOT auto-merge — the adversarial report on this PR may surface findings that the fix introduces. Kyle reviews and merges.