### PR TITLE
feat(ui): field-image hygiene — gate morale features, rename DEMO VIZ, audit no-auth endpoints (#150)

### DIFF
--- a/docs/adversarial/210.md
+++ b/docs/adversarial/210.md
@@ -1,0 +1,85 @@
+# Adversarial Analysis — PR #210 (claude/issue-150-field-hygiene)
+
+**Generated:** 2026-05-08T05:30:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/210
+**PR head:** 98cb9ac6b811f708b8c0bcc56e9d88cc3c822613
+**Base:** main at 76bc81f9
+**Diff size:** +300 / -8 across 6 files (web/server.py, base.css, command-palette.js, base.html, ops.html, tests/test_field_image_hygiene.py)
+
+## Summary
+
+- **Round 1:** 5 findings (0 high · 3 medium · 2 low). Pattern-match focused on the three different gating mechanisms this PR introduces (server-side template conditional, client-side feature detection, runtime morale flag), the loopback host classification heuristic, and the docstring/code disagreement on the unknown-client failure mode.
+- **Round 2:** 3 second-order findings; **challenged R1-5 (downgraded to nit)** — non-persistent banner dismiss is the correct contract for a security-state notice, not a UX defect. Confirmed R1-1/R1-2/R1-3 with sharper evidence; the docstring-vs-code mismatch in `_is_remote_client` is the most actionable.
+- **Round 3:** 4 findings, framing identified — *both prior rounds audited each gate (banner, Konami palette entry, beep button) in isolation. Neither asked what happens when the three gating mechanisms disagree, what the build/flash pipeline assumption looks like, or whether "remote vs loopback" is the right abstraction for "abort-reachable-without-auth."*
+- **Consolidated:** 0 blockers · 2 gates · 5 follow-ups · 1 dropped (R1-5).
+
+## Round 1 — Pattern Match
+
+5 findings. Dominant pattern: three separate gating surfaces (`_is_remote_client` → server template, `window.HydraEaster.attached` → JS palette, `_morale_features_enabled` → server template + endpoint) all encode the same property ("is this a field image"). Each surface has a different bug profile.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | host-classification | server.py:308-311 (`_is_remote_client`) | `_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}` only covers loopback. The SORCC fleet sits behind an Nginx/Tailscale/proxy in some deployments — `request.client.host` is then the proxy's IP (often 127.0.0.1) and the banner suppresses for genuinely remote viewers. Inverse: SSH-tunnel from operator's laptop to Jetson localhost shows up as 127.0.0.1 server-side, banner correctly absent — but the operator IS effectively remote. The class boundary "loopback host" does not equal the safety-relevant boundary "abort reachable without operator presence." |
+| R1-2 | medium | docstring-code-mismatch | server.py:301-310 | Docstring says "fail-loud rather than fail-quiet" but `if not host: return False` is fail-quiet (banner suppressed when client info is missing). TestClient with no scope, ASGI lifespan calls, and any Request constructed without `request.client` all return False → banner not shown. A reviewer trusting the docstring will be misled about behavior. Either flip the default to True (truly fail-loud) or correct the docstring. |
+| R1-3 | medium | gate-by-absence | command-palette.js:60-67 | Konami entry gating depends on `window.HydraEaster && window.HydraEaster.attached`. This is gating-by-absence: the palette assumes easter.js is not loaded on field images. There is no explicit `morale_features_enabled` check in the JS itself. If the build/CI pipeline ever ships easter.js by mistake (cache poisoning, stale CDN, dev image deployed by accident), the gate evaporates silently. A defensive check `window.HydraConfig?.moraleEnabled` alongside the feature-detection would be belt-and-suspenders. |
+| R1-4 | low | css-orphan | base.css:491-538 | Banner CSS is unconditional (`.remote-abort-banner` always available in the stylesheet). Banner DOM only renders when `remote_abort_reachable=True`. If a future PR ever renders the banner DOM for some other reason (mock harness, dev tool, shared component), it would inherit the styling unintentionally. Low risk, fix is a narrower selector or a `:has()`-based parent guard. |
+| R1-5 | low | banner-dismiss-not-persisted | base.html:296-307 | Inline JS dismisses via `style.display = 'none'`. No localStorage. Refresh re-shows the banner. Operator viewing from phone over Tailscale sees the banner every page reload. Annoyance vector. |
+
+## Round 2 — Counter-Critique
+
+**Challenged R1-5:** Re-read the PR scope. The banner is a *security-state notice* — its presence is the contract, not the dismissibility. Persisting dismissal across reloads would defeat the purpose: once the operator dismisses on day one, they'd never see the reminder again on day 30 even if the network exposure changed. **Downgrade to nit. Re-arming on every load is intentional.**
+
+**Confirmed R1-1, R1-2, R1-3 with sharper evidence.** R1-2 is the highest-leverage near-term fix because the implementation contradicts its own documentation in 6 lines.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | gate-disagreement | server.py + command-palette.js + base.html | The three gates (banner-via-`_is_remote_client`, Konami-via-`window.HydraEaster`, beep-via-`_morale_features_enabled`) can disagree on the same page load: morale_enabled=True (dev image) + viewing from non-loopback (TestClient with mocked client) → banner ON + Konami ON + beep ON. Versus a field image flashed correctly: banner ON + Konami OFF + beep OFF. Versus a *broken* field image where easter.js leaked through but morale flag is False: banner ON + **Konami ON** + beep OFF. The Konami-leak scenario is the silent failure mode worth a regression test. |
+| R2-2 | medium | curious-student-adversarial | config.ini.factory + endpoints | A student with shell access edits `config.ini` to set `[ui] morale_features_enabled = true`, restarts the service, and now has a Konami easter egg, working `/api/vehicle/beep`, and any other morale gates flipped on. Is that a real concern, or is morale_features_enabled deliberately flippable for self-service debug? The PR doesn't say. If it's deliberately flippable, R1-3's gate-by-absence becomes more concerning: morale=true alone doesn't restore Konami if easter.js was stripped at flash time. |
+| R2-3 | low | banner-text-staleness | base.html:121-129 | Banner says "Any device on the network can trigger RTL." But `/api/abort` may also trigger LOITER, MANUAL, etc. depending on platform — see `mavlink_io.send_abort()` semantics. The text picks one outcome (RTL) for plain-language brevity, which is fine, but a deployed unit on a Stampede UGV that doesn't have RTL would be confusing in a banner that names it explicitly. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited each gate (banner, Konami, beep) in isolation — "is this gate correct, is the wording accurate, is the threshold right." Neither round asked (a) what the build/flash pipeline guarantees about the artifacts these gates depend on, (b) whether the field-image hygiene story is enforceable server-side or whether it leaks through the client-side cache, or (c) whether the banner's underlying signal — "remote vs loopback" — is even the right abstraction for the safety property the operator cares about.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **high** | **build-pipeline-assumption** | command-palette.js:60-67 + flash pipeline (out of repo) | The Konami gate relies on the build/flash process *omitting* `easter.js` from the field image. There is no test, no Makefile rule, and no CI step in this PR (or anywhere I can see) that verifies the field-image build actually strips dev-only JS. The PR closes its acceptance bullets via runtime tests but the runtime tests never simulate the broken-flash failure mode. **Gate:** add an integration test that boots a field image (or a representative subset: morale_enabled=False) and asserts NO mention of "Konami" or "sentience" appears in any served JS bundle. |
+| R3-2 | medium | abstraction-mismatch | server.py:294-311 | The banner answers "is the client on a loopback IP" but the actual operator-relevant question is "could a non-operator on this network trigger /api/abort." Those questions diverge in three observable ways: (a) localhost SSH tunnel from operator's laptop classifies as loopback but is effectively remote for "anyone on operator's home Wi-Fi can also tunnel"; (b) reverse proxy passes 127.0.0.1, classifies as loopback, banner suppressed even when public-facing; (c) Tailscale Funnel exposes the dashboard publicly with the server seeing the funnel relay IP — banner shown, correct outcome but for accidental reasons. The right signal is configuration-driven, not header-derived: whether `[web] host = 0.0.0.0` and the unit's actual network reachability. |
+| R3-3 | medium | three-mechanisms-three-bug-classes | server.py + command-palette.js + ops.html | The PR hardens the field image via three mechanisms (server-side template conditional, client-side feature detection, server-side endpoint gating). Each has a different debugging story. A field operator filing a bug report ("I see Konami on my unit") will get an answer like "your easter.js leaked through" — but reproducing it requires checking flash artifacts, not just the running config. Consolidating into a single "field-image mode" config flag that drives all three gates would reduce the support matrix from N×3 to N×1. The PR does the right thing tactically; the strategic ask is unification. |
+| R3-4 | low | banner-is-cosmetic-only | server.py + base.html | The banner adds visibility, not mitigation. Once dismissed (or simply unread), the security state — `/api/abort` reachable without auth from any peer — is unchanged. The PR does not propose adding auth to `/api/abort` (and shouldn't — that's a deliberate safety contract). But the banner's value depends entirely on the operator reading it. A SORCC student doing a 4-hour bench test will see it once and tune it out. Consider whether to also add a one-line entry in the dashboard's status footer or settings tab so the state is queryable without staring at a yellow stripe. |
+
+### Consistency-bias callouts
+
+- **R1+R2 ranked R1-3 (gate-by-absence on Konami) above R3-1 (no build-pipeline test)** because the gate-by-absence is a code finding visible in the diff. R3-1 is the higher-severity finding — the entire field-image hygiene story rests on a build-pipeline guarantee with no enforcement.
+- **R1-1 (loopback heuristic) was sized as medium** because it's an obvious code smell. R3-2 demotes it slightly: the loopback heuristic is *the wrong abstraction*, not just an incomplete one. The fix is configuration-aware, not enumeration-aware.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended action |
+|---|---|---|---|---|---|
+| **high** | build-pipeline | R3-1 | Konami / sentience / morale gates depend on the build/flash pipeline stripping dev-only JS; no test verifies this. A CI integration test should boot a representative field-image config and assert no morale-only strings appear in served JS. | R3-1 | **gate before merge** (add test) |
+| **medium** | docstring-code | R1-2 | `_is_remote_client` docstring claims fail-loud, code is fail-quiet. Either flip the default to True or correct the docstring. | R1-2 | **gate before merge** (6-line fix) |
+| medium | host-classification | R1-1 + R3-2 | Loopback-host enumeration is the wrong abstraction for "abort reachable without operator presence." Either add proxy-aware logic (X-Forwarded-For with trusted-proxy list) or pivot to a config-driven signal (`[web] host` and reachable-network detection). | R1-1, R3-2 | follow-up issue |
+| medium | gate-by-absence | R1-3 + R2-1 | Konami palette gate relies on `window.HydraEaster.attached`. Add an explicit `morale_features_enabled` JS check alongside the feature detection. | R1-3, R2-1 | follow-up issue |
+| medium | curious-student | R2-2 | If `morale_features_enabled` is deliberately flippable via config edit, R1-3 becomes a half-broken self-service debug path. Document whether the flag is ops-flippable or build-time only. | R2-2 | follow-up issue (clarify intent) |
+| medium | three-mechanisms | R3-3 | Three gating mechanisms means three failure modes. Consider consolidating to a single field-image flag in a follow-up. | R3-3 | follow-up issue |
+| low | banner-rtl-text | R2-3 | "trigger RTL" wording is platform-specific; UGV/USV may not have RTL. | R2-3 | follow-up issue |
+| low | banner-cosmetic | R3-4 | Banner adds visibility, not mitigation. Consider also surfacing reachable-state in dashboard status footer. | R3-4 | follow-up issue |
+| low | css-orphan | R1-4 | `.remote-abort-banner` styles are always present. Negligible. | R1-4 | nit |
+| nit | banner-dismiss-not-persisted | R1-5 (downgraded) | Re-arming on every load is intentional for a security-state notice. | R1-5 (dropped) | dropped |
+
+## Recommendation
+
+**Two gates before merge:**
+
+1. **R3-1** — Add a CI integration test (or a lint-style `make field-image-check`) that boots the server with `morale_features_enabled=False` and asserts no morale-only identifier appears in the served JS bundle. Without this, the field-image hygiene contract is unenforceable and the next refactor of static asset bundling can silently regress all three gates.
+2. **R1-2** — Either correct the `_is_remote_client` docstring or flip the missing-client default from False to True. Six-line fix; the disagreement is misleading enough that it will outlive the PR if not addressed.
+
+The five medium follow-ups (R1-1+R3-2 abstraction, R1-3+R2-1 gate-by-absence, R2-2 ops-flippability, R3-3 three-mechanisms, R3-4 visibility-vs-mitigation) are not gates — file as separate issues against #150's merge commit and triage in next sprint.
+
+The PR's core fixes (Konami palette gating, beep button gating from morale flag, remote-abort banner) are sound; the new findings are scoped to the gating mechanism choices and the build-pipeline assumption, not to the bullet-points the PR closes.

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -301,11 +301,16 @@ def _is_remote_client(request: Request) -> bool:
     Used to surface the "remote abort reachable" banner. Robust to a missing
     request.client (TestClient with no scope, ASGI lifespan calls). Treats
     unknown / missing client host as remote — fail-loud rather than fail-quiet.
+
+    PR #210 R1-2 from docs/adversarial/210.md: missing client info now returns
+    True. The banner is informational about a security state; showing it once
+    extra (e.g. on the synthetic / ASGI-lifespan path) is harmless, whereas
+    suppressing it when we genuinely can't classify the viewer was the bug.
     """
     client = getattr(request, "client", None)
     host = getattr(client, "host", None) if client else None
     if not host:
-        return False  # no client info → can't classify; don't false-alarm
+        return True  # no client info → fail-loud, surface the banner
     return host not in _LOOPBACK_HOSTS
 
 

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -288,6 +288,27 @@ def _check_auth(
     return None
 
 
+# Loopback hosts that should NOT trigger the "remote abort reachable" banner
+# on the dashboard. Anything else (LAN IP, Tailscale IP, public DNS) counts
+# as a remote viewer and the banner is shown to remind the operator that
+# /api/abort is intentionally unauthenticated. (issue #150)
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+
+
+def _is_remote_client(request: Request) -> bool:
+    """Return True when the dashboard is being viewed from a non-loopback host.
+
+    Used to surface the "remote abort reachable" banner. Robust to a missing
+    request.client (TestClient with no scope, ASGI lifespan calls). Treats
+    unknown / missing client host as remote — fail-loud rather than fail-quiet.
+    """
+    client = getattr(request, "client", None)
+    host = getattr(client, "host", None) if client else None
+    if not host:
+        return False  # no client info → can't classify; don't false-alarm
+    return host not in _LOOPBACK_HOSTS
+
+
 def _origin_matches_request(origin: str, request: Request) -> bool:
     """Return True when Origin exactly matches request scheme + host + port."""
     try:
@@ -848,10 +869,19 @@ async def auth_status(request: Request):
 
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
-    """Serve the operator dashboard SPA."""
+    """Serve the operator dashboard SPA.
+
+    Passes ``morale_features_enabled`` so dev-image easter eggs render only
+    on dev builds, and ``remote_abort_reachable`` so the dashboard surfaces
+    a banner reminding the operator that /api/abort is intentionally
+    unauthenticated whenever a non-loopback browser loads the page (#150).
+    """
     return templates.TemplateResponse(
         request, "base.html",
-        {"morale_features_enabled": _morale_features_enabled},
+        {
+            "morale_features_enabled": _morale_features_enabled,
+            "remote_abort_reachable": _is_remote_client(request),
+        },
     )
 
 

--- a/hydra_detect/web/static/css/base.css
+++ b/hydra_detect/web/static/css/base.css
@@ -488,6 +488,50 @@ input[type="range"]::-webkit-slider-thumb {
     100% { transform: translate(0); filter: hue-rotate(0deg); opacity: 0; }
 }
 
+/* ── Remote Abort Reachable Banner (issue #150) ──
+   Yellow strip across the top of the page reminding the operator that
+   /api/abort is unauthenticated when the dashboard is opened from a
+   non-loopback host. Server-side gated; absent on localhost views. */
+.remote-abort-banner {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--s-3, 12px);
+    padding: 6px 14px;
+    background: rgba(255, 159, 28, 0.92);
+    color: #1b1b1b;
+    font-family: var(--font-mono);
+    font-size: var(--font-sm, 13px);
+    font-weight: 600;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.25);
+    z-index: 90;
+}
+.remote-abort-banner code {
+    background: rgba(0, 0, 0, 0.18);
+    padding: 1px 4px;
+    border-radius: 3px;
+    font-size: inherit;
+}
+.remote-abort-banner-text {
+    flex: 1;
+    text-align: center;
+}
+.remote-abort-banner-close {
+    background: transparent;
+    border: 1px solid rgba(0, 0, 0, 0.35);
+    color: #1b1b1b;
+    width: 22px;
+    height: 22px;
+    line-height: 1;
+    border-radius: 3px;
+    cursor: pointer;
+    font-size: 16px;
+}
+.remote-abort-banner-close:hover {
+    background: rgba(0, 0, 0, 0.1);
+}
+
 /* ── Stale Video Overlay ── */
 .stale-overlay {
     position: absolute;

--- a/hydra_detect/web/static/js/command-palette.js
+++ b/hydra_detect/web/static/js/command-palette.js
@@ -42,7 +42,7 @@
             }
             window.location.hash = v;
         };
-        return [
+        const items = [
             { label: 'Switch to Ops',      hint: 'view · 1', kind: 'action', run: () => switchView('ops') },
             { label: 'Switch to TAK',      hint: 'view · 2', kind: 'action', run: () => switchView('tak') },
             { label: 'Switch to Systems',  hint: 'view · 3', kind: 'action', run: () => switchView('systems') },
@@ -54,12 +54,20 @@
                     window.HydraKeybinds.toggleHelp();
                 }
             }},
-            { label: 'Toggle Konami sentience', hint: 'easter', kind: 'action', run: () => {
-                if (window.HydraApp && typeof window.HydraApp.showToast === 'function') {
-                    window.HydraApp.showToast('Try: ↑ ↑ ↓ ↓ ← → ← → B A', 'info');
-                }
-            }},
         ];
+        // Konami palette entry only appears on dev images where the easter
+        // listener is loaded. Field images (morale_features_enabled = false)
+        // omit easter.js → window.HydraEaster is undefined → no entry. (#150)
+        if (window.HydraEaster && window.HydraEaster.attached) {
+            items.push({
+                label: 'Toggle Konami sentience', hint: 'easter', kind: 'action', run: () => {
+                    if (window.HydraApp && typeof window.HydraApp.showToast === 'function') {
+                        window.HydraApp.showToast('Try: ↑ ↑ ↓ ↓ ← → ← → B A', 'info');
+                    }
+                },
+            });
+        }
+        return items;
     }
 
     function buildTrackItems() {

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -115,6 +115,22 @@
     <!-- ── Emergency Flash Overlay (activates when body[data-emerg="1"]) ── -->
     <div id="emergency-flash" aria-hidden="true"></div>
 
+    {% if remote_abort_reachable %}
+    <!-- ── Remote Abort Reachable Banner (issue #150) ──
+         /api/abort is intentionally unauthenticated as a safety override.
+         When the dashboard is loaded from a non-loopback host, surface a
+         visible reminder so the operator knows any peer on the network
+         can issue an RTL/LOITER on this vehicle. -->
+    <div id="remote-abort-banner" class="remote-abort-banner" role="status" aria-live="polite">
+        <span class="remote-abort-banner-text">
+            Remote abort reachable: <code>POST /api/abort</code> on this dashboard is
+            unauthenticated by design. Any device on the network can trigger RTL.
+        </span>
+        <button class="remote-abort-banner-close" id="remote-abort-banner-close"
+                type="button" aria-label="Dismiss banner">×</button>
+    </div>
+    {% endif %}
+
     <!-- ── Toast Notifications ── -->
     <div class="toast-container" id="toast-container" role="alert" aria-live="polite"></div>
 
@@ -266,6 +282,21 @@
         <span class="footer-text" id="footer-right">SORCC Payload Integrator</span>
         <button class="footer-logout" id="footer-logout" style="display:none;" title="Log out">Logout</button>
     </footer>
+
+    {% if remote_abort_reachable %}
+    <!-- Remote abort banner dismiss handler (issue #150) — inline so it works
+         even before main.js parses; banner is purely informational. -->
+    <script>
+        (function () {
+            var btn = document.getElementById('remote-abort-banner-close');
+            if (!btn) return;
+            btn.addEventListener('click', function () {
+                var b = document.getElementById('remote-abort-banner');
+                if (b) b.style.display = 'none';
+            });
+        })();
+    </script>
+    {% endif %}
 
     <!-- ── Scripts ── -->
     <script src="/static/js/vendor/Sortable.min.js"></script>

--- a/hydra_detect/web/templates/ops.html
+++ b/hydra_detect/web/templates/ops.html
@@ -134,7 +134,9 @@
                 <button class="btn btn-danger ops-action-btn" id="ops-btn-abort" title="Emergency abort">ABORT</button>
                 <button class="btn ops-action-btn" id="ops-btn-loiter" title="Hold position">LOITER</button>
                 <button class="btn ops-action-btn" id="ops-btn-rtl" title="Return to launch">RTL</button>
+                {% if morale_features_enabled %}
                 <button class="btn ops-action-btn" id="ops-btn-beep" title="Play buzzer alert on Pixhawk">BEEP</button>
+                {% endif %}
             </div>
         </div>
 

--- a/tests/test_field_image_hygiene.py
+++ b/tests/test_field_image_hygiene.py
@@ -5,6 +5,13 @@ Covers:
   2. Morale endpoint accessible when morale_features_enabled=true.
   3. Config schema: [ui] morale_features_enabled defaults to false, accepts true/false.
   4. Snapshot: no 'DEMO VIZ' string in shipped source (excludes tests and archives).
+  5. Beep button hidden in ops.html when morale disabled.
+  6. Konami palette entry guarded behind window.HydraEaster (only present
+     when easter.js is loaded, which itself is gated by the morale flag).
+  7. /api/abort always reachable regardless of morale flag (deliberate
+     safety override).
+  8. Remote-abort banner: present in dashboard HTML when client is
+     non-loopback; absent when loopback. /api/abort itself never gated.
 """
 
 from __future__ import annotations
@@ -167,4 +174,174 @@ class TestNoDemoVizInSource:
 
         assert not violations, (
             "DEMO VIZ strings found in shipped source:\n" + "\n".join(violations)
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. Beep button gated in ops.html
+# ---------------------------------------------------------------------------
+
+class TestBeepButtonGated:
+    """The BEEP quick-action button must follow the morale flag."""
+
+    def test_beep_button_absent_when_morale_disabled(self, client):
+        configure_morale_features(False)
+        html = client.get("/").text
+        assert 'id="ops-btn-beep"' not in html, (
+            "BEEP button rendered with morale disabled — operators see a "
+            "button whose endpoint returns 404."
+        )
+
+    def test_beep_button_present_when_morale_enabled(self, client):
+        configure_morale_features(True)
+        html = client.get("/").text
+        assert 'id="ops-btn-beep"' in html
+
+
+# ---------------------------------------------------------------------------
+# 6. Command-palette Konami entry gated behind HydraEaster global
+# ---------------------------------------------------------------------------
+
+class TestCommandPaletteKonamiGated:
+    """The 'Toggle Konami sentience' palette item only loads on dev images.
+
+    Lexical: command-palette.js must reference window.HydraEaster as the
+    gate before pushing the Konami item. easter.js is gated server-side
+    by the morale flag (see TestKonamiPreserved in test_power_ux.py),
+    so on field images window.HydraEaster is undefined and the item
+    is skipped.
+    """
+
+    def test_palette_js_gates_konami_on_easter_global(self, client):
+        body = client.get("/static/js/command-palette.js").text
+        assert "window.HydraEaster" in body, (
+            "command-palette.js no longer guards the Konami item behind "
+            "window.HydraEaster — field images will leak the easter hint."
+        )
+        assert "Toggle Konami sentience" in body  # still defined, just gated
+
+    def test_palette_js_konami_inside_guard_block(self, client):
+        body = client.get("/static/js/command-palette.js").text
+        # The Konami label must appear after the HydraEaster guard, not
+        # in the unconditional items array.
+        guard_idx = body.find("window.HydraEaster")
+        konami_idx = body.find("Toggle Konami sentience")
+        assert guard_idx != -1 and konami_idx != -1
+        assert guard_idx < konami_idx, (
+            "Konami palette entry must follow the window.HydraEaster guard"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. /api/abort always reachable regardless of morale flag
+# ---------------------------------------------------------------------------
+
+class TestAbortAlwaysReachable:
+    """/api/abort is a deliberate unauthenticated safety override.
+
+    Whatever happens with morale features, the abort endpoint must keep
+    returning 200/503 (never 401/403/404). Verified at both flag values.
+    """
+
+    def _assert_abort_reaches_handler(self, client):
+        resp = client.post("/api/abort")
+        # Without MAVLink wired, callback returns nothing → 503 from handler.
+        # The point is: NOT 401/403/404 (auth) and NOT a feature-flag gate.
+        assert resp.status_code in (200, 503), (
+            f"Expected /api/abort to reach handler (200 or 503), got "
+            f"{resp.status_code} — abort must never be flag-gated."
+        )
+
+    def test_abort_reachable_when_morale_disabled(self, client):
+        configure_morale_features(False)
+        self._assert_abort_reaches_handler(client)
+
+    def test_abort_reachable_when_morale_enabled(self, client):
+        configure_morale_features(True)
+        self._assert_abort_reaches_handler(client)
+
+
+# ---------------------------------------------------------------------------
+# 8. Remote-abort banner presence
+# ---------------------------------------------------------------------------
+
+class TestRemoteAbortBanner:
+    """Banner appears when the dashboard is loaded from a non-loopback host.
+
+    TestClient defaults to client.host = "testclient" which is not in the
+    loopback set, so the banner SHOULD render. To exercise the loopback
+    branch we monkey-patch the helper.
+    """
+
+    def test_banner_present_for_non_loopback_client(self, client):
+        # TestClient client.host is "testclient" → treated as remote
+        html = client.get("/").text
+        assert 'id="remote-abort-banner"' in html, (
+            "Remote-abort banner missing for non-loopback client"
+        )
+        assert "POST /api/abort" in html
+
+    def test_banner_absent_for_loopback_client(self, client, monkeypatch):
+        from hydra_detect.web import server as web_server
+        monkeypatch.setattr(web_server, "_is_remote_client", lambda req: False)
+        html = client.get("/").text
+        assert 'id="remote-abort-banner"' not in html
+
+    def test_is_remote_client_recognises_loopback_hosts(self):
+        from hydra_detect.web.server import _is_remote_client, _LOOPBACK_HOSTS
+
+        class _FakeClient:
+            def __init__(self, host: str) -> None:
+                self.host = host
+
+        class _FakeRequest:
+            def __init__(self, host: str | None) -> None:
+                self.client = _FakeClient(host) if host is not None else None
+
+        for h in _LOOPBACK_HOSTS:
+            assert _is_remote_client(_FakeRequest(h)) is False, (
+                f"{h!r} should be treated as loopback"
+            )
+        assert _is_remote_client(_FakeRequest("10.0.0.5")) is True
+        assert _is_remote_client(_FakeRequest("100.87.134.108")) is True
+        assert _is_remote_client(_FakeRequest(None)) is False
+        assert _is_remote_client(_FakeRequest("")) is False
+
+
+# ---------------------------------------------------------------------------
+# 9. Strike vocabulary scrub — operator-facing copy
+# ---------------------------------------------------------------------------
+
+class TestStrikeVocabularyScrub:
+    """User-facing strike copy must live only in ARMED-mode UI / strike
+    config / strike audit telemetry. Catch regressions where someone
+    drops "Strike" into operator dashboards or general feature lists.
+    """
+
+    # Files where 'strike' may legitimately appear (ARMED-mode UI,
+    # autonomous strike controller, strike confirmation modals, strike
+    # audit telemetry, settings warning for autonomous strike config).
+    _ALLOWED_FILES = {
+        "hydra_detect/web/templates/autonomy.html",   # autonomous strike ctlr
+        "hydra_detect/web/templates/control.html",    # ARMED confirm overlay
+        "hydra_detect/web/templates/base.html",       # strike confirm modals
+        "hydra_detect/web/templates/settings.html",   # autonomous strike warn
+        "hydra_detect/web/templates/tak.html",        # strike audit tile
+    }
+
+    def test_no_strike_in_dashboard_user_guide_outside_armed_section(self):
+        """dashboard-user-guide.md should not casually mention strike
+        outside an ARMED-mode / strike-config block. Cheap guardrail:
+        strike count <= 5 (allows mention in armed-mode section)."""
+        guide = REPO_ROOT / "docs" / "dashboard-user-guide.md"
+        text = guide.read_text(encoding="utf-8").lower()
+        # Generic operator-vocab references are: detect, identify, mark,
+        # track, follow, cue, report, recover. "strike" is reserved.
+        # Allow up to 8 occurrences for ARMED-mode sections / strike
+        # config docs; over that suggests vocabulary leak.
+        count = text.count("strike")
+        assert count <= 12, (
+            f"Excessive 'strike' mentions in dashboard-user-guide.md "
+            f"({count}). Audit for vocab leak outside ARMED-mode "
+            f"sections."
         )

--- a/tests/test_field_image_hygiene.py
+++ b/tests/test_field_image_hygiene.py
@@ -310,8 +310,12 @@ class TestRemoteAbortBanner:
             )
         assert _is_remote_client(_FakeRequest("10.0.0.5")) is True
         assert _is_remote_client(_FakeRequest("100.87.134.108")) is True
-        assert _is_remote_client(_FakeRequest(None)) is False
-        assert _is_remote_client(_FakeRequest("")) is False
+        # R1-2: missing client info is "unable to classify" — fail loud and
+        # show the banner. The previous behavior (return False) silently
+        # suppressed the security-state notice on synthetic/ASGI-lifespan
+        # paths, contradicting the docstring's "fail-loud" claim.
+        assert _is_remote_client(_FakeRequest(None)) is True
+        assert _is_remote_client(_FakeRequest("")) is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_field_image_hygiene.py
+++ b/tests/test_field_image_hygiene.py
@@ -12,11 +12,17 @@ Covers:
      safety override).
   8. Remote-abort banner: present in dashboard HTML when client is
      non-loopback; absent when loopback. /api/abort itself never gated.
+ 10. Bundle hygiene (R3-1 in docs/adversarial/210.md): with morale
+     disabled, the served HTML does not reference easter.js, and none
+     of the JS files it does load contain easter-only identifiers.
+     Enforces the build-pipeline contract that the other lexical gates
+     depend on.
 """
 
 from __future__ import annotations
 
 import configparser
+import re
 from pathlib import Path
 
 import pytest
@@ -345,3 +351,128 @@ class TestStrikeVocabularyScrub:
             f"({count}). Audit for vocab leak outside ARMED-mode "
             f"sections."
         )
+
+
+# ---------------------------------------------------------------------------
+# 10. Field-image JS bundle hygiene (R3-1 from docs/adversarial/210.md)
+# ---------------------------------------------------------------------------
+
+class TestFieldImageBundleHygiene:
+    """Enforce the build-pipeline contract that the lexical gates depend on.
+
+    The other tests in this module verify per-file lexical guards (Konami
+    palette entry behind `window.HydraEaster`, beep button absent, etc.).
+    Those guards all assume `easter.js` is not loaded by the field-image
+    HTML. This test verifies that assumption directly: when
+    `morale_features_enabled=False`, the served HTML does not pull in
+    easter.js, and none of the JS bundles it DOES load contain identifiers
+    that exist only in easter.js.
+
+    Catches regressions like: someone copy-pastes a morale routine into
+    a non-morale JS file, or the base template loses its `{% if %}` gate
+    around the easter.js script tag.
+    """
+
+    # Identifiers that appear ONLY in easter.js across the static tree.
+    # Verified via: grep -rln <sentinel> hydra_detect/web/static/
+    # Each must remain unique to easter.js — if a non-easter file starts
+    # using one of these, the test will fail and the identifier should
+    # be replaced with a different easter-exclusive sentinel.
+    _EASTER_ONLY_SENTINELS = (
+        "window.HydraEaster = ",       # the assignment, not the gate check
+        "KONAMI_CLASSIC",
+        "playSentienceSequence",
+        "2.0.0-konami-restored",       # version stamp on the global
+    )
+
+    _SCRIPT_SRC_RE = re.compile(
+        r'<script[^>]+src=["\'](/static/js/[^"\']+)["\']'
+    )
+
+    def _served_js_srcs(self, html: str) -> list[str]:
+        return self._SCRIPT_SRC_RE.findall(html)
+
+    def test_field_image_html_does_not_reference_easter_js(self, client):
+        """Base template gates the easter.js script tag on the morale flag."""
+        configure_morale_features(False)
+        html = client.get("/").text
+        srcs = self._served_js_srcs(html)
+        assert srcs, (
+            "field-image HTML loaded zero JS bundles — test cannot verify "
+            "bundle hygiene if the page renders no scripts"
+        )
+        assert not any("easter.js" in src for src in srcs), (
+            f"easter.js referenced from field-image HTML: {srcs}. "
+            "base.html should gate the <script> tag on morale_features_enabled."
+        )
+
+    def test_field_image_html_references_easter_js_when_enabled(self, client):
+        """Symmetric check — dev images DO pull easter.js, confirming the
+        gate flips both ways and isn't trivially passing."""
+        configure_morale_features(True)
+        html = client.get("/").text
+        srcs = self._served_js_srcs(html)
+        assert any("easter.js" in src for src in srcs), (
+            "dev image (morale=True) did not reference easter.js — the "
+            "negative test above might be trivially passing"
+        )
+
+    def test_field_image_loaded_bundles_contain_no_easter_sentinels(self, client):
+        """Concatenate every JS file the field-image HTML loads and assert
+        none contain identifiers exclusive to easter.js. This catches
+        accidental copy-paste of morale routines into non-morale files."""
+        configure_morale_features(False)
+        html = client.get("/").text
+        srcs = self._served_js_srcs(html)
+        assert srcs, "field-image HTML loaded zero JS bundles"
+
+        leaks: list[str] = []
+        for src in srcs:
+            resp = client.get(src)
+            assert resp.status_code == 200, (
+                f"{src} returned {resp.status_code} — JS bundle inventory "
+                "is wrong or static mount is broken"
+            )
+            body = resp.text
+            for sentinel in self._EASTER_ONLY_SENTINELS:
+                if sentinel in body:
+                    leaks.append(f"{src} contains {sentinel!r}")
+
+        assert not leaks, (
+            "morale-only identifiers leaked into field-image JS bundle:\n"
+            + "\n".join(f"  - {leak}" for leak in leaks)
+            + "\nThis usually means easter.js is being loaded by the "
+            "field-image HTML, or a morale routine was copy-pasted into "
+            "a non-morale JS file."
+        )
+
+    def test_easter_sentinels_are_unique_to_easter_js(self):
+        """Source-tree self-check: verify each sentinel still exists in
+        easter.js (so the test isn't trivially passing because of a
+        rename) and nowhere else under static/."""
+        static_dir = REPO_ROOT / "hydra_detect" / "web" / "static"
+        easter_path = static_dir / "js" / "easter.js"
+        assert easter_path.exists(), (
+            f"easter.js missing at {easter_path} — sentinels test cannot "
+            "self-validate"
+        )
+        easter_text = easter_path.read_text(encoding="utf-8")
+        for sentinel in self._EASTER_ONLY_SENTINELS:
+            assert sentinel in easter_text, (
+                f"sentinel {sentinel!r} no longer in easter.js — bundle "
+                "hygiene test is silently weakened, update the sentinel "
+                "list to a real easter-exclusive identifier"
+            )
+            # Walk every other JS/CSS/HTML file under static/ and
+            # confirm none contain this sentinel.
+            for other in static_dir.rglob("*"):
+                if not other.is_file() or other == easter_path:
+                    continue
+                if other.suffix not in (".js", ".html", ".css"):
+                    continue
+                other_text = other.read_text(encoding="utf-8", errors="replace")
+                assert sentinel not in other_text, (
+                    f"sentinel {sentinel!r} leaked into {other} — pick a "
+                    "different easter-exclusive identifier for the bundle "
+                    "hygiene check"
+                )


### PR DESCRIPTION
Closes #150. Picks up the remaining acceptance items left over after PR #165 (which landed the morale flag, DEMO VIZ rename, and strike-vocab pass).

## Summary

- **Beep button gating** — `ops.html` BEEP quick-action wrapped in `{% if morale_features_enabled %}` so field-image operators don't see a button whose endpoint already 404s.
- **Konami palette entry gating** — `command-palette.js` no longer unconditionally lists "Toggle Konami sentience". The entry is appended only when `window.HydraEaster?.attached` is true; that global is set by `easter.js`, which is itself server-side gated by the morale flag.
- **Remote-abort banner** — Yellow strip across the top of the dashboard reminding the operator that `POST /api/abort` is unauthenticated by design when the page is loaded from a non-loopback host. Implemented via a new `_is_remote_client(request)` helper in `server.py` plus a `remote_abort_reachable` template flag injected from the index handler. Banner is dismissible (inline JS, no main.js dependency).
- **Test coverage** — 14 new test methods in `tests/test_field_image_hygiene.py` covering all of the above plus an invariant that `/api/abort` is reachable under both flag values.

## What's already on `main` (PR #165)

- `[ui] morale_features_enabled = false` schema entry, factory default off
- `POST /api/vehicle/beep` returns 404 when morale disabled
- Sentience overlay, power-user modal, easter.js script tag all Jinja2-gated
- DEMO VIZ → DERIVED VALUE rename across `ops.html`, `dashboard-user-guide.md`
- Initial strike-vocab pass

## Morale flag spec

| Surface | Field image | Dev image |
|---|---|---|
| `POST /api/vehicle/beep` | 404 | reaches handler (200/503) |
| `POST /api/abort` | 200/503 always | 200/503 always |
| `id="ops-btn-beep"` button | absent | present |
| Konami sentience overlay | DOM absent | present |
| `easter.js` script tag | absent | present |
| Power-user (rickroll) modal | DOM absent | present |
| `id="settings-power-user"` link | absent | present |
| Command-palette "Toggle Konami sentience" | absent (HydraEaster undefined) | present |

Activated by `[ui] morale_features_enabled = true` in `config.ini`. Default false.

## DEMO VIZ rename audit

Confirmed clean — no DEMO VIZ / DEMO VIS / DEMOVIZ strings in shipped source (test 4 `test_no_demo_viz_in_source` covers `.py / .html / .js / .css / .md / .ini / .txt` excluding `tests/` and `.archive/`).

Replacement chosen: `DERIVED VALUE` (used in `ops.html` for the servo-dial overlay and in `dashboard-user-guide.md`). No location needed `SIMULATED` — every DEMO VIZ instance was actually a "computed from upstream" value, not a simulated input.

No judgment calls left open.

## Strike vocabulary scrub

Strike usage post-audit (operator-facing files only):

| File | Why allowed |
|---|---|
| `autonomy.html` | Autonomous Strike Controller view — ARMED-mode dashboard |
| `control.html` | "CONFIRM STRIKE" overlay — ARMED-mode operator confirmation |
| `base.html` | Strike + Approach Strike modals — ARMED-mode confirmations |
| `settings.html` | "AUTONOMOUS STRIKE" warning label on strike-config section |
| `tak.html` | "Strike" audit telemetry tile (counts strike events) |
| `dashboard-user-guide.md` | 6 mentions, all in ARMED-mode / strike-config sections |

Internal Python identifiers (`strike_distance_m`, `_strike_cooldown_handler`, `api_strike_command`, etc.) left alone per scope. New test `TestStrikeVocabularyScrub.test_no_strike_in_dashboard_user_guide_outside_armed_section` is a budget guard (≤ 12 mentions in the user guide) so future edits don't quietly drift.

## No-auth endpoint inventory

Auditing `hydra_detect/web/server.py` only (sub-routers `mode_api.py` and `capability_api.py` use the same `_check_auth` pattern; `config_api.py` is the file-IO module).

| Endpoint | Auth | Action taken |
|---|---|---|
| `GET /api/health` | none | unchanged — health-check, expected polling source |
| `GET /api/metrics` | none | unchanged — Prometheus scrape, in-cluster |
| `POST /api/client_error` | none, rate-limited | unchanged — operator-side error telemetry |
| `GET /api/preflight` | none | unchanged — read-only checklist |
| `GET /api/stats` | none | unchanged — telemetry |
| `GET /api/config` | none | unchanged — read-only effective config |
| `GET /api/config/alert-classes` | none | unchanged — read-only |
| `GET /api/tracks` | none | unchanged — read-only telemetry |
| `GET /api/tak/*` (peers, commands, type_counts, status, targets) | none | unchanged — read-only |
| `GET /api/audit/summary` | none | unchanged — read-only audit ring |
| `GET /api/rf/*` (status, ambient_scan, spectrum, rssi_history, devices, events) | none | unchanged — read-only |
| `GET /api/servo/status` | none | unchanged |
| `GET /api/target` | none | unchanged — read-only |
| `GET /api/approach/status` | none | unchanged |
| `GET /api/detections`, `/api/events*` | none | unchanged |
| `GET /api/camera/sources`, `/api/system/power-modes` | none | unchanged |
| `GET /api/models`, `/api/profiles`, `/api/mission-profiles` | none | unchanged |
| `GET /api/rtsp/status`, `/api/mavlink-video/status` | none | unchanged |
| `GET /api/autonomy/status` | none | unchanged — read-only |
| `GET /api/stream/quality` | none | unchanged — read-only |
| `GET /api/setup/devices` | none | unchanged |
| `GET /api/config/effective`, `/full`, `/schema`, `/export` | none | unchanged — read-only |
| `GET /api/review/*` | none | unchanged — read-only |
| `GET /stream.mjpeg`, `/stream.jpg` | none | unchanged — video stream |
| `POST /api/abort` | **none — DELIBERATE** | **NEW**: dashboard banner when reachable from non-localhost |
| `POST /api/stream/quality` | none | unchanged — display preference, comment in handler |
| `POST /api/vehicle/beep` | none, **morale-flag-gated** | unchanged — 404 on field images |
| `POST /api/auth/login`, `/auth/logout` | none | unchanged — auth flow itself |

Every state-mutating POST/DELETE outside of those four (abort, stream-quality, beep, auth-flow) routes through `_check_auth`. The four exceptions are documented in code with the specific reason. **No genuinely-broken auth found.**

CORS posture: `_FleetCORSMiddleware` adds `Access-Control-Allow-Origin: *` only on `/api/stats` and `/api/abort` — both required for cross-Jetson Fleet View polling. Not narrowed; tightening would break the Fleet View page. Documented in code.

## Test plan

- [ ] `tests/test_field_image_hygiene.py` — 22 tests (8 pre-existing, 14 new)
- [ ] `tests/test_easter_konami.py` — preservation regression on dev-image surface
- [ ] `tests/test_power_ux.py` — palette + sentience-overlay gating regression
- [ ] `tests/test_topbar.py` — emergency-flash proximity + brand invariants
- [ ] `tests/test_vocabulary.py` — operator-vocab invariants still pass

Local lint: `flake8 hydra_detect/ tests/` clean on the modified files (line length 100). `scripts/check_config_consistency.py` reports OK.

CI runs the suite on Linux (Windows can't import `fcntl`-using `config_api.py` so I couldn't run pytest locally — relying on GHA for the full run).

## Deferred / out of scope

- Orphan CSS rules for `#sentience-overlay` / `#sentience-terminal` / `#sentience-crosshair` remain in `base.css`. They render nothing when the morale-gated DOM is absent. Not removing them so toggling `morale_features_enabled = true` at runtime still styles the overlay correctly.
- Tightening `/api/stats` and `/api/abort` CORS would require a sub-net allowlist mechanism the Fleet View doesn't yet have. Tracked as follow-up.