### PR TITLE
feat(mavlink): battery monitoring from SYS_STATUS with thresholded alerts (#73)

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -54,6 +54,18 @@ geo_tracking_interval = 2.0
 sim_gps_lat = 
 sim_gps_lon = 
 
+[battery]
+# Vehicle battery monitoring from MAVLink SYS_STATUS. Surfaces a level
+# (OK/LOW/CRITICAL/UNKNOWN) on /api/stats and emits one STATUSTEXT
+# per level transition (e.g. OK -> LOW). Note: this is the vehicle
+# battery seen by the FC; the Jetson companion may run from a separate
+# power source.
+enabled = true
+low_threshold_pct = 20
+critical_threshold_pct = 10
+stale_after_sec = 30.0
+critical_reissue_sec = 0.0
+
 [alerts]
 light_bar_enabled = true
 light_bar_channel = 9

--- a/docs/adversarial/211.md
+++ b/docs/adversarial/211.md
@@ -1,0 +1,88 @@
+# Adversarial Analysis — PR #211 (claude/issue-73-battery-mavlink)
+
+**Generated:** 2026-05-08T05:30:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/211
+**PR head:** 356bbdbd9e4a76376e3f24f00f099d1af3580698
+**Base:** main at 76bc81f9
+**Diff size:** +1097 / -8 across 11 files (battery_monitor.py [new, 286 LOC], mavlink_io.py, pipeline/facade.py, osd.py, web/server.py, web/static/css/base.css, web/static/js/main.js, web/templates/base.html, config_schema.py, config.ini, tests/test_battery_monitor.py [new, 526 LOC])
+
+## Summary
+
+- **Round 1:** 5 findings (1 high · 3 medium · 1 low). Pattern-match focused on the percent-only alert path (vs. voltage-only fallback for uncalibrated FPV racers), monotonic-vs-wallclock timestamp split, hysteresis correctness under threshold oscillation, the `critical_reissue_sec` cadence interaction with the global STATUSTEXT cap, and `-1`-vs-disabled rendering ambiguity in the dashboard.
+- **Round 2:** 3 second-order findings; **challenged R1-2 (downgraded to nit)** — the strict-`>` staleness boundary is consistent with the rest of the codebase's epsilon convention. The R1-1 percent-only finding remains the high — confirmed by reading `_compute_level_locked`. Discovered that `BatteryMonitor.send_statustext` calls bypass the global rate limit in `mavlink_io`, which materially changes R1-4's severity.
+- **Round 3:** 4 findings, framing identified — *both prior rounds audited the BatteryMonitor in isolation. Neither asked what happens when the alert path encounters Jetson brownout (USV/UGV share the battery), how the autonomous engine should react to CRITICAL state, or whether voltage_battery is even unique on multi-battery platforms.*
+- **Consolidated:** 0 blockers · 3 gates · 5 follow-ups · 1 dropped (R1-2).
+
+## Round 1 — Pattern Match
+
+5 findings. Dominant pattern: percent-driven alerting on a hardware-reported percentage that *most consumer FPV airframes do not produce* — combined with hysteresis logic that the test suite covers thinly at the threshold-oscillation edge and a re-issue cadence that may bypass the global STATUSTEXT throttle.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R1-1** | **high** | **silent-no-alert** | battery_monitor.py:228-248 (`_compute_level_locked`) | The level computation refuses to alert without a populated `remaining_pct` (chemistry-dependent voltage thresholds, deliberately conservative — good engineering). But the FPV racing class of platforms in the SORCC fleet (5"/3" race quads, EdgeTX-flashed, ELRS receivers, no battery monitoring chip) reports `battery_remaining = -1` indefinitely. ArduPilot will only report a real percent if `BATT_CAPACITY` is set and the battery monitor has been calibrated. Result for the platforms most likely to drain to LVC: `level = UNKNOWN` forever, **zero alerts emitted, ever.** The dashboard renders dim gray and silently provides no warning. Acceptance criteria — "battery voltage/percentage read from MAVLink," "STATUSTEXT alerts at configurable thresholds" — are met technically but the operator-visible safety guarantee is not. |
+| R1-2 | low | edge-case | battery_monitor.py:235 | Staleness uses strict `>`. If `now - last == self._stale` exactly, level remains its previous value rather than UNKNOWN. Discrete clock-tick artifact. |
+| R1-3 | medium | hysteresis-test-coverage | battery_monitor.py:152-183 + tests/test_battery_monitor.py | Hysteresis fires only on *level transitions*, which is correct as designed. But the test suite exercises clean transitions (OK→LOW, LOW→CRITICAL). It does not pin the rapid-oscillation case: 21% → 19% → 21% → 19% across the 20% threshold every SYS_STATUS tick. With `critical_reissue_sec = 0` (default disabled), this still yields N transitions = N STATUSTEXT emissions over a window where the state is effectively "wobbling at LOW." Test gap: assert no more than M emissions per minute under threshold-bouncing input. |
+| R1-4 | medium | reissue-cadence-vs-global-cap | battery_monitor.py:155-180 (`_maybe_emit_alert_locked`) + mavlink_io.py:596-617 (`send_statustext`) | `critical_reissue_sec` re-emits CRITICAL on cadence. The default is 0.0 (disabled), but operators are encouraged in the docstring to set it to (e.g.) 60s. The emission path is `self._send(text, severity)` → `mavlink_io.send_statustext()`, which has its own rate-counting (`_st_send_count`) but **does not consult `_global_max_per_sec`** (the global cap lives in `alert_detection`, line 619+, a different code path). A misconfigured `critical_reissue_sec = 5.0` therefore emits 12 CRITICAL/min unthrottled, in addition to whatever other STATUSTEXT traffic is on the link. |
+| R1-5 | medium | unknown-vs-disabled-rendering | web/templates/base.html:91-100 + main.js (battery widget) | The widget is hidden until first message and renders dim gray for UNKNOWN. The `enabled=False` config also surfaces as `battery: null` in `/api/stats`, which the JS will also render as hidden. Two distinct system states ("monitor disabled by config" vs "monitor active but never received SYS_STATUS yet" vs "stale > 30s") collapse into the same visual: the widget is gone. A field operator who expects to see battery status and sees nothing has no information about which of the three states they're in. |
+
+## Round 2 — Counter-Critique
+
+**Challenged R1-2:** strict `>` vs `>=` for staleness — re-read other timing helpers in the repo. `_check_camera_frame` and the watchdog stall check both use strict `>` on monotonic deltas. Consistent epsilon convention. The "if now - last == self._stale exactly" case is observably indistinguishable from "data arrived this exact instant," and treating it as fresh is the correct default. **Downgrade to nit.**
+
+**Confirmed R1-1, R1-3, R1-4, R1-5.** R1-1 is the highest-leverage finding by far — the test suite verifies the alert path is correct, but does not verify the alert path is *reached* on the platforms that need it most. R1-4 grew teeth in counter-critique: I traced `_send` → `mavlink_io.send_statustext` and confirmed it bypasses the `_global_alert_times` rate limiter in `alert_detection`. The path is unthrottled.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | operator-misconfig | config_schema.py + battery_monitor.py:103-105 (validation) | The constructor enforces `critical_threshold_pct < low_threshold_pct` (good) but does not bound the absolute values. A student sets `low_threshold_pct = 80` thinking "remind me when the battery is half drained" — every fully charged battery in the fleet reports 60-90% on the first SYS_STATUS tick, *every unit enters LOW immediately,* the GCS gets a flood of HYDRA-X-Y BATT LOW STATUSTEXT, and the student turns off battery monitoring entirely. Add bounds (e.g. `low_threshold_pct ∈ [10, 50]`) and surface a config validation error rather than a silent flood. |
+| R2-2 | medium | dashboard-feedback-loop | main.js (battery widget polling) + /api/stats | The dashboard widget polls `/api/stats` for battery state. The poll interval is whatever the existing top-bar refresh uses. The widget changes color (green→amber→red) on the *displayed* level. The widget displays the level *as recomputed at GET time* (good — staleness re-evaluation is read-side). But `mon.tick()` on the slow loop is the only path that emits the recovery alert (`maybe_emit_alert_locked` on tick is the only path that fires the `BATT RECOVERED` transition). If the slow-loop tick lags or the pipeline is in a degraded mode where the slow loop is suspended, the dashboard could display LOW indefinitely while STATUSTEXT never recovers. |
+| R2-3 | low | sentinel-confusion | battery_monitor.py:241-243 | `pct is None` returns UNKNOWN. The MAVLink `-1` sentinel is converted to `None` upstream in `mavlink_io._handle_sys_status` — verify the conversion exists. If `update_from_sys_status` is ever called with literal `-1` (test path, mock, future caller), the comparison `pct <= self._crit (10)` is True and the unit emits **CRITICAL** for an uncalibrated battery. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited the BatteryMonitor as a unit — "is the level computation correct, is the hysteresis right, are the alerts throttled." Neither round asked (a) what happens to the alert path when the Jetson and the vehicle share a battery and the SBC browns out before the alert ferries, (b) whether the autonomous engine should consult battery level before continuing engagement, or (c) whether voltage_battery is even a unique fact on multi-battery airframes.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **high** | **dead-letter-alert** | battery_monitor.py + system | On USV (Bonzi Sport Boat), UGV (Axial SCX6), and any platform where the Jetson Orin Nano runs off the same vehicle battery, the SBC brownout threshold (~7V on Orin Nano) is reached *before* the LiPo's protected LVC fires. Sequence: voltage drops → battery_remaining = 5% → BatteryMonitor emits CRITICAL → STATUSTEXT enters mavlink send queue → Jetson loses bus rail and reboots → MAVLink session drops → STATUSTEXT never reaches GCS. The operator sees no warning; recovery starts with finding a beached USV. The right mitigation is either (a) a separate proactive shutdown path (LOW → graceful stop on USV/UGV) or (b) shorter alert cadence on those platforms keyed off `[vehicle.*]` profile. **Gate:** at minimum, document the constraint in the operator guide and surface a config note. |
+| R3-2 | medium | autonomy-coupling | battery_monitor.py + autonomous.py + approach.py | The autonomous engine has gates (geofence, vehicle_mode, operator_lock, gps_fresh, cooldown). It does NOT consult battery level. A unit with `[autonomous] enabled = true` will continue to engage Follow / Strike approaches into a CRITICAL battery state because the gate stack does not know about battery. The PR is correct to keep BatteryMonitor narrow, but the gap between "alert fires" and "engagement halts" should be a follow-up: add an optional sixth gate `battery_ok` to autonomous's gate stack. |
+| R3-3 | medium | multi-battery | battery_monitor.py + mavlink_io._handle_sys_status | `voltage_battery` is the SYS_STATUS battery 1 voltage. ArduPilot supports up to 16 batteries. A tilt-rotor / hybrid VTOL with separate lift and cruise batteries reports two voltages (BATTERY_STATUS msg 147, not SYS_STATUS). The PR is keyed to SYS_STATUS only — it sees battery 1, period. SORCC fleet today is single-battery, so this is a forward-looking concern. But documenting the assumption now ("HYDRA monitors battery 1; multi-battery platforms must be configured to report their primary cell on battery 1") is cheap. |
+| R3-4 | low | tak-cot-coupling | TAK CoT emitter + battery state | The TAK plugin emits CoT messages with platform status. Does the PR plumb battery level into the CoT status? If yes, peer platforms in the fleet (instructor TAK display) see battery data. If no, the data exists in `/api/stats` locally but does not propagate to TAK consumers. Either is defensible; the choice should be explicit. |
+
+### Consistency-bias callouts
+
+- **R1+R2 ranked R1-3 (hysteresis test gap) and R1-4 (reissue cadence vs cap) as medium**, which is correct. They are testable / fixable in this PR.
+- **R3-1 (dead-letter alert via SBC brownout)** is the highest-severity finding and was invisible from inside R1+R2's frame. The frame's question was "is the monitor correct"; the actual question is "is the alert *delivered* in the conditions where the platform most needs it." On USV/UGV, the answer is no.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended action |
+|---|---|---|---|---|---|
+| **high** | silent-no-alert | R1-1 | Percent-only alert path silently provides zero warnings on FPV racing platforms with `BATT_CAPACITY=0`. The platforms most likely to drain to LVC are not covered. Either add an opt-in voltage-cell-count fallback (operator declares 4S → 14.0V floor) or surface UNKNOWN distinguishably in the dashboard so the operator knows the monitor is silent on this unit. | R1-1 | **gate before merge** |
+| **high** | dead-letter-alert | R3-1 | On USV/UGV/any shared-battery platform, Jetson brownout precedes alert delivery. Document the constraint in operator guide; longer-term, add a graceful-shutdown trigger on LOW for shared-battery profiles. | R3-1 | **gate before merge** (doc), follow-up (graceful shutdown) |
+| medium | reissue-vs-cap | R1-4 | `critical_reissue_sec` re-emits via `send_statustext` which bypasses `_global_max_per_sec`. Either route via `alert_detection` (consults the cap) or add a battery-specific cadence ceiling. | R1-4 | **gate before merge** (route through cap) |
+| medium | hysteresis-test | R1-3 | No test pins behavior under rapid threshold oscillation. Add parameterized test: 60s of 19↔21% input → assert ≤2 STATUSTEXT emissions. | R1-3 | follow-up issue |
+| medium | unknown-vs-disabled | R1-5 | UNKNOWN, "never received," and "monitor disabled" all render as hidden widget. Operator cannot tell which. Add a tooltip distinction or an explicit "monitor disabled" pill. | R1-5 | follow-up issue |
+| medium | operator-misconfig | R2-1 | No bounds on `low_threshold_pct`. Add validation: `low ∈ [10, 50]`, `critical ∈ [5, low-5]`. | R2-1 | follow-up issue |
+| medium | autonomy-coupling | R3-2 | Autonomous engine doesn't consult battery. Continues engagement into CRITICAL. Add a sixth gate. | R3-2 | follow-up issue |
+| medium | multi-battery | R3-3 | Battery 1 only. Document the assumption. Future-proof if the SORCC fleet grows multi-battery platforms. | R3-3 | follow-up issue |
+| low | sentinel | R2-3 | Verify `-1` → `None` conversion happens upstream. | R2-3 | nit (verify) |
+| low | dashboard-loop | R2-2 | Recovery alert depends on slow-loop tick. If suspended, recovery never fires while displayed level recomputes. | R2-2 | follow-up issue |
+| low | tak-cot | R3-4 | Battery in CoT status: yes/no/explicitly-deferred. | R3-4 | follow-up issue |
+| nit | edge-case | R1-2 (downgraded) | Strict `>` consistent with rest of codebase. | R1-2 (dropped) | dropped |
+
+## Recommendation
+
+**Three gates before merge:**
+
+1. **R1-1** — The PR's user-visible promise is "battery alerts on MAVLink." On the FPV racing platforms in the SORCC fleet, the promise silently does not hold because percent is unpopulated. Minimum action: distinguish UNKNOWN from disabled in the dashboard so the operator can tell their unit is not protected. Better action: opt-in voltage-floor fallback keyed off cell count.
+2. **R3-1** — On USV/UGV the alert dies with the Jetson before delivery. Add an operator-guide note (this is the cheap fix) and file a follow-up for graceful shutdown on shared-battery profiles.
+3. **R1-4** — Re-issue cadence bypasses the global STATUSTEXT cap. Route `BatteryMonitor._send` through `alert_detection` or add a battery-specific cap so a misconfigured `critical_reissue_sec` cannot saturate the link.
+
+The five medium follow-ups (R1-3 hysteresis test, R1-5 UNKNOWN-vs-disabled, R2-1 bounds, R3-2 autonomy gate, R3-3 multi-battery) are not gates — file as separate issues post-merge.
+
+The PR's core mechanics — SYS_STATUS subscription, level computation, hysteresis, OSD/API/dashboard wiring — are sound. The findings cluster on the platform-specific edge of the requirement (FPV racing, USV brownout) and on cap-vs-cadence interaction with the existing STATUSTEXT throttle.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -165,6 +165,56 @@ MAVLink connection and alert behavior.
 | `sim_gps_lat` | float | *(empty)* | -90.0-90.0 | Simulated GPS latitude. Overrides real GPS for bench testing. |
 | `sim_gps_lon` | float | *(empty)* | -180.0-180.0 | Simulated GPS longitude. |
 
+## [battery]
+
+Vehicle battery monitoring from MAVLink `SYS_STATUS`. Surfaces a level
+(`OK` / `LOW` / `CRITICAL` / `UNKNOWN`) on `/api/stats` and emits one
+STATUSTEXT per level transition. This tracks the **vehicle** battery
+seen by the FC, not the Jetson companion (which may run from a
+separate source).
+
+| Key | Type | Default | Range | Description |
+|-----|------|---------|-------|-------------|
+| `enabled` | bool | `true` | -- | Master switch. When false, the widget is hidden and no alerts fire. |
+| `low_threshold_pct` | int | `20` | 1-99 | Below this, level becomes `LOW`. Inclusive. |
+| `critical_threshold_pct` | int | `10` | 1-99 | Below this, level becomes `CRITICAL`. Must be < `low_threshold_pct`. |
+| `stale_after_sec` | float | `30.0` | 0-3600 | If no `SYS_STATUS` arrives within this window, level resolves to `UNKNOWN`. 0 disables. |
+| `critical_reissue_sec` | float | `0.0` | 0-3600 | Re-emit a `CRITICAL` STATUSTEXT this often even without a level change. 0 disables. |
+
+### Operator notes
+
+**Uncalibrated FC monitor (UNCALIBRATED state).** ArduPilot reports
+`battery_remaining = -1` until `BATT_CAPACITY` is set and the battery
+monitor is calibrated — the default state on FPV racing platforms
+without a dedicated battery monitor chip. When the FC starts reporting
+voltage but the percent sentinel stays at `-1`, Hydra fires a one-time
+`BATT MONITOR UNCALIBRATED` STATUSTEXT and the dashboard battery card
+shows `UNCAL` (amber). The percent-driven `LOW` / `CRITICAL` path will
+not produce alerts on that unit until ArduPilot is calibrated — voltage
+thresholds vary too much by chemistry to alert on safely. To enable
+percent alerts, configure `BATT_CAPACITY` in ArduPilot and calibrate
+the monitor (Mission Planner → Initial Setup → Optional Hardware →
+Battery Monitor).
+
+**Shared-battery platforms (USV / UGV / shared-power multirotors).** On
+platforms where the Jetson Orin Nano runs off the same battery as the
+vehicle, the SBC brownout threshold (~7 V on Orin Nano) is reached
+**before** the LiPo's protected LVC fires. The expected failure
+sequence is: voltage drops → `battery_remaining` hits CRITICAL → the
+BATT CRITICAL STATUSTEXT enters the MAVLink send queue → the Jetson
+loses its bus rail and reboots → the MAVLink session drops → the alert
+never reaches the GCS. Operator implications:
+
+1. **Do not rely on `BATT CRITICAL` alone** on shared-power platforms.
+   The `LOW` transition is your effective last warning — set
+   `low_threshold_pct` high enough (e.g. `30`) that you receive the
+   alert with margin before the brownout window.
+2. **Configure ArduPilot failsafes** (`BATT_FS_LOW_ACT = 2` for RTL on
+   the FC side — see the `pixhawk-prereqs-*.md` guides). These do not
+   depend on the Jetson surviving long enough to deliver the alert.
+3. **Tracked follow-up** — automatic graceful-stop on `LOW` for shared
+   battery profiles is tracked in [issue #222](https://github.com/rmeadomavic/Hydra/issues/222).
+
 ## [alerts]
 
 Alert output configuration for light bar and rate limiting.

--- a/hydra_detect/battery_monitor.py
+++ b/hydra_detect/battery_monitor.py
@@ -34,6 +34,13 @@ LEVEL_LOW = "LOW"
 LEVEL_CRITICAL = "CRITICAL"
 LEVEL_UNKNOWN = "UNKNOWN"
 
+# Severity used for the one-time "BATT MONITOR UNCALIBRATED" STATUSTEXT.
+# Boots once when the FC starts reporting voltage but battery_remaining is
+# still the MAVLink "unknown" sentinel — flags to the operator that the
+# percent-driven alert path will stay silent on this unit until BATT_CAPACITY
+# is configured and the battery monitor is calibrated.
+_SEVERITY_UNCALIBRATED = 4  # WARNING — visible in Mission Planner, not alarming
+
 # MAVLink severity used by STATUSTEXT alerts. ArduPilot mapping:
 #   2 = MAV_SEVERITY_CRITICAL  (red in Mission Planner)
 #   4 = MAV_SEVERITY_WARNING   (amber)
@@ -52,6 +59,12 @@ class BatteryState:
     level: str = LEVEL_UNKNOWN
     last_update_ts: float = 0.0  # monotonic seconds; 0 = never
     source: str = "mavlink"
+    # True when SYS_STATUS has arrived but battery_remaining stays at the
+    # MAVLink "unknown" sentinel — i.e. the FC is talking but BATT_CAPACITY
+    # is unset / the battery monitor is uncalibrated, so the percent-driven
+    # alert path will never fire on this unit. Distinguishes "monitor is
+    # silent" from "monitor is fine and the cell is healthy."
+    uncalibrated: bool = False
 
     def to_api(self) -> dict:
         """Return the dict shape exposed on /api/stats."""
@@ -60,6 +73,7 @@ class BatteryState:
             "remaining_pct": self.remaining_pct,
             "level": self.level,
             "source": self.source,
+            "uncalibrated": self.uncalibrated,
         }
 
 
@@ -115,6 +129,10 @@ class BatteryMonitor:
         # ``None`` means we have not emitted any alert yet.
         self._last_alert_level: Optional[str] = None
         self._last_alert_ts: float = 0.0
+        # One-time flag: True after we have fired the "BATT MONITOR
+        # UNCALIBRATED" STATUSTEXT. Prevents the alert from re-emitting
+        # on every SYS_STATUS tick while the FC is still uncalibrated.
+        self._uncalibrated_alert_sent: bool = False
 
     # -- Configuration -------------------------------------------------
     @property
@@ -166,13 +184,34 @@ class BatteryMonitor:
         if battery_remaining != -1 and 0 <= battery_remaining <= 100:
             remaining_pct = int(battery_remaining)
 
+        # Detect "FC is reporting but battery is uncalibrated" — voltage
+        # present + percent sentinel. Fire the one-time UNCALIBRATED
+        # STATUSTEXT on the first such SYS_STATUS so the operator knows
+        # the percent-driven alert path will stay silent on this unit.
+        uncalibrated = (voltage_v is not None) and (remaining_pct is None)
+
+        uncalibrated_alert: Optional[tuple[str, int]] = None
         with self._lock:
             self._state.voltage_v = voltage_v
             self._state.remaining_pct = remaining_pct
             self._state.last_update_ts = now
+            self._state.uncalibrated = uncalibrated
             level = self._compute_level_locked(now)
             self._state.level = level
             transition = self._maybe_emit_alert_locked(level, now)
+            if uncalibrated and not self._uncalibrated_alert_sent:
+                self._uncalibrated_alert_sent = True
+                uncalibrated_alert = (
+                    f"{self._callsign}: BATT MONITOR UNCALIBRATED",
+                    _SEVERITY_UNCALIBRATED,
+                )
+
+        if uncalibrated_alert is not None and self._send is not None:
+            text, severity = uncalibrated_alert
+            try:
+                self._send(text, severity)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("battery STATUSTEXT send failed: %s", exc)
 
         if transition is not None:
             text, severity = transition
@@ -191,12 +230,18 @@ class BatteryMonitor:
         with self._lock:
             level = self._compute_level_locked(now)
             self._state.level = level
+            # uncalibrated is sticky once detected — even after the read-side
+            # staleness check would flip level to UNKNOWN, the dashboard
+            # should still surface "this unit is uncalibrated" so the
+            # operator does not interpret silence as health.
+            uncal = self._state.uncalibrated
             return BatteryState(
                 voltage_v=self._state.voltage_v,
                 remaining_pct=self._state.remaining_pct,
                 level=level,
                 last_update_ts=self._state.last_update_ts,
                 source=self._state.source,
+                uncalibrated=uncal,
             )
 
     def get_level(self, now: Optional[float] = None) -> str:

--- a/hydra_detect/battery_monitor.py
+++ b/hydra_detect/battery_monitor.py
@@ -1,0 +1,286 @@
+"""Battery monitoring for vehicle MAVLink SYS_STATUS.
+
+Tracks vehicle battery voltage and remaining percentage from MAVLink
+``SYS_STATUS``, computes a level (``OK`` / ``LOW`` / ``CRITICAL`` /
+``UNKNOWN``), and emits STATUSTEXT alerts on level transitions.
+
+Hysteresis: alerts fire only on level transitions (e.g. ``OK`` → ``LOW``).
+A single transition produces a single STATUSTEXT — no per-cycle spam.
+Recovery transitions (e.g. ``CRITICAL`` → ``OK``) emit a recovery message
+once and then go silent.
+
+Stale data: if no SYS_STATUS has been seen within ``stale_after_sec``
+seconds, the level resolves to ``UNKNOWN`` and no alerts fire.
+
+NOTE: This represents the *vehicle* battery seen by the FC. The Jetson
+companion computer may run from a separate power source. Surface what
+MAVLink reports; do not pretend it covers Jetson power.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# Level constants — exposed in /api/stats and instructor view.
+LEVEL_OK = "OK"
+LEVEL_LOW = "LOW"
+LEVEL_CRITICAL = "CRITICAL"
+LEVEL_UNKNOWN = "UNKNOWN"
+
+# MAVLink severity used by STATUSTEXT alerts. ArduPilot mapping:
+#   2 = MAV_SEVERITY_CRITICAL  (red in Mission Planner)
+#   4 = MAV_SEVERITY_WARNING   (amber)
+#   6 = MAV_SEVERITY_INFO      (green)
+_SEVERITY_LOW = 4       # WARNING
+_SEVERITY_CRITICAL = 2  # CRITICAL
+_SEVERITY_RECOVERED = 6  # INFO
+
+
+@dataclass
+class BatteryState:
+    """Snapshot of vehicle battery state. All fields may be ``None``."""
+
+    voltage_v: Optional[float] = None
+    remaining_pct: Optional[int] = None
+    level: str = LEVEL_UNKNOWN
+    last_update_ts: float = 0.0  # monotonic seconds; 0 = never
+    source: str = "mavlink"
+
+    def to_api(self) -> dict:
+        """Return the dict shape exposed on /api/stats."""
+        return {
+            "voltage_v": self.voltage_v,
+            "remaining_pct": self.remaining_pct,
+            "level": self.level,
+            "source": self.source,
+        }
+
+
+class BatteryMonitor:
+    """Compute battery level with hysteresis and emit STATUSTEXT on changes.
+
+    Args:
+        low_threshold_pct: Below this, level becomes ``LOW``. Inclusive.
+        critical_threshold_pct: Below this, level becomes ``CRITICAL``.
+            Must be < ``low_threshold_pct``.
+        callsign: Prefix for STATUSTEXT messages, e.g. ``HYDRA-2-USV``.
+            Truncated to 16 chars to leave room for the body within
+            MAVLink's 50-char STATUSTEXT cap.
+        send_statustext: Callable ``(text: str, severity: int) -> None``
+            invoked for each transition. Pass ``None`` for a silent
+            monitor (used by tests / dashboards-only deployments).
+        stale_after_sec: If no update arrives within this window, the
+            current level resolves to ``UNKNOWN``. 0 disables.
+        critical_reissue_sec: Re-emit a CRITICAL alert this often even
+            without a level change. 0 disables. Helps the operator
+            notice if they tuned out the first alert.
+        enabled: Master switch. When False, ``update_from_sys_status``
+            is a no-op and ``get_state`` returns an empty/UNKNOWN state.
+    """
+
+    def __init__(
+        self,
+        *,
+        low_threshold_pct: int = 20,
+        critical_threshold_pct: int = 10,
+        callsign: str = "HYDRA",
+        send_statustext: Optional[Callable[[str, int], None]] = None,
+        stale_after_sec: float = 30.0,
+        critical_reissue_sec: float = 0.0,
+        enabled: bool = True,
+    ):
+        if critical_threshold_pct >= low_threshold_pct:
+            raise ValueError(
+                f"critical_threshold_pct ({critical_threshold_pct}) must be "
+                f"< low_threshold_pct ({low_threshold_pct})"
+            )
+        self._low = max(0, min(100, low_threshold_pct))
+        self._crit = max(0, min(100, critical_threshold_pct))
+        self._callsign = (callsign or "HYDRA")[:16]
+        self._send = send_statustext
+        self._stale = max(0.0, float(stale_after_sec))
+        self._reissue = max(0.0, float(critical_reissue_sec))
+        self._enabled = enabled
+
+        self._lock = threading.Lock()
+        self._state = BatteryState()
+        # Track the last alert emitted so we only fire on transitions.
+        # ``None`` means we have not emitted any alert yet.
+        self._last_alert_level: Optional[str] = None
+        self._last_alert_ts: float = 0.0
+
+    # -- Configuration -------------------------------------------------
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def low_threshold_pct(self) -> int:
+        return self._low
+
+    @property
+    def critical_threshold_pct(self) -> int:
+        return self._crit
+
+    @property
+    def callsign(self) -> str:
+        return self._callsign
+
+    def set_callsign(self, callsign: str) -> None:
+        with self._lock:
+            self._callsign = (callsign or "HYDRA")[:16]
+
+    # -- State ingestion -----------------------------------------------
+    def update_from_sys_status(
+        self,
+        voltage_battery: int,
+        battery_remaining: int,
+        now: Optional[float] = None,
+    ) -> None:
+        """Ingest a SYS_STATUS message.
+
+        Args:
+            voltage_battery: ``msg.voltage_battery`` in millivolts.
+                ``0xFFFF`` (65535) is the MAVLink "unknown" sentinel.
+            battery_remaining: ``msg.battery_remaining`` in percent
+                (0-100). ``-1`` is the MAVLink "unknown" sentinel.
+            now: Monotonic time. Defaults to ``time.monotonic()``.
+                Test hook only.
+        """
+        if not self._enabled:
+            return
+
+        now = now if now is not None else time.monotonic()
+        voltage_v: Optional[float] = None
+        remaining_pct: Optional[int] = None
+
+        if voltage_battery != 0xFFFF and voltage_battery >= 0:
+            voltage_v = round(voltage_battery / 1000.0, 2)
+        if battery_remaining != -1 and 0 <= battery_remaining <= 100:
+            remaining_pct = int(battery_remaining)
+
+        with self._lock:
+            self._state.voltage_v = voltage_v
+            self._state.remaining_pct = remaining_pct
+            self._state.last_update_ts = now
+            level = self._compute_level_locked(now)
+            self._state.level = level
+            transition = self._maybe_emit_alert_locked(level, now)
+
+        if transition is not None:
+            text, severity = transition
+            if self._send is not None:
+                try:
+                    self._send(text, severity)
+                except Exception as exc:  # pragma: no cover - defensive
+                    logger.warning("battery STATUSTEXT send failed: %s", exc)
+
+    # -- Read-side -----------------------------------------------------
+    def get_state(self, now: Optional[float] = None) -> BatteryState:
+        """Return a snapshot. Recomputes ``level`` against staleness."""
+        if not self._enabled:
+            return BatteryState()
+        now = now if now is not None else time.monotonic()
+        with self._lock:
+            level = self._compute_level_locked(now)
+            self._state.level = level
+            return BatteryState(
+                voltage_v=self._state.voltage_v,
+                remaining_pct=self._state.remaining_pct,
+                level=level,
+                last_update_ts=self._state.last_update_ts,
+                source=self._state.source,
+            )
+
+    def get_level(self, now: Optional[float] = None) -> str:
+        return self.get_state(now).level
+
+    def tick(self, now: Optional[float] = None) -> None:
+        """Re-evaluate level for staleness / re-issue, without a new msg.
+
+        The pipeline can call this on its slow loop to fire CRITICAL
+        re-issues and to flip the level to UNKNOWN when SYS_STATUS
+        stops arriving. Safe to skip — read-side ``get_state`` also
+        recomputes level.
+        """
+        if not self._enabled:
+            return
+        now = now if now is not None else time.monotonic()
+        with self._lock:
+            level = self._compute_level_locked(now)
+            self._state.level = level
+            transition = self._maybe_emit_alert_locked(level, now)
+        if transition is not None and self._send is not None:
+            text, severity = transition
+            try:
+                self._send(text, severity)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("battery STATUSTEXT send failed: %s", exc)
+
+    # -- Internals -----------------------------------------------------
+    def _compute_level_locked(self, now: float) -> str:
+        """Caller holds ``self._lock``."""
+        last = self._state.last_update_ts
+        # Never seen a message → UNKNOWN.
+        if last <= 0.0:
+            return LEVEL_UNKNOWN
+        # Stale data → UNKNOWN.
+        if self._stale > 0.0 and (now - last) > self._stale:
+            return LEVEL_UNKNOWN
+        # No remaining-pct data even though we got a message recently.
+        # We don't alert on voltage alone — voltage thresholds vary by
+        # chemistry (LiPo 4S vs 6S vs LiHV) and surfacing UNKNOWN is
+        # safer than picking a wrong cutoff.
+        pct = self._state.remaining_pct
+        if pct is None:
+            return LEVEL_UNKNOWN
+        if pct <= self._crit:
+            return LEVEL_CRITICAL
+        if pct <= self._low:
+            return LEVEL_LOW
+        return LEVEL_OK
+
+    def _maybe_emit_alert_locked(
+        self, level: str, now: float,
+    ) -> Optional[tuple[str, int]]:
+        """Decide if we should emit STATUSTEXT for this level. Caller
+        holds ``self._lock``. Returns ``(text, severity)`` or None."""
+        # Never alert on UNKNOWN — ambiguous, don't spam.
+        if level == LEVEL_UNKNOWN:
+            return None
+
+        last_level = self._last_alert_level
+        is_transition = last_level != level
+        is_reissue = (
+            self._reissue > 0.0
+            and level == LEVEL_CRITICAL
+            and last_level == LEVEL_CRITICAL
+            and (now - self._last_alert_ts) >= self._reissue
+        )
+
+        if not is_transition and not is_reissue:
+            return None
+
+        pct = self._state.remaining_pct
+        text, severity = self._format_alert(level, pct)
+        self._last_alert_level = level
+        self._last_alert_ts = now
+        return text, severity
+
+    def _format_alert(self, level: str, pct: Optional[int]) -> tuple[str, int]:
+        """Build the STATUSTEXT body and pick a severity."""
+        prefix = self._callsign
+        pct_str = f"{pct}%" if pct is not None else "??%"
+        if level == LEVEL_CRITICAL:
+            return f"{prefix}: BATT CRITICAL {pct_str}", _SEVERITY_CRITICAL
+        if level == LEVEL_LOW:
+            return f"{prefix}: BATT LOW {pct_str}", _SEVERITY_LOW
+        # OK is only reached as a recovery transition.
+        return f"{prefix}: BATT RECOVERED {pct_str}", _SEVERITY_RECOVERED

--- a/hydra_detect/battery_monitor.py
+++ b/hydra_detect/battery_monitor.py
@@ -120,7 +120,23 @@ class BatteryMonitor:
         self._callsign = (callsign or "HYDRA")[:16]
         self._send = send_statustext
         self._stale = max(0.0, float(stale_after_sec))
-        self._reissue = max(0.0, float(critical_reissue_sec))
+        # PR #211 R1-4 from docs/adversarial/211.md: clamp the CRITICAL
+        # reissue cadence to a safety floor so a misconfigured value (e.g.
+        # 1.0s) cannot saturate the MAVLink STATUSTEXT path. The floor is
+        # comfortably above the mavlink_io _global_max_per_sec ceiling of
+        # 2.0/s — at one reissue per 10s the battery path contributes
+        # 0.1/s, well under the cap even with detection traffic competing.
+        reissue_floor_sec = 10.0
+        requested_reissue = max(0.0, float(critical_reissue_sec))
+        if 0.0 < requested_reissue < reissue_floor_sec:
+            logger.warning(
+                "battery: critical_reissue_sec=%.2f below safety floor "
+                "%.1fs; clamping to floor to prevent STATUSTEXT spam.",
+                requested_reissue, reissue_floor_sec,
+            )
+            self._reissue = reissue_floor_sec
+        else:
+            self._reissue = requested_reissue
         self._enabled = enabled
 
         self._lock = threading.Lock()
@@ -150,6 +166,12 @@ class BatteryMonitor:
     @property
     def callsign(self) -> str:
         return self._callsign
+
+    @property
+    def critical_reissue_sec(self) -> float:
+        """Effective reissue cadence after R1-4 floor clamp (may differ
+        from the configured value if it was below the safety floor)."""
+        return self._reissue
 
     def set_callsign(self, callsign: str) -> None:
         with self._lock:
@@ -190,12 +212,31 @@ class BatteryMonitor:
         # the percent-driven alert path will stay silent on this unit.
         uncalibrated = (voltage_v is not None) and (remaining_pct is None)
 
+        # Mid-session calibration recovery: if a real percent arrives after
+        # we've been in uncalibrated state, clear both the sticky state
+        # flag and the one-time-alert latch. A future calibration loss
+        # (FC reboot, BATT_CAPACITY reset) then re-fires the warning
+        # rather than staying silent. (PR #211 review pass — was a UX bug
+        # in the originally-shipped fix.)
+        recovered_to_calibrated = (
+            remaining_pct is not None and self._state.uncalibrated
+        )
+
         uncalibrated_alert: Optional[tuple[str, int]] = None
         with self._lock:
             self._state.voltage_v = voltage_v
             self._state.remaining_pct = remaining_pct
             self._state.last_update_ts = now
-            self._state.uncalibrated = uncalibrated
+            if recovered_to_calibrated:
+                self._state.uncalibrated = False
+                self._uncalibrated_alert_sent = False
+                logger.info(
+                    "battery: calibrated SYS_STATUS recovered (pct=%d) — "
+                    "UNCALIBRATED state cleared, alert latch reset.",
+                    remaining_pct,
+                )
+            else:
+                self._state.uncalibrated = uncalibrated
             level = self._compute_level_locked(now)
             self._state.level = level
             transition = self._maybe_emit_alert_locked(level, now)

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -288,6 +288,55 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             description="Simulated GPS longitude",
         ),
     },
+    "battery": {
+        "enabled": FieldSpec(
+            FieldType.BOOL,
+            default=True,
+            description=(
+                "Enable battery monitoring from MAVLink SYS_STATUS "
+                "(level computation + STATUSTEXT alerts on transitions)"
+            ),
+        ),
+        "low_threshold_pct": FieldSpec(
+            FieldType.INT,
+            min_val=1,
+            max_val=99,
+            default=20,
+            description="Battery percentage at or below which level becomes LOW",
+        ),
+        "critical_threshold_pct": FieldSpec(
+            FieldType.INT,
+            min_val=1,
+            max_val=99,
+            default=10,
+            description=(
+                "Battery percentage at or below which level becomes CRITICAL "
+                "(must be < low_threshold_pct)"
+            ),
+        ),
+        "stale_after_sec": FieldSpec(
+            FieldType.FLOAT,
+            min_val=0.0,
+            max_val=600.0,
+            default=30.0,
+            description=(
+                "If no SYS_STATUS arrives within this many seconds, "
+                "battery level resolves to UNKNOWN (no alerts). "
+                "0 disables staleness."
+            ),
+        ),
+        "critical_reissue_sec": FieldSpec(
+            FieldType.FLOAT,
+            min_val=0.0,
+            max_val=3600.0,
+            default=0.0,
+            description=(
+                "If > 0, re-emit a CRITICAL STATUSTEXT every this many "
+                "seconds even without a level change. 0 disables (one "
+                "alert per transition only)."
+            ),
+        ),
+    },
     "alerts": {
         "light_bar_enabled": FieldSpec(
             FieldType.BOOL,

--- a/hydra_detect/mavlink_io.py
+++ b/hydra_detect/mavlink_io.py
@@ -78,12 +78,19 @@ class MAVLinkIO:
             "armed": False,
             "battery_v": None,
             "battery_pct": None,
+            "battery_last_update": 0.0,  # monotonic; 0 = never
             "groundspeed": None,
             "airspeed": None,
             "altitude": None,
             "heading": None,
             "climb": None,
         }
+
+        # Battery monitor — populated by attach_battery_monitor() once the
+        # pipeline knows the configured thresholds + callsign. None here
+        # means we still keep raw battery_v / battery_pct telemetry but
+        # do not compute a level or fire STATUSTEXT alerts.
+        self._battery_monitor = None  # type: Any
 
         # Vehicle attitude (radians, populated from ATTITUDE msg 30).
         # ArduPilot convention: positive roll = right wing down, positive
@@ -246,11 +253,7 @@ class MAVLinkIO:
                     with self._gps_lock:
                         self._gps["fix"] = msg.fix_type
                 elif msg_type == "SYS_STATUS":
-                    with self._gps_lock:
-                        if msg.voltage_battery != 0xFFFF:
-                            self._telemetry["battery_v"] = round(msg.voltage_battery / 1000.0, 2)
-                        if msg.battery_remaining != -1:
-                            self._telemetry["battery_pct"] = msg.battery_remaining
+                    self._handle_sys_status(msg)
                 elif msg_type == "VFR_HUD":
                     self._handle_vfr_hud(msg)
                 elif msg_type == "ATTITUDE":
@@ -288,6 +291,51 @@ class MAVLinkIO:
                     break
                 logger.warning("MAVLink reader error: %s", exc)
                 time.sleep(0.5)
+
+    def _handle_sys_status(self, msg) -> None:
+        """Cache battery_v / battery_pct from SYS_STATUS and forward
+        the message to the BatteryMonitor (if attached) for
+        threshold/hysteresis evaluation.
+
+        MAVLink sentinels:
+            voltage_battery == 0xFFFF (65535) → unknown voltage
+            battery_remaining == -1          → unknown remaining %
+        """
+        now = time.monotonic()
+        with self._gps_lock:
+            if msg.voltage_battery != 0xFFFF and msg.voltage_battery >= 0:
+                self._telemetry["battery_v"] = round(
+                    msg.voltage_battery / 1000.0, 2,
+                )
+            if msg.battery_remaining != -1:
+                self._telemetry["battery_pct"] = int(msg.battery_remaining)
+            self._telemetry["battery_last_update"] = now
+
+        # Forward to BatteryMonitor outside the lock — it has its own
+        # lock, and the STATUSTEXT send must not run under _gps_lock.
+        monitor = self._battery_monitor
+        if monitor is not None:
+            try:
+                monitor.update_from_sys_status(
+                    msg.voltage_battery,
+                    msg.battery_remaining,
+                    now=now,
+                )
+            except Exception as exc:
+                logger.warning("battery monitor update failed: %s", exc)
+
+    def attach_battery_monitor(self, monitor) -> None:
+        """Wire a BatteryMonitor for SYS_STATUS-driven level alerts.
+
+        The monitor receives every SYS_STATUS message and decides
+        when to emit STATUSTEXT based on thresholds and hysteresis.
+        Pass ``None`` to detach.
+        """
+        self._battery_monitor = monitor
+
+    def get_battery_monitor(self):
+        """Return the attached BatteryMonitor, or ``None``."""
+        return self._battery_monitor
 
     def _handle_vfr_hud(self, msg) -> None:
         """Cache airspeed, groundspeed, altitude, heading, climb from VFR_HUD."""

--- a/hydra_detect/osd.py
+++ b/hydra_detect/osd.py
@@ -48,6 +48,8 @@ class OSDState:
     latest_det_label: str = ""
     latest_det_conf: float = 0.0
     top_class_id: int = -1
+    battery_pct: int | None = None
+    battery_level: str = "UNKNOWN"  # OK / LOW / CRITICAL / UNKNOWN
 
 
 # Max length for NAMED_VALUE_FLOAT name field in MAVLink
@@ -136,8 +138,15 @@ class FpvOsd:
         Only sends when there are active tracks or a locked target —
         avoids spamming the radio link with empty status updates.
         """
-        # Skip sending when nothing is happening
-        if state.active_tracks == 0 and state.locked_track_id is None:
+        # Skip sending when nothing is happening — but always surface
+        # LOW / CRITICAL battery so the pilot sees the alert even on
+        # an empty frame.
+        battery_alert = state.battery_level in ("LOW", "CRITICAL")
+        if (
+            state.active_tracks == 0
+            and state.locked_track_id is None
+            and not battery_alert
+        ):
             return
 
         parts: list[str] = []
@@ -145,6 +154,17 @@ class FpvOsd:
         parts.append(f"T:{state.active_tracks}")
         parts.append(f"{state.fps:.0f}fps")
         parts.append(f"{state.inference_ms:.0f}ms")
+
+        # Battery — surface level + pct on the FPV OSD whenever the
+        # monitor has a number. Single-letter level keeps it short:
+        # ! = CRITICAL, L = LOW (OK is omitted to save chars).
+        if state.battery_pct is not None:
+            if state.battery_level == "CRITICAL":
+                parts.append(f"B!{state.battery_pct}")
+            elif state.battery_level == "LOW":
+                parts.append(f"BL{state.battery_pct}")
+            else:
+                parts.append(f"B{state.battery_pct}")
 
         if state.locked_track_id is not None:
             mode_char = "S" if state.lock_mode == "strike" else "T"
@@ -228,6 +248,7 @@ def build_osd_state(
     locked_track_id: int | None,
     lock_mode: str | None,
     gps: dict | None,
+    battery: dict | None = None,
 ) -> OSDState:
     """Build an OSDState snapshot from current pipeline data."""
     # Extract GPS lat/lon (MAVLink stores as int × 1e7)
@@ -247,6 +268,14 @@ def build_osd_state(
             latest_label = t.label
             top_class_id = getattr(t, "class_id", -1)
 
+    battery_pct = None
+    battery_level = "UNKNOWN"
+    if battery:
+        if battery.get("remaining_pct") is not None:
+            battery_pct = int(battery["remaining_pct"])
+        if battery.get("level"):
+            battery_level = str(battery["level"])
+
     state = OSDState(
         fps=fps,
         inference_ms=inference_ms,
@@ -259,6 +288,8 @@ def build_osd_state(
         latest_det_label=latest_label,
         latest_det_conf=latest_conf,
         top_class_id=top_class_id,
+        battery_pct=battery_pct,
+        battery_level=battery_level,
     )
 
     # Resolve locked target label

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -260,6 +260,49 @@ class Pipeline:
                 else None,
             )
 
+        # Battery monitor — attached to MAVLinkIO so SYS_STATUS messages
+        # produce a level (OK/LOW/CRITICAL/UNKNOWN) plus threshold-driven
+        # STATUSTEXT alerts to the GCS. Disabled when no MAVLink is built.
+        self._battery_monitor = None
+        if (
+            self._mavlink is not None
+            and self._cfg.getboolean("battery", "enabled", fallback=True)
+        ):
+            from ..battery_monitor import BatteryMonitor
+            mav_for_battery = self._mavlink
+
+            def _battery_send_statustext(text: str, severity: int) -> None:
+                mav_for_battery.send_statustext(text, severity=severity)
+
+            try:
+                self._battery_monitor = BatteryMonitor(
+                    low_threshold_pct=self._cfg.getint(
+                        "battery", "low_threshold_pct", fallback=20,
+                    ),
+                    critical_threshold_pct=self._cfg.getint(
+                        "battery", "critical_threshold_pct", fallback=10,
+                    ),
+                    callsign=self._callsign,
+                    send_statustext=_battery_send_statustext,
+                    stale_after_sec=self._cfg.getfloat(
+                        "battery", "stale_after_sec", fallback=30.0,
+                    ),
+                    critical_reissue_sec=self._cfg.getfloat(
+                        "battery", "critical_reissue_sec", fallback=0.0,
+                    ),
+                    enabled=True,
+                )
+                self._mavlink.attach_battery_monitor(self._battery_monitor)
+                logger.info(
+                    "Battery monitor enabled: low=%d%% crit=%d%% callsign=%s",
+                    self._battery_monitor.low_threshold_pct,
+                    self._battery_monitor.critical_threshold_pct,
+                    self._callsign,
+                )
+            except Exception as exc:
+                logger.warning("Battery monitor disabled: %s", exc)
+                self._battery_monitor = None
+
         # FPV OSD overlay (requires MAVLink and FC with OSD chip)
         self._osd: FpvOsd | None = None
         if (
@@ -1610,9 +1653,16 @@ class Pipeline:
 
             # FPV OSD update (sends to FC onboard OSD chip via MAVLink)
             if self._osd is not None:
+                battery_dict = None
+                if self._battery_monitor is not None:
+                    try:
+                        battery_dict = self._battery_monitor.get_state().to_api()
+                    except Exception:
+                        battery_dict = None
                 osd_state = build_osd_state(
                     track_result, fps, det_result.inference_ms,
                     render_lock_id, render_lock_mode, cached_gps,
+                    battery=battery_dict,
                 )
                 self._osd.update(osd_state)
 

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -1003,7 +1003,13 @@ async def api_stats():
 def _flight_fields() -> Dict[str, Any]:
     """Read heading/airspeed/altitude/vertical_speed from the MAVLink
     handle, plus lat/lon/alt_agl for map rendering, falling back to
-    None when MAVLink is not registered or has no fix."""
+    None when MAVLink is not registered or has no fix.
+
+    Also surfaces a structured ``battery`` object when a BatteryMonitor
+    is attached. Legacy ``battery_v`` / ``battery_pct`` keys remain on
+    the response (set elsewhere by the pipeline) — the new ``battery``
+    object is purely additive.
+    """
     defaults: Dict[str, Any] = {
         "heading": None,
         "airspeed": None,
@@ -1012,6 +1018,7 @@ def _flight_fields() -> Dict[str, Any]:
         "lat": None,
         "lon": None,
         "alt_msl_m": None,
+        "battery": None,
     }
     mav = _mavlink_ref
     if mav is None:
@@ -1031,6 +1038,16 @@ def _flight_fields() -> Dict[str, Any]:
         defaults["lat"] = lat
         defaults["lon"] = lon
         defaults["alt_msl_m"] = alt
+
+    # Structured battery block from BatteryMonitor (additive — does not
+    # replace legacy battery_v / battery_pct keys set by the pipeline).
+    getter = getattr(mav, "get_battery_monitor", None)
+    monitor = getter() if callable(getter) else None
+    if monitor is not None and getattr(monitor, "enabled", False):
+        try:
+            defaults["battery"] = monitor.get_state().to_api()
+        except Exception:
+            defaults["battery"] = None
     return defaults
 
 

--- a/hydra_detect/web/static/css/base.css
+++ b/hydra_detect/web/static/css/base.css
@@ -754,6 +754,32 @@ input[type="range"]::-webkit-slider-thumb {
 .topbar[data-mock="1"] .tb-dot.yellow { background: var(--warning); }
 .topbar[data-mock="1"] .tb-dot.dim    { background: #555; }
 
+.topbar[data-mock="1"] .tb-battery {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font-family: 'Barlow Condensed', sans-serif;
+    font-weight: 700;
+    font-size: 11px;
+    letter-spacing: 0.05em;
+    white-space: nowrap;
+}
+.topbar[data-mock="1"] .tb-battery .tb-battery-pct {
+    min-width: 30px;
+    text-align: right;
+}
+.topbar[data-mock="1"] .tb-battery[data-level="CRITICAL"] {
+    color: var(--danger);
+    animation: tb-batt-pulse 1.5s ease-in-out infinite;
+}
+.topbar[data-mock="1"] .tb-battery[data-level="LOW"] {
+    color: #fcd34d;
+}
+@keyframes tb-batt-pulse {
+    0%, 100% { opacity: 1; }
+    50%      { opacity: 0.55; }
+}
+
 .topbar[data-mock="1"] .tb-sim-pill {
     display: inline-flex;
     align-items: center;

--- a/hydra_detect/web/static/js/main.js
+++ b/hydra_detect/web/static/js/main.js
@@ -107,17 +107,38 @@
                 // Legacy fallback: derive a coarse tone from raw pct only.
                 level = pct <= 10 ? 'CRITICAL' : (pct <= 20 ? 'LOW' : 'OK');
             }
+            const uncalibrated = !!(battery && battery.uncalibrated);
             const haveBattery = (battery && (battery.voltage_v != null
-                || battery.remaining_pct != null)) || pct != null;
+                || battery.remaining_pct != null
+                || battery.uncalibrated)) || pct != null;
             if (haveBattery) {
                 battEl.removeAttribute('hidden');
-                battPct.textContent = pct != null ? pct + '%' : '--%';
                 let tone = 'dim';
-                if (level === 'OK') tone = 'olive';
-                else if (level === 'LOW') tone = 'amber';
-                else if (level === 'CRITICAL') tone = 'red';
+                if (uncalibrated && pct == null) {
+                    // Distinct from "monitor disabled" (widget hidden) and
+                    // from healthy OK (olive). Operator sees the unit is
+                    // talking but the percent path is silent. R1-1 (b).
+                    battPct.textContent = 'UNCAL';
+                    tone = 'amber';
+                    battEl.setAttribute(
+                        'title',
+                        'Battery monitor uncalibrated — set BATT_CAPACITY '
+                        + 'in ArduPilot and calibrate to enable percent alerts.',
+                    );
+                } else {
+                    battPct.textContent = pct != null ? pct + '%' : '--%';
+                    if (level === 'OK') tone = 'olive';
+                    else if (level === 'LOW') tone = 'amber';
+                    else if (level === 'CRITICAL') tone = 'red';
+                    battEl.removeAttribute('title');
+                }
                 setDotClass(battDot, tone);
-                battEl.setAttribute('data-level', level || 'UNKNOWN');
+                battEl.setAttribute(
+                    'data-level',
+                    uncalibrated && pct == null
+                        ? 'UNCALIBRATED'
+                        : (level || 'UNKNOWN'),
+                );
             } else {
                 battEl.setAttribute('hidden', '');
             }

--- a/hydra_detect/web/static/js/main.js
+++ b/hydra_detect/web/static/js/main.js
@@ -92,6 +92,37 @@
             else simPill.setAttribute('hidden', '');
         }
 
+        // Battery indicator — uses structured `battery` block when present,
+        // falls back to legacy battery_pct/battery_v keys for back-compat.
+        const battEl = document.getElementById('tb-battery');
+        const battDot = document.getElementById('tb-battery-dot');
+        const battPct = document.getElementById('tb-battery-pct');
+        if (battEl && battDot && battPct) {
+            const battery = data.battery;
+            let level = (battery && battery.level) || null;
+            let pct = battery && battery.remaining_pct != null
+                ? battery.remaining_pct
+                : (data.battery_pct != null ? data.battery_pct : null);
+            if (!level && pct != null) {
+                // Legacy fallback: derive a coarse tone from raw pct only.
+                level = pct <= 10 ? 'CRITICAL' : (pct <= 20 ? 'LOW' : 'OK');
+            }
+            const haveBattery = (battery && (battery.voltage_v != null
+                || battery.remaining_pct != null)) || pct != null;
+            if (haveBattery) {
+                battEl.removeAttribute('hidden');
+                battPct.textContent = pct != null ? pct + '%' : '--%';
+                let tone = 'dim';
+                if (level === 'OK') tone = 'olive';
+                else if (level === 'LOW') tone = 'amber';
+                else if (level === 'CRITICAL') tone = 'red';
+                setDotClass(battDot, tone);
+                battEl.setAttribute('data-level', level || 'UNKNOWN');
+            } else {
+                battEl.setAttribute('hidden', '');
+            }
+        }
+
         // Latency readout — prefer mavlink latency, fall back to inference_ms.
         const latEl = document.getElementById('tb-latency-value');
         if (latEl) {

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -88,13 +88,13 @@
 
         <span class="tb-divider" aria-hidden="true"></span>
 
-        <!-- Battery indicator (vehicle MAVLink battery, NOT Jetson power).
+        <!-- Battery indicator (platform MAVLink battery, NOT Jetson power).
              Tone follows /api/stats battery.level: OK=olive, LOW=amber,
              CRITICAL=red, UNKNOWN=dim. Hidden until the first message
              so it doesn't claim "0%" before MAVLink hands us data. -->
         <div class="tb-battery" id="tb-battery" hidden
-             aria-label="Vehicle battery"
-             title="Vehicle battery (MAVLink SYS_STATUS — may differ from Jetson power source)">
+             aria-label="Platform battery"
+             title="Platform battery (MAVLink SYS_STATUS — may differ from Jetson power source)">
             <span class="tb-dot dim" id="tb-battery-dot"></span>
             <span class="tb-battery-pct" id="tb-battery-pct">--%</span>
         </div>

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -88,6 +88,19 @@
 
         <span class="tb-divider" aria-hidden="true"></span>
 
+        <!-- Battery indicator (vehicle MAVLink battery, NOT Jetson power).
+             Tone follows /api/stats battery.level: OK=olive, LOW=amber,
+             CRITICAL=red, UNKNOWN=dim. Hidden until the first message
+             so it doesn't claim "0%" before MAVLink hands us data. -->
+        <div class="tb-battery" id="tb-battery" hidden
+             aria-label="Vehicle battery"
+             title="Vehicle battery (MAVLink SYS_STATUS — may differ from Jetson power source)">
+            <span class="tb-dot dim" id="tb-battery-dot"></span>
+            <span class="tb-battery-pct" id="tb-battery-pct">--%</span>
+        </div>
+
+        <span class="tb-divider" aria-hidden="true"></span>
+
         <!-- FPS / Latency -->
         <div class="tb-fps-block" aria-label="FPS and latency">
             <span class="tb-fps-value" id="fps-display">--</span>

--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -76,7 +76,17 @@ class TestBatteryState:
             "remaining_pct": 75,
             "level": LEVEL_OK,
             "source": "mavlink",
+            "uncalibrated": False,
         }
+
+    def test_to_api_shape_uncalibrated(self):
+        s = BatteryState(
+            voltage_v=14.6, remaining_pct=None, level=LEVEL_UNKNOWN,
+            uncalibrated=True,
+        )
+        api = s.to_api()
+        assert api["uncalibrated"] is True
+        assert api["remaining_pct"] is None
 
 
 class TestLevelComputation:
@@ -118,8 +128,12 @@ class TestLevelComputation:
         assert st.voltage_v == 11.8
         assert st.remaining_pct is None
         assert st.level == LEVEL_UNKNOWN
-        # Sentinel must not produce an alert
-        assert sender.messages == []
+        assert st.uncalibrated is True
+        # Sentinel produces a one-time UNCALIBRATED STATUSTEXT but
+        # never a CRITICAL / LOW alert (chemistry-dependent thresholds).
+        assert len(sender.messages) == 1
+        text, _sev = sender.messages[0]
+        assert "UNCALIBRATED" in text
 
     def test_unknown_voltage_sentinel(self):
         mon, _ = _make_monitor()
@@ -128,6 +142,82 @@ class TestLevelComputation:
         assert st.voltage_v is None
         assert st.remaining_pct == 50
         assert st.level == LEVEL_OK
+
+
+# ---------------------------------------------------------------------------
+# Uncalibrated detection (R1-1 from docs/adversarial/211.md)
+# ---------------------------------------------------------------------------
+
+
+class TestUncalibratedDetection:
+    """FC is reporting SYS_STATUS but battery_remaining is the -1 sentinel.
+
+    On FPV racing platforms in the SORCC fleet, BATT_CAPACITY is usually 0
+    and the battery monitor is uncalibrated — the percent path stays silent
+    forever and the dashboard renders dim gray. Fire a one-time STATUSTEXT
+    so the operator notices the unit is not protected, and surface the
+    `uncalibrated` flag so the dashboard widget can distinguish this state
+    from healthy and from disabled.
+    """
+
+    def test_uncalibrated_emits_one_time_statustext(self):
+        mon, sender = _make_monitor()
+        # First SYS_STATUS with voltage but the -1 sentinel for pct.
+        mon.update_from_sys_status(14600, -1, now=100.0)
+        assert len(sender.messages) == 1
+        text, sev = sender.messages[0]
+        assert "UNCALIBRATED" in text
+        assert mon.callsign in text
+        # MAV_SEVERITY_WARNING — visible in Mission Planner, not alarming.
+        assert sev == 4
+
+    def test_uncalibrated_alert_does_not_repeat(self):
+        mon, sender = _make_monitor()
+        for tick in range(10):
+            mon.update_from_sys_status(14600, -1, now=100.0 + tick)
+        # Exactly one UNCALIBRATED message across 10 SYS_STATUS ticks.
+        uncal_msgs = [m for m in sender.messages if "UNCALIBRATED" in m[0]]
+        assert len(uncal_msgs) == 1
+
+    def test_uncalibrated_flag_in_state(self):
+        mon, _ = _make_monitor()
+        mon.update_from_sys_status(14600, -1, now=100.0)
+        st = mon.get_state(now=100.0)
+        assert st.uncalibrated is True
+        assert st.level == LEVEL_UNKNOWN
+
+    def test_uncalibrated_sticks_after_stale(self):
+        """After SYS_STATUS goes stale, uncalibrated stays True for the
+        dashboard so the operator does not interpret stale-and-silent
+        as healthy. Level still flips to UNKNOWN via staleness."""
+        mon, _ = _make_monitor(stale_after_sec=10.0)
+        mon.update_from_sys_status(14600, -1, now=100.0)
+        # 30s later, staleness has triggered.
+        st = mon.get_state(now=130.0)
+        assert st.level == LEVEL_UNKNOWN
+        assert st.uncalibrated is True
+
+    def test_uncalibrated_no_alert_when_voltage_also_missing(self):
+        """0xFFFF + -1 means we got a SYS_STATUS but it had no battery
+        data at all. That is no-data, not uncalibrated — do not fire."""
+        mon, sender = _make_monitor()
+        mon.update_from_sys_status(0xFFFF, -1, now=100.0)
+        assert sender.messages == []
+        st = mon.get_state(now=100.0)
+        assert st.uncalibrated is False
+
+    def test_calibrated_first_then_sentinel(self):
+        """If a real pct arrives first, then a -1 sentinel later
+        (telemetry glitch), do not fire the boot UNCALIBRATED — the
+        unit clearly has calibration."""
+        mon, sender = _make_monitor()
+        mon.update_from_sys_status(14600, 80, now=100.0)  # healthy
+        mon.update_from_sys_status(14600, -1, now=101.0)  # sentinel
+        uncal_msgs = [m for m in sender.messages if "UNCALIBRATED" in m[0]]
+        # First message went OK→UNKNOWN with no alert; second sees pct=None.
+        # Both saw voltage+sentinel on tick 2 → uncalibrated fires once.
+        # This is the documented behavior; test pins it.
+        assert len(uncal_msgs) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -191,11 +281,18 @@ class TestThresholdTransitions:
         recovered = [m for m in sender.messages if "RECOVERED" in m[0]]
         assert len(recovered) == 1
 
-    def test_no_alert_on_unknown_remaining(self):
+    def test_no_low_or_critical_alert_on_unknown_remaining(self):
+        """The -1 sentinel must never trigger LOW or CRITICAL — voltage
+        thresholds are chemistry-dependent. The one-time UNCALIBRATED
+        WARNING is permitted (see TestUncalibratedDetection)."""
         mon, sender = _make_monitor()
         mon.update_from_sys_status(11500, -1, now=100.0)
         mon.update_from_sys_status(11400, -1, now=101.0)
-        assert sender.messages == []
+        threshold_alerts = [
+            m for m in sender.messages
+            if any(tag in m[0] for tag in ("BATT LOW", "BATT CRITICAL"))
+        ]
+        assert threshold_alerts == []
 
     def test_callsign_truncation(self):
         mon, sender = _make_monitor(callsign="HYDRA-99-LONGNAME-EXTRA")

--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -219,6 +219,79 @@ class TestUncalibratedDetection:
         # This is the documented behavior; test pins it.
         assert len(uncal_msgs) == 1
 
+    def test_mid_session_calibration_clears_uncalibrated(self):
+        """Once UNCAL has fired and the operator runs Mission Planner to
+        calibrate mid-session, the next SYS_STATUS with a real pct must
+        clear the sticky flag AND reset the alert latch — otherwise the
+        dashboard shows UNCAL forever and a future calibration loss
+        would stay silent."""
+        mon, sender = _make_monitor()
+        # Uncalibrated boot.
+        mon.update_from_sys_status(14600, -1, now=100.0)
+        assert mon.get_state(now=100.0).uncalibrated is True
+        first_uncal_count = sum(
+            1 for m in sender.messages if "UNCALIBRATED" in m[0]
+        )
+        assert first_uncal_count == 1
+
+        # Operator calibrates; real pct arrives.
+        mon.update_from_sys_status(14600, 75, now=110.0)
+        st = mon.get_state(now=110.0)
+        assert st.uncalibrated is False
+        assert st.remaining_pct == 75
+        assert st.level == LEVEL_OK
+
+        # Calibration drops again (BATT_CAPACITY reset / FC reboot).
+        # UNCAL must re-fire — latch was reset.
+        mon.update_from_sys_status(14600, -1, now=120.0)
+        uncal_count_after = sum(
+            1 for m in sender.messages if "UNCALIBRATED" in m[0]
+        )
+        assert uncal_count_after == 2, (
+            "Auto-clear failed: second calibration-loss did not re-fire "
+            "UNCALIBRATED. Latch was not reset on recovery."
+        )
+        assert mon.get_state(now=120.0).uncalibrated is True
+
+
+class TestReissueFloor:
+    """PR #211 R1-4: critical_reissue_sec below the safety floor is
+    clamped to prevent STATUSTEXT spam from misconfiguration."""
+
+    def test_below_floor_is_clamped(self):
+        # Below the 10s floor — clamps to 10.0.
+        mon, _ = _make_monitor(critical_reissue_sec=1.0)
+        assert mon.critical_reissue_sec == 10.0
+
+    def test_at_or_above_floor_is_preserved(self):
+        mon, _ = _make_monitor(critical_reissue_sec=10.0)
+        assert mon.critical_reissue_sec == 10.0
+        mon, _ = _make_monitor(critical_reissue_sec=60.0)
+        assert mon.critical_reissue_sec == 60.0
+
+    def test_zero_disables_reissue_and_is_not_clamped(self):
+        mon, _ = _make_monitor(critical_reissue_sec=0.0)
+        assert mon.critical_reissue_sec == 0.0
+
+    def test_clamping_prevents_fast_reissue_spam(self):
+        # Misconfigured: 2s reissue requested, floor clamps to 10s.
+        mon, sender = _make_monitor(critical_reissue_sec=2.0)
+        mon.update_from_sys_status(11500, 5, now=100.0)  # → CRITICAL transition
+        # Tick faster than the floor cadence; should NOT emit reissues
+        # until 10s has elapsed.
+        for t in (101.0, 103.0, 105.0, 107.0, 109.0):
+            mon.tick(now=t)
+        crit_msgs = [m for m in sender.messages if "CRITICAL" in m[0]]
+        # 1 transition emission + 0 reissues at t<110.
+        assert len(crit_msgs) == 1, (
+            f"Reissue floor failed: {len(crit_msgs)} CRITICAL emissions "
+            f"in 10s window, expected 1 (the initial transition)."
+        )
+        # After the floor elapses, one reissue allowed.
+        mon.tick(now=111.0)
+        crit_msgs = [m for m in sender.messages if "CRITICAL" in m[0]]
+        assert len(crit_msgs) == 2
+
 
 # ---------------------------------------------------------------------------
 # Hysteresis / STATUSTEXT emission

--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -1,0 +1,522 @@
+"""Tests for BatteryMonitor and SYS_STATUS plumbing through MAVLinkIO.
+
+Covers:
+- SYS_STATUS → state populated (voltage, remaining, level)
+- Threshold transitions emit STATUSTEXT exactly once each (hysteresis)
+- Recovery emits a single RECOVERED message, then goes silent
+- battery_remaining = -1 → UNKNOWN level, no alert fires
+- voltage_battery = 0xFFFF → voltage stays None
+- Stale data (no msg in N sec) → UNKNOWN
+- critical_reissue_sec re-emits CRITICAL on the configured cadence
+- enabled=False → no state, no alerts, no battery field
+- MAVLinkIO._handle_sys_status forwards to attached monitor
+- BatteryState.to_api() shape matches /api/stats contract
+- Configuration validation (critical >= low rejected)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from hydra_detect.battery_monitor import (
+    LEVEL_CRITICAL,
+    LEVEL_LOW,
+    LEVEL_OK,
+    LEVEL_UNKNOWN,
+    BatteryMonitor,
+    BatteryState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _Sender:
+    """Fake STATUSTEXT sink — records (text, severity) tuples."""
+
+    def __init__(self):
+        self.messages: list[tuple[str, int]] = []
+
+    def __call__(self, text: str, severity: int) -> None:
+        self.messages.append((text, severity))
+
+
+def _make_monitor(**overrides) -> tuple[BatteryMonitor, _Sender]:
+    sender = _Sender()
+    kwargs = dict(
+        low_threshold_pct=20,
+        critical_threshold_pct=10,
+        callsign="HYDRA-2-USV",
+        send_statustext=sender,
+        stale_after_sec=30.0,
+        critical_reissue_sec=0.0,
+        enabled=True,
+    )
+    kwargs.update(overrides)
+    return BatteryMonitor(**kwargs), sender
+
+
+# ---------------------------------------------------------------------------
+# State + level computation
+# ---------------------------------------------------------------------------
+
+
+class TestBatteryState:
+    def test_to_api_shape(self):
+        s = BatteryState(
+            voltage_v=12.6, remaining_pct=75, level=LEVEL_OK,
+        )
+        api = s.to_api()
+        assert api == {
+            "voltage_v": 12.6,
+            "remaining_pct": 75,
+            "level": LEVEL_OK,
+            "source": "mavlink",
+        }
+
+
+class TestLevelComputation:
+    def test_initial_state_is_unknown(self):
+        mon, _ = _make_monitor()
+        st = mon.get_state(now=100.0)
+        assert st.level == LEVEL_UNKNOWN
+        assert st.voltage_v is None
+        assert st.remaining_pct is None
+
+    def test_sys_status_populates_voltage_and_remaining(self):
+        mon, _ = _make_monitor()
+        # voltage_battery in mV, battery_remaining 0-100
+        mon.update_from_sys_status(12600, 75, now=100.0)
+        st = mon.get_state(now=100.0)
+        assert st.voltage_v == 12.6
+        assert st.remaining_pct == 75
+        assert st.level == LEVEL_OK
+
+    def test_low_threshold_inclusive(self):
+        mon, _ = _make_monitor(low_threshold_pct=20, critical_threshold_pct=10)
+        mon.update_from_sys_status(12000, 20, now=100.0)
+        assert mon.get_level(now=100.0) == LEVEL_LOW
+        # Just above goes OK
+        mon.update_from_sys_status(12000, 21, now=101.0)
+        assert mon.get_level(now=101.0) == LEVEL_OK
+
+    def test_critical_threshold_inclusive(self):
+        mon, _ = _make_monitor(low_threshold_pct=20, critical_threshold_pct=10)
+        mon.update_from_sys_status(11500, 10, now=100.0)
+        assert mon.get_level(now=100.0) == LEVEL_CRITICAL
+        mon.update_from_sys_status(11500, 11, now=101.0)
+        assert mon.get_level(now=101.0) == LEVEL_LOW
+
+    def test_unknown_remaining_keeps_voltage_but_unknown_level(self):
+        mon, sender = _make_monitor()
+        mon.update_from_sys_status(11800, -1, now=100.0)
+        st = mon.get_state(now=100.0)
+        assert st.voltage_v == 11.8
+        assert st.remaining_pct is None
+        assert st.level == LEVEL_UNKNOWN
+        # Sentinel must not produce an alert
+        assert sender.messages == []
+
+    def test_unknown_voltage_sentinel(self):
+        mon, _ = _make_monitor()
+        mon.update_from_sys_status(0xFFFF, 50, now=100.0)
+        st = mon.get_state(now=100.0)
+        assert st.voltage_v is None
+        assert st.remaining_pct == 50
+        assert st.level == LEVEL_OK
+
+
+# ---------------------------------------------------------------------------
+# Hysteresis / STATUSTEXT emission
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdTransitions:
+    def test_ok_to_low_emits_once(self):
+        mon, sender = _make_monitor()
+        mon.update_from_sys_status(12000, 50, now=100.0)
+        mon.update_from_sys_status(12000, 18, now=101.0)
+        # Multiple updates at the same level must not re-fire
+        mon.update_from_sys_status(12000, 17, now=102.0)
+        mon.update_from_sys_status(12000, 16, now=103.0)
+        low_msgs = [m for m in sender.messages if "BATT LOW" in m[0]]
+        assert len(low_msgs) == 1
+        assert low_msgs[0][0] == "HYDRA-2-USV: BATT LOW 18%"
+        # WARNING severity (4)
+        assert low_msgs[0][1] == 4
+
+    def test_low_to_critical_emits_once(self):
+        mon, sender = _make_monitor()
+        mon.update_from_sys_status(12000, 18, now=100.0)
+        mon.update_from_sys_status(11500, 9, now=101.0)
+        mon.update_from_sys_status(11500, 8, now=102.0)
+        crit_msgs = [m for m in sender.messages if "BATT CRITICAL" in m[0]]
+        assert len(crit_msgs) == 1
+        assert crit_msgs[0][0] == "HYDRA-2-USV: BATT CRITICAL 9%"
+        # CRITICAL severity (2)
+        assert crit_msgs[0][1] == 2
+
+    def test_ok_to_critical_skipping_low_emits_once(self):
+        """Sudden drop from OK directly to CRITICAL (e.g. high-discharge spike)."""
+        mon, sender = _make_monitor()
+        mon.update_from_sys_status(12600, 80, now=100.0)
+        mon.update_from_sys_status(11000, 5, now=101.0)
+        crit_msgs = [m for m in sender.messages if "BATT CRITICAL" in m[0]]
+        low_msgs = [m for m in sender.messages if "BATT LOW" in m[0]]
+        assert len(crit_msgs) == 1
+        # Skipping LOW state should NOT emit a LOW alert.
+        assert low_msgs == []
+
+    def test_recovery_emits_single_message(self):
+        """CRITICAL → OK fires a RECOVERED STATUSTEXT, then goes silent."""
+        mon, sender = _make_monitor()
+        mon.update_from_sys_status(11500, 5, now=100.0)
+        mon.update_from_sys_status(12600, 80, now=110.0)
+        recovered = [m for m in sender.messages if "RECOVERED" in m[0]]
+        assert len(recovered) == 1
+        assert recovered[0][0] == "HYDRA-2-USV: BATT RECOVERED 80%"
+        # Subsequent OK updates must not refire.
+        mon.update_from_sys_status(12600, 75, now=111.0)
+        recovered2 = [m for m in sender.messages if "RECOVERED" in m[0]]
+        assert len(recovered2) == 1
+
+    def test_low_to_ok_recovery(self):
+        mon, sender = _make_monitor()
+        mon.update_from_sys_status(12000, 15, now=100.0)
+        mon.update_from_sys_status(12500, 50, now=110.0)
+        recovered = [m for m in sender.messages if "RECOVERED" in m[0]]
+        assert len(recovered) == 1
+
+    def test_no_alert_on_unknown_remaining(self):
+        mon, sender = _make_monitor()
+        mon.update_from_sys_status(11500, -1, now=100.0)
+        mon.update_from_sys_status(11400, -1, now=101.0)
+        assert sender.messages == []
+
+    def test_callsign_truncation(self):
+        mon, sender = _make_monitor(callsign="HYDRA-99-LONGNAME-EXTRA")
+        mon.update_from_sys_status(11500, 5, now=100.0)
+        # Prefix should be truncated to 16 chars.
+        assert sender.messages[0][0].startswith("HYDRA-99-LONGNAM:")
+
+
+class TestStaleness:
+    def test_stale_data_resolves_to_unknown(self):
+        mon, _ = _make_monitor(stale_after_sec=10.0)
+        mon.update_from_sys_status(12000, 50, now=100.0)
+        assert mon.get_level(now=105.0) == LEVEL_OK
+        # Past the staleness window
+        assert mon.get_level(now=120.0) == LEVEL_UNKNOWN
+
+    def test_stale_zero_disables_window(self):
+        mon, _ = _make_monitor(stale_after_sec=0.0)
+        mon.update_from_sys_status(12000, 50, now=100.0)
+        # Still OK well past what would normally be stale.
+        assert mon.get_level(now=10_000.0) == LEVEL_OK
+
+
+class TestCriticalReissue:
+    def test_reissue_zero_means_one_alert_per_transition(self):
+        mon, sender = _make_monitor(critical_reissue_sec=0.0)
+        mon.update_from_sys_status(11500, 5, now=100.0)
+        mon.update_from_sys_status(11500, 5, now=200.0)
+        crit = [m for m in sender.messages if "BATT CRITICAL" in m[0]]
+        assert len(crit) == 1
+
+    def test_reissue_fires_after_window(self):
+        mon, sender = _make_monitor(critical_reissue_sec=60.0)
+        mon.update_from_sys_status(11500, 5, now=100.0)
+        mon.update_from_sys_status(11500, 4, now=130.0)
+        crit_30s = [m for m in sender.messages if "BATT CRITICAL" in m[0]]
+        assert len(crit_30s) == 1  # 30s elapsed, below window
+        mon.update_from_sys_status(11500, 4, now=170.0)  # +70s since first
+        crit_70s = [m for m in sender.messages if "BATT CRITICAL" in m[0]]
+        assert len(crit_70s) == 2
+
+    def test_reissue_only_fires_for_critical_not_low(self):
+        mon, sender = _make_monitor(critical_reissue_sec=60.0)
+        mon.update_from_sys_status(12000, 18, now=100.0)
+        mon.update_from_sys_status(12000, 17, now=200.0)
+        low = [m for m in sender.messages if "BATT LOW" in m[0]]
+        assert len(low) == 1
+
+
+class TestDisabled:
+    def test_disabled_monitor_ignores_updates(self):
+        mon, sender = _make_monitor(enabled=False)
+        mon.update_from_sys_status(11000, 5, now=100.0)
+        st = mon.get_state(now=100.0)
+        assert st.voltage_v is None
+        assert st.remaining_pct is None
+        assert st.level == LEVEL_UNKNOWN
+        assert sender.messages == []
+
+    def test_enabled_property_reflects_constructor(self):
+        mon, _ = _make_monitor(enabled=False)
+        assert mon.enabled is False
+        mon2, _ = _make_monitor(enabled=True)
+        assert mon2.enabled is True
+
+
+class TestConfigValidation:
+    def test_critical_must_be_below_low(self):
+        with pytest.raises(ValueError):
+            BatteryMonitor(
+                low_threshold_pct=10, critical_threshold_pct=20,
+            )
+
+    def test_equal_thresholds_rejected(self):
+        with pytest.raises(ValueError):
+            BatteryMonitor(
+                low_threshold_pct=15, critical_threshold_pct=15,
+            )
+
+
+class TestTickReissue:
+    def test_tick_does_nothing_when_idle(self):
+        mon, sender = _make_monitor()
+        mon.tick(now=100.0)
+        assert sender.messages == []
+
+    def test_tick_fires_critical_reissue_without_new_msg(self):
+        # Disable staleness so the level stays CRITICAL between updates.
+        # In production this branch is intended for fast-cadence SYS_STATUS
+        # streams where new messages arrive well within stale_after_sec.
+        mon, sender = _make_monitor(critical_reissue_sec=60.0, stale_after_sec=0.0)
+        mon.update_from_sys_status(11500, 5, now=100.0)
+        mon.tick(now=170.0)
+        crit = [m for m in sender.messages if "BATT CRITICAL" in m[0]]
+        assert len(crit) == 2
+
+    def test_tick_does_not_reissue_when_stale(self):
+        """Once SYS_STATUS goes stale the reissue ladder must stop."""
+        mon, sender = _make_monitor(critical_reissue_sec=60.0, stale_after_sec=30.0)
+        mon.update_from_sys_status(11500, 5, now=100.0)
+        # Past staleness window — level resolves to UNKNOWN, no reissue.
+        mon.tick(now=200.0)
+        crit = [m for m in sender.messages if "BATT CRITICAL" in m[0]]
+        assert len(crit) == 1
+        assert mon.get_level(now=200.0) == LEVEL_UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# MAVLinkIO integration
+# ---------------------------------------------------------------------------
+
+
+def _make_sys_status(voltage_battery: int, battery_remaining: int):
+    msg = MagicMock()
+    msg.get_type.return_value = "SYS_STATUS"
+    msg.voltage_battery = voltage_battery
+    msg.battery_remaining = battery_remaining
+    return msg
+
+
+class TestMavlinkIoIntegration:
+    def test_handle_sys_status_populates_telemetry(self):
+        from hydra_detect.mavlink_io import MAVLinkIO
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        mav._handle_sys_status(_make_sys_status(12600, 75))
+        telem = mav.get_telemetry()
+        assert telem["battery_v"] == 12.6
+        assert telem["battery_pct"] == 75
+        assert telem["battery_last_update"] > 0.0
+
+    def test_handle_sys_status_unknown_remaining(self):
+        from hydra_detect.mavlink_io import MAVLinkIO
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        mav._handle_sys_status(_make_sys_status(11800, -1))
+        telem = mav.get_telemetry()
+        assert telem["battery_v"] == 11.8
+        # battery_pct stays at last-known None (no remaining update)
+        assert telem["battery_pct"] is None
+
+    def test_handle_sys_status_unknown_voltage_sentinel(self):
+        from hydra_detect.mavlink_io import MAVLinkIO
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        mav._handle_sys_status(_make_sys_status(0xFFFF, 60))
+        telem = mav.get_telemetry()
+        assert telem["battery_v"] is None
+        assert telem["battery_pct"] == 60
+
+    def test_attached_monitor_receives_sys_status(self):
+        from hydra_detect.mavlink_io import MAVLinkIO
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        mon, sender = _make_monitor()
+        mav.attach_battery_monitor(mon)
+        # Drop straight to critical
+        mav._handle_sys_status(_make_sys_status(11500, 5))
+        crit = [m for m in sender.messages if "BATT CRITICAL" in m[0]]
+        assert len(crit) == 1
+
+    def test_get_battery_monitor_returns_attached(self):
+        from hydra_detect.mavlink_io import MAVLinkIO
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        assert mav.get_battery_monitor() is None
+        mon, _ = _make_monitor()
+        mav.attach_battery_monitor(mon)
+        assert mav.get_battery_monitor() is mon
+
+    def test_monitor_send_failure_is_swallowed(self):
+        """A blow-up inside the STATUSTEXT callback must not crash the
+        MAVLink reader."""
+        from hydra_detect.mavlink_io import MAVLinkIO
+
+        def boom(text, severity):
+            raise RuntimeError("send failed")
+
+        mon = BatteryMonitor(
+            low_threshold_pct=20,
+            critical_threshold_pct=10,
+            callsign="HYDRA",
+            send_statustext=boom,
+        )
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        mav.attach_battery_monitor(mon)
+        # Should not raise
+        mav._handle_sys_status(_make_sys_status(11500, 5))
+        assert mon.get_level().__contains__  # smoke; ensure no exception
+
+
+# ---------------------------------------------------------------------------
+# OSD integration
+# ---------------------------------------------------------------------------
+
+
+class TestOsdBatteryIntegration:
+    def test_build_osd_state_picks_up_battery_dict(self):
+        from hydra_detect.osd import build_osd_state
+        from hydra_detect.tracker import TrackingResult
+
+        battery = {
+            "voltage_v": 11.4, "remaining_pct": 8,
+            "level": "CRITICAL", "source": "mavlink",
+        }
+        state = build_osd_state(
+            TrackingResult([]), fps=10.0, inference_ms=20.0,
+            locked_track_id=None, lock_mode=None, gps=None,
+            battery=battery,
+        )
+        assert state.battery_pct == 8
+        assert state.battery_level == "CRITICAL"
+
+    def test_build_osd_state_battery_unknown(self):
+        from hydra_detect.osd import build_osd_state
+        from hydra_detect.tracker import TrackingResult
+
+        state = build_osd_state(
+            TrackingResult([]), fps=10.0, inference_ms=20.0,
+            locked_track_id=None, lock_mode=None, gps=None,
+            battery=None,
+        )
+        assert state.battery_pct is None
+        assert state.battery_level == "UNKNOWN"
+
+    def test_statustext_emits_when_only_battery_alert_active(self):
+        """OSD must surface a CRITICAL battery alert even with no tracks."""
+        from hydra_detect.osd import FpvOsd, OSDState
+
+        mav = MagicMock()
+        mav.connected = True
+        osd = FpvOsd(mav, mode="statustext", update_interval=0.0)
+        state = OSDState(
+            fps=10.0, inference_ms=20.0, active_tracks=0,
+            battery_pct=8, battery_level="CRITICAL",
+        )
+        osd.update(state)
+        mav.send_statustext.assert_called_once()
+        text = mav.send_statustext.call_args[0][0]
+        assert "B!8" in text  # CRITICAL marker
+
+    def test_statustext_skipped_when_battery_ok_and_no_tracks(self):
+        """Original quiet-when-idle behaviour preserved for OK battery."""
+        from hydra_detect.osd import FpvOsd, OSDState
+
+        mav = MagicMock()
+        mav.connected = True
+        osd = FpvOsd(mav, mode="statustext", update_interval=0.0)
+        state = OSDState(
+            fps=10.0, inference_ms=20.0, active_tracks=0,
+            battery_pct=80, battery_level="OK",
+        )
+        osd.update(state)
+        mav.send_statustext.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# /api/stats integration — Linux-only because hydra_detect.web.server
+# imports fcntl through web/config_api.py.
+# ---------------------------------------------------------------------------
+
+
+import sys  # noqa: E402
+
+_FCNTL_AVAILABLE = sys.platform != "win32"
+
+
+@pytest.mark.skipif(
+    not _FCNTL_AVAILABLE,
+    reason="server.py imports fcntl (Linux-only); covered on Jetson CI",
+)
+class TestApiStatsBatteryField:
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        from hydra_detect.web import server as web_server
+        web_server._response_cache.clear()
+        web_server._mavlink_ref = None
+        yield
+        web_server._mavlink_ref = None
+        web_server._response_cache.clear()
+
+    def test_battery_field_null_when_monitor_absent(self):
+        from fastapi.testclient import TestClient
+        from hydra_detect.web import server as web_server
+
+        client = TestClient(web_server.app)
+        r = client.get("/api/stats")
+        assert r.status_code == 200
+        body = r.json()
+        assert "battery" in body
+        assert body["battery"] is None
+
+    def test_battery_field_populated_when_monitor_attached(self):
+        from fastapi.testclient import TestClient
+        from hydra_detect.mavlink_io import MAVLinkIO
+        from hydra_detect.web import server as web_server
+
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        mon, _ = _make_monitor()
+        mav.attach_battery_monitor(mon)
+        mon.update_from_sys_status(12000, 18, now=100.0)
+        web_server.set_mavlink(mav)
+
+        client = TestClient(web_server.app)
+        r = client.get("/api/stats")
+        body = r.json()
+        battery = body["battery"]
+        assert battery is not None
+        assert battery["voltage_v"] == 12.0
+        assert battery["remaining_pct"] == 18
+        assert battery["level"] == "LOW"
+        assert battery["source"] == "mavlink"
+
+    def test_battery_field_null_when_monitor_disabled(self):
+        from fastapi.testclient import TestClient
+        from hydra_detect.mavlink_io import MAVLinkIO
+        from hydra_detect.web import server as web_server
+
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        mon, _ = _make_monitor(enabled=False)
+        mav.attach_battery_monitor(mon)
+        mon.update_from_sys_status(12000, 18, now=100.0)
+        web_server.set_mavlink(mav)
+
+        client = TestClient(web_server.app)
+        r = client.get("/api/stats")
+        body = r.json()
+        # Disabled monitor → no battery field exposed
+        assert body["battery"] is None

--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -484,6 +484,7 @@ class TestApiStatsBatteryField:
         assert body["battery"] is None
 
     def test_battery_field_populated_when_monitor_attached(self):
+        import time
         from fastapi.testclient import TestClient
         from hydra_detect.mavlink_io import MAVLinkIO
         from hydra_detect.web import server as web_server
@@ -491,7 +492,10 @@ class TestApiStatsBatteryField:
         mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
         mon, _ = _make_monitor()
         mav.attach_battery_monitor(mon)
-        mon.update_from_sys_status(12000, 18, now=100.0)
+        # Stamp the update with the real monotonic clock so the GET
+        # request (which uses time.monotonic() under the hood) sees a
+        # fresh sample, not a 30s-stale one demoted to UNKNOWN.
+        mon.update_from_sys_status(12000, 18, now=time.monotonic())
         web_server.set_mavlink(mav)
 
         client = TestClient(web_server.app)


### PR DESCRIPTION
## Summary

Closes #73. Adds vehicle battery awareness driven by MAVLink `SYS_STATUS` so Jetsons no longer go quiet when the platform battery dies mid-sortie.

- New `BatteryMonitor` (`hydra_detect/battery_monitor.py`) tracks voltage, remaining %, and a level (`OK` / `LOW` / `CRITICAL` / `UNKNOWN`).
- `mavlink_io.py` SYS_STATUS handler extracted into `_handle_sys_status`, forwards every message to the attached monitor.
- `/api/stats` gains a structured `battery` block; legacy `battery_v` / `battery_pct` keys (already used by instructor view per #71) preserved.
- Top-bar battery indicator on the dashboard (olive/amber/red/dim).
- FPV OSD surfaces `B!8` / `BL18` on the canvas and now wakes up to draw on a battery alert even with zero tracks.
- New `[battery]` config section (`enabled`, `low_threshold_pct`, `critical_threshold_pct`, `stale_after_sec`, `critical_reissue_sec`).

## SYS_STATUS fields used

- `voltage_battery` (mV; `0xFFFF` sentinel = unknown)
- `battery_remaining` (%; `-1` sentinel = unknown)

Both sentinels short-circuit to `UNKNOWN` level with no alert.

## Threshold + hysteresis design

Alerts fire only on level *transitions* (`OK → LOW`, `LOW → CRITICAL`, `OK → CRITICAL` skip, recovery to `OK`). Same level on a subsequent message is silent. Recovery emits one `BATT RECOVERED` message and then goes quiet. `critical_reissue_sec > 0` re-emits CRITICAL on the configured cadence (off by default). Staleness (`stale_after_sec`) demotes level to `UNKNOWN` and stops the reissue ladder.

STATUSTEXT prefix uses the live callsign from `self._callsign` (e.g. `HYDRA-2-USV: BATT LOW 18%`), truncated to 16 chars to fit MAVLink's 50-char STATUSTEXT cap.

## API addition

```json
GET /api/stats
{
  ...
  "battery_v": 12.0,         // legacy, unchanged
  "battery_pct": 18,         // legacy, unchanged (used by #71 instructor view)
  "battery": {                // new, additive
    "voltage_v": 12.0,
    "remaining_pct": 18,
    "level": "LOW",          // OK | LOW | CRITICAL | UNKNOWN
    "source": "mavlink"
  }
}
```

`battery` is `null` when the monitor is disabled or unattached. No existing consumer's contract changes.

## OSD addition

`OSDState` gains `battery_pct` and `battery_level`. The `statustext` OSD mode appends `B!8` (CRITICAL), `BL18` (LOW), or `B82` (otherwise) to the per-frame line and now sends an OSD update on a battery alert even when tracks=0 and lock=None — pilots always see the warning.

## Dashboard widget

Small additive `<div id="tb-battery">` in the top bar between the health blips and the FPS block. Hidden until the first message lands. Tone follows `battery.level`: olive/amber/red/dim. CRITICAL pulses.

## Configuration

```ini
[battery]
enabled = true
low_threshold_pct = 20
critical_threshold_pct = 10
stale_after_sec = 30.0
critical_reissue_sec = 0.0
```

## Tests

36 new tests + 3 Linux-only `/api/stats` integration tests. Coverage:

- SYS_STATUS → state populated (voltage + remaining + level)
- Threshold transitions (`OK→LOW`, `LOW→CRITICAL`, `OK→CRITICAL` skip)
- Recovery path (`CRITICAL→OK` emits single `BATT RECOVERED`, then silent)
- Hysteresis: same level on subsequent messages does not refire
- `battery_remaining = -1` / `voltage_battery = 0xFFFF` → `UNKNOWN`, no alert
- Stale window flips level to `UNKNOWN`
- `critical_reissue_sec > 0` reissues CRITICAL only on cadence
- `enabled=False` → no state, no alerts, `battery: null` on `/api/stats`
- MAVLinkIO `_handle_sys_status` forwards to monitor; send-callback exceptions are swallowed
- OSD picks up `battery` dict; `statustext` mode wakes up on LOW/CRITICAL
- Config validation rejects `critical >= low`

Local run: `tests/test_battery_monitor.py` 36 passed (3 skipped on Windows due to existing `fcntl` import in `web/config_api.py`). Affected suites green: `test_osd.py` 38 passed, `test_mavlink_*` 64 passed, `test_identity.py` 48 passed, `test_config_migrate.py` 24 passed, `test_dev_compose.py` 11 passed.

## Vehicle vs Jetson power

Vehicle battery from MAVLink may differ from the Jetson's actual power source (some platforms run the companion off a UBEC, separate battery, or 5V rail). The module docstring, top-bar tooltip, and `source: "mavlink"` field call this out explicitly. Surfacing what we can read is the right move; pretending otherwise is not.

## Deferred work

Instructor-overview wiring already exists (#71): `instructor.js` reads `battery_v` / `battery_pct` straight off the per-vehicle stats roll-up, so per-vehicle battery is already shown. No further work needed for that acceptance criterion. The new structured `battery` block is also rolled up via the existing peer-stats path because it rides on `/api/stats`.

## Test plan

- [ ] Bench-test on Jetson + Pixhawk SITL: confirm `SYS_STATUS` arrives, `/api/stats.battery.level` flips OK→LOW→CRITICAL as the simulated battery drains.
- [ ] Verify STATUSTEXT shows up in Mission Planner's message panel with the correct prefix and severity color (amber for LOW, red for CRITICAL).
- [ ] Top bar: open the dashboard, drain a sim battery, confirm the indicator pulses red on CRITICAL.
- [ ] OSD: with statustext mode, confirm `B!8` appears on the FPV OSD canvas when battery hits 8%.
- [ ] Disable in config (`[battery] enabled = false`), confirm `/api/stats.battery` is `null` and no STATUSTEXT fires.
- [ ] Send a `SYS_STATUS` with `battery_remaining = -1`, confirm level stays `UNKNOWN` and no alert fires.