### PR TITLE
feat(boot): config.ini.bak fallback on corrupted-config startup (#60)

### DIFF
--- a/docs/adversarial/222.md
+++ b/docs/adversarial/222.md
@@ -1,0 +1,78 @@
+# Adversarial Analysis — PR #222 (feat/boot-config-corrupt-recovery)
+
+**Generated:** 2026-05-19T16:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/222
+**Base:** main at 9b31efe
+**Diff size:** ~110 LOC production change across 2 files (web/config_api.py, __main__.py) plus tests/test_safety_hardening.py
+**Closes:** #60 (boot-time corrupted-config fallback to .bak — the last open acceptance bullet)
+
+## Summary
+
+- **Round 1:** 5 findings (0 high, 3 medium, 2 low). Pattern match focused on the boot-path ordering, the parse heuristic, and behavior on the fresh-install case.
+- **Round 2:** 3 second-order findings; downgraded R1-3 after re-reading `_run_boot_migrations` (it does not partial-write on a parse failure). Confirmed R1-1, R1-2, R1-4, R1-5.
+- **Round 3:** Framing identified — *prior rounds audited the recovery function in isolation but did not ask what the operator perceives, whether the .bak can itself be stale-by-policy, or how the recovery interacts with the LKG snapshot that lives one filesystem hop away.*
+- **Consolidated:** 0 blockers, 2 gates closed inline, 5 follow-ups, 1 dropped (R1-3).
+
+## Round 1 — Pattern Match
+
+Five findings. The change adds `attempt_corrupt_recovery()` and wires it as the first thing in `main()` before `_run_boot_migrations`. It restores from `.bak` (written at the end of the previous successful boot by `facade.Pipeline.start -> backup_on_boot`) using the same atomic-copy pattern as `write_config()`. Returns `False` on no-bak-or-bak-also-corrupt, and the caller exits 1.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | parse-heuristic | config_api.py `_parses_ok` | The recovery decides "corrupt" by `cfg.read()` raising OR `cfg.sections()` being empty. A legitimately fresh config.ini that was created but never populated by Platform Setup would be classified as corrupt and replaced with the previous unit's .bak — silent identity-bleed. |
+| R1-2 | medium | ordering | __main__.py recovery before _run_boot_migrations | Recovery runs before migrations. If a partial v3 to v4 migration left the file unparseable, recovery rolls back to a v3 .bak, then `_run_boot_migrations` re-runs the same migration and re-hits the same bug. Loop is bounded by reboot count, not by retry policy. |
+| R1-3 | medium | restore-atomicity | config_api.py:_atomic shutil.copy2 + os.fsync + os.replace | The fsync after copy2 reopens for read-write. On a filesystem mounted with `data=writeback`, the fsync covers only the directory entry inode of `.tmp`, not the byte stream copied from `.bak`. Power-cut during recovery still produces a partial config.ini. |
+| R1-4 | low | observability | config_api.py:recovery, no audit event | Recovery emits a `logger.warning` to the in-memory ring + RotatingFileHandler but NOT to the hydra.audit JSONL sink. Post-mortem on a unit that booted from .bak three times in a row has no durable record once `hydra.log.3` rotates out. |
+| R1-5 | low | doc-drift | config_api.py:backup_on_boot vs. attempt_corrupt_recovery | Two siblings now reason about `.bak` lifecycle (one writes, one restores). The write side is called from `facade.Pipeline.start` near line 1050; the restore side is called from `__main__.main` before migrations. No single docstring describes the contract — what the restore side will and will not do, and when the write side might leave a STALE-BY-MIGRATION .bak that the restore side will gladly use. |
+
+## Round 2 — Counter-Critique
+
+**Challenged R1-3:** re-read the implementation. The `r+b` open with `os.fsync()` after `shutil.copy2` is a best-effort pattern — the explicit try/except OSError around it acknowledges some filesystems may not honor fsync on a re-opened handle. The `os.replace` is the atomic step; the .tmp byte stream durability across power cut is bounded by `shutil.copy2`'s own write semantics, which call `write()` followed by close (no fsync). **R1-3 stands at LOW** — same exposure as `write_config()`'s own pattern (lines 181-205), which is the established baseline. Not a gate; would require a project-wide hardening pass to lift.
+
+**Confirmed:** R1-1, R1-2, R1-4, R1-5 with sharper framing.
+
+**R1-1 stands at MEDIUM.** The fresh-install path is guarded by `if not path.exists(): return True` — but a `path.exists()` with zero bytes (Platform Setup wrote the section header and crashed before writing keys) falls into `_parses_ok` and returns False because `cfg.sections()` is empty. The recovery then restores from .bak. If this unit was imaged from a golden image that carried a `.bak`, the .bak is from the GOLDEN IMAGE'S source unit, not this unit. Result: identity drift across the fleet. **Gate closed inline:** the test `test_empty_config_with_no_sections_restored_from_bak` is the intended behavior — restore IS correct when `.bak` is fresh-on-this-unit. The fleet-imaging concern is a separate issue tracked outside #60; flag in PR body as a follow-up.
+
+**R1-2 stands at MEDIUM.** Verified the boot ordering: `attempt_corrupt_recovery -> _run_boot_migrations -> pre-load cfg.read`. If a migration corrupts the file, the rollback in `config_migrate.run_migrations` (lines 280-284) copies the migration-time backup back, so the migration loop is bounded by migration-internal recovery, not by `attempt_corrupt_recovery`. Still, recovery should ideally annotate the WARNING with "If this WARNING reappears across reboots, the .bak itself is incompatible with the current code version — consider Factory Reset." Follow-up only; not a gate.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | low | tmp-leak-on-rapid-reboot | config_api.py:attempt_corrupt_recovery finally | The `.tmp` cleanup is only on the OSError branch. The success path leaves the `.tmp` to `os.replace` (which renames it away), but if the process is killed (SIGKILL, kernel OOM) between `shutil.copy2` and `os.replace`, the `.tmp` survives. Next boot recovery does not look for an orphan `.tmp` and does not clean it up. Cosmetic, not safety-critical. |
+| R2-2 | medium | LKG-snapshot-orthogonal | config_lkg.py `snapshot_if_healthy` + restore_lkg vs .bak | The repo ships TWO last-known-good mechanisms: this PR uses `config.ini.bak` (rolling, written every boot in `facade.Pipeline.start`), while `config_lkg.py` writes `config.ini.lkg` (rotates on healthcheck). The .lkg is currently called only by tests — no production caller. Recovery on boot pulls from `.bak`, NOT `.lkg`. Operator confusion is inevitable when one path runs in production and the other is referenced in CLI design notes. |
+| R2-3 | nit | name-collision-future | config_api.py:attempt_corrupt_recovery returning bool | The function name implies a side-effecting "attempt"; the return value is a binary "config is now usable." A future maintainer reading `if attempt_corrupt_recovery(path):` plausibly reads "if recovery was attempted" instead of "if config is valid." Rename to `ensure_config_parseable` would read more clearly. Style only; not a gate. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited the recovery function in isolation, asking "does it correctly classify corrupt vs. valid, does it restore atomically, does it log loudly." Neither round asked (a) what the operator sees on the dashboard when this fires, (b) whether the .bak can be policy-stale even when byte-correct, or (c) how the existence of two competing LKG mechanisms — `.bak` from facade.py and `.lkg` from config_lkg.py — affects the operator's mental model when they read a recovery WARNING.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R3-1 | medium | operator-blind-spot | __main__.py:recovery → pipeline init → dashboard | Recovery WARNING goes to stdout and `hydra.log`. The web dashboard reads `audit_log` events, NOT the python `logger.warning` stream. A SORCC operator who connects to the unit after recovery fires sees a fully booted Hydra with the previous boot's config silently restored — they have to grep the logs to know recovery happened. Not a gate (out of scope for #60), but a real follow-up: emit a `recovery_from_bak` audit event so the dashboard can surface a one-time banner. |
+| R3-2 | medium | bak-staleness-policy | config_api.py:backup_on_boot vs migrations | `backup_on_boot` writes `.bak` on every successful boot. `_run_boot_migrations` runs BEFORE Pipeline.start, so the `.bak` written at end-of-boot reflects the POST-migration schema. After a migration, the `.bak` is at the new schema. After a code rollback (Hydra v2.0 to v1.9 via systemd unit), boot reads a `.bak` whose schema is one version ahead of the code. Recovery succeeds, downstream code crashes on unknown fields. The .bak is byte-correct but policy-stale. Out of scope for #60 — flag as follow-up. |
+| R3-3 | low | two-LKG-mechanisms | config_api.py:attempt_corrupt_recovery + config_lkg.py:restore_lkg | The repo has two restore paths: rolling .bak (this PR uses it on boot) and the .lkg snapshot (called only by tests, gated on `health_check_fn`). An operator told "restore from backup" via two different channels (CLI scripts say .lkg, dashboard says .bak) sees two different files. This is documentation drift, not behavior drift — PR body should call out that #60 deliberately uses .bak because it is the one written in production. Will note in PR description. |
+| R3-4 | low | recovery-warning-rate-limit | __main__.py boot path | A unit stuck in a reboot loop where config.ini keeps getting corrupted (e.g., failing SD card) emits one WARNING per boot. After 50 reboots in an hour, the log is 50 copies of "restored from last-known-good backup." Useful for incident replay; noisy for the operator on dashboard tail. Acceptable — log volume is the right signal for "your SD card is dying." Cosmetic note only. |
+| R3-5 | nit | test-coverage-of-callsite | tests/test_safety_hardening.py covers the function, NOT the boot wire-up | The added test class covers `attempt_corrupt_recovery()` directly. There is no integration test that asserts `main()` itself bails with sys.exit(1) when recovery fails. Adding one requires fixing import-time side effects in __main__; out of scope for #60. Function-level coverage is adequate. |
+
+### Consistency-bias callouts
+
+- **R1+R2 framed the .bak as "the obvious source of truth" without questioning why it was chosen over .lkg.** The reason is operational: .bak is what facade.py writes, and the corruption case fires before the pipeline (and the .lkg health check) ever runs — so .bak is the only file guaranteed to be on-disk at boot time. R3-3 surfaces this explicitly so the PR reviewer does not have to re-derive it.
+- **R1-1 (fresh-install identity-bleed) was flagged as a serious risk in pattern-match.** Re-examined in R2: the test `test_empty_config_with_no_sections_restored_from_bak` is the desired behavior. A unit that has no .bak (truly fresh install) returns True and proceeds; a unit that has a .bak (booted before) trusts it. The "golden image with .bak baked in" failure is a fleet-imaging policy issue, not a recovery-function bug.
+
+## Consolidated disposition
+
+- **Blockers (must fix before merge):** none.
+- **Gates closed inline:**
+  - R1-1 (fresh-install vs. golden-image .bak) — verified by `test_empty_config_with_no_sections_restored_from_bak`; documented in PR body as a fleet-imaging follow-up, not a #60 scope item.
+  - R1-2 (recovery-then-migration loop on same bug) — bounded by `run_migrations`' own rollback; documented as expected.
+- **Follow-ups (track outside #60):**
+  - R3-1: add a `recovery_from_bak` audit event + dashboard banner.
+  - R3-2: rejection-on-future-schema policy when `.bak`'s schema_version exceeds CURRENT_SCHEMA_VERSION.
+  - R3-3: unify or clearly delineate `.bak` vs. `.lkg` semantics; the `.lkg` restore_lkg function is dead code in production.
+  - R2-1: orphan `.tmp` cleanup on next-boot recovery.
+  - R2-2: wire `config_lkg.snapshot_if_healthy` into a production caller or remove the module.
+- **Dropped:** R1-3 (restore-atomicity below baseline) — same exposure as the existing write_config pattern.

--- a/docs/adversarial/225.md
+++ b/docs/adversarial/225.md
@@ -1,8 +1,8 @@
-# Adversarial Analysis — PR #222 (feat/boot-config-corrupt-recovery)
+# Adversarial Analysis — PR #225 (feat/boot-config-corrupt-recovery)
 
 **Generated:** 2026-05-19T16:00:00Z
 **Target kind:** pr
-**Target:** https://github.com/rmeadomavic/Hydra/pull/222
+**Target:** https://github.com/rmeadomavic/Hydra/pull/225
 **Base:** main at 9b31efe
 **Diff size:** ~110 LOC production change across 2 files (web/config_api.py, __main__.py) plus tests/test_safety_hardening.py
 **Closes:** #60 (boot-time corrupted-config fallback to .bak — the last open acceptance bullet)

--- a/hydra_detect/__main__.py
+++ b/hydra_detect/__main__.py
@@ -195,6 +195,19 @@ def main():
     )
     args = parser.parse_args()
 
+    # Power-loss recovery: if config.ini was truncated mid-write, restore
+    # from config.ini.bak (written at the end of the previous successful boot
+    # by Pipeline.start -> backup_on_boot). Must run before migrations and
+    # the pre-load below, both of which call cfg.read() with no fallback.
+    from .web.config_api import attempt_corrupt_recovery
+    if not attempt_corrupt_recovery(args.config):
+        logger.critical(
+            "Config recovery exhausted — refusing to start with no usable "
+            "config at %s. Restore from factory defaults via the dashboard "
+            "or re-run Platform Setup.", args.config,
+        )
+        sys.exit(1)
+
     # Run config schema migrations before anything reads config values.
     # Must happen before cfg.read() so the pipeline sees the migrated file.
     _run_boot_migrations(args.config)

--- a/hydra_detect/web/config_api.py
+++ b/hydra_detect/web/config_api.py
@@ -325,6 +325,90 @@ def backup_on_boot() -> None:
     logger.info("Config backed up to %s", bak_path)
 
 
+def attempt_corrupt_recovery(config_path: Path | str) -> bool:
+    """Try to parse config_path; on ParsingError, restore from .bak and retry.
+
+    Called from the boot path BEFORE any migration runs or pipeline init. The
+    .bak is written by backup_on_boot() at the end of the previous successful
+    boot (facade.py: Pipeline.start), so it represents the last-known-good
+    config. If config.ini is truncated (power cut mid-write), unparseable, or
+    empty-of-sections, restore from .bak in place — atomic copy via tmp +
+    os.replace, same pattern as write_config — and log a loud WARNING so the
+    operator sees recovery happened.
+
+    Returns True if config is valid (either originally or after recovery),
+    False if neither config.ini nor .bak is usable. The caller should log
+    CRITICAL and exit on False; continuing into migration / pipeline init with
+    no parseable config produces incomprehensible downstream errors.
+    """
+    path = Path(config_path)
+    if not path.exists():
+        # Fresh install or first boot — let downstream handle missing-file.
+        # Not a corruption case, not our responsibility.
+        return True
+
+    def _parses_ok(p: Path) -> bool:
+        try:
+            cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+            cfg.read(p)
+        except configparser.Error:
+            return False
+        return bool(cfg.sections())
+
+    if _parses_ok(path):
+        return True
+
+    bak_path = Path(str(path) + ".bak")
+    if not bak_path.exists():
+        logger.critical(
+            "Config file %s is corrupted or empty and no .bak exists for "
+            "recovery. Restore from factory defaults via the dashboard, or "
+            "re-run Platform Setup.",
+            path,
+        )
+        return False
+
+    if not _parses_ok(bak_path):
+        logger.critical(
+            "Config file %s is corrupted AND backup %s is also unparseable. "
+            "Restore from factory defaults via the dashboard.",
+            path, bak_path,
+        )
+        return False
+
+    # Atomic restore: copy .bak -> .tmp, fsync, os.replace -> config.ini.
+    # Mirrors the write_config pattern at lines 181-205 so a crash mid-recovery
+    # cannot make a bad situation worse.
+    tmp_path = Path(str(path) + ".tmp")
+    try:
+        shutil.copy2(bak_path, tmp_path)
+        try:
+            with open(tmp_path, "r+b") as f:
+                os.fsync(f.fileno())
+        except OSError:
+            pass  # non-fatal — best-effort durability
+        os.replace(tmp_path, path)
+    except OSError as exc:
+        logger.critical(
+            "Config recovery failed during restore of %s from %s: %s",
+            path, bak_path, exc,
+        )
+        if tmp_path.exists():
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        return False
+
+    logger.warning(
+        "Config file %s was corrupted; restored from last-known-good backup "
+        "%s. Review the active configuration on the dashboard — any changes "
+        "made since the last successful boot are LOST.",
+        path, bak_path,
+    )
+    return True
+
+
 def has_factory() -> bool:
     """Check if factory defaults file exists."""
     path = get_config_path()

--- a/tests/test_safety_hardening.py
+++ b/tests/test_safety_hardening.py
@@ -133,6 +133,104 @@ class TestBackupOnBoot:
 
 
 # ---------------------------------------------------------------------------
+# 3b. attempt_corrupt_recovery — boot-time fallback (#60)
+# ---------------------------------------------------------------------------
+
+class TestAttemptCorruptRecovery:
+    """Power-loss recovery: corrupted config.ini falls back to .bak on boot.
+
+    Covers issue #60 "Corrupted config falls back to backup with warning."
+    The function is wired into __main__.main() before _run_boot_migrations
+    so the migration runner never sees a half-written file.
+    """
+
+    def test_valid_config_passes_through(self, tmp_path):
+        """Healthy config returns True with no changes to the file."""
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+        path = tmp_path / "config.ini"
+        path.write_text("[camera]\nsource = auto\n")
+        before = path.read_text()
+        assert attempt_corrupt_recovery(path) is True
+        # Recovery must be a no-op on healthy configs.
+        assert path.read_text() == before
+
+    def test_missing_config_returns_true(self, tmp_path):
+        """Fresh install with no config.ini is not a corruption case."""
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+        path = tmp_path / "config.ini"
+        assert attempt_corrupt_recovery(path) is True
+        assert not path.exists()  # we must not create one
+
+    def test_truncated_config_restored_from_bak(self, tmp_path, caplog):
+        """A truncated config.ini is replaced by its .bak, with WARNING logged."""
+        import logging
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        # .bak holds the last-known-good snapshot.
+        bak.write_text("[camera]\nsource = auto\nwidth = 640\n")
+        # config.ini was truncated mid-write (configparser raises on a bare
+        # key with no '=', which is the most plausible truncation residue).
+        path.write_text("[camera]\nsource\n")
+
+        with caplog.at_level(logging.WARNING):
+            assert attempt_corrupt_recovery(path) is True
+
+        # The restored file must match the backup byte-for-byte.
+        assert path.read_text() == bak.read_text()
+        assert any("restored from last-known-good" in r.message for r in caplog.records)
+
+    def test_empty_config_with_no_sections_restored_from_bak(self, tmp_path):
+        """Empty / sectionless config.ini is treated as corrupt and restored."""
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        bak.write_text("[camera]\nsource = auto\n")
+        path.write_text("")  # zero bytes — power-cut at the start of write_config
+        assert attempt_corrupt_recovery(path) is True
+        assert "[camera]" in path.read_text()
+
+    def test_corrupt_config_no_bak_returns_false(self, tmp_path, caplog):
+        """No .bak available means no recovery; caller should exit 1."""
+        import logging
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+
+        path = tmp_path / "config.ini"
+        path.write_text("[camera]\nsource\n")  # bad
+
+        with caplog.at_level(logging.CRITICAL):
+            assert attempt_corrupt_recovery(path) is False
+        assert any(
+            "no .bak exists" in r.message.lower() for r in caplog.records
+        )
+
+    def test_corrupt_config_and_corrupt_bak_returns_false(self, tmp_path, caplog):
+        """Both files unparseable — caller should exit 1, not loop."""
+        import logging
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        path.write_text("[camera]\nsource\n")
+        bak.write_text("[also-bad\n")  # missing ']' — configparser ParsingError
+
+        with caplog.at_level(logging.CRITICAL):
+            assert attempt_corrupt_recovery(path) is False
+        assert any("backup" in r.message.lower() for r in caplog.records)
+
+    def test_recovery_is_atomic_no_tmp_left(self, tmp_path):
+        """The .tmp sibling must not survive a successful recovery."""
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        bak.write_text("[camera]\nsource = auto\n")
+        path.write_text("[bad")
+        attempt_corrupt_recovery(path)
+        assert not (tmp_path / "config.ini.tmp").exists()
+
+
+# ---------------------------------------------------------------------------
 # 4. restore_factory works
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the last open acceptance bullet on issue #60: **"Corrupted config falls back to backup with warning."**

The other four bullets were already done by prior PRs. This change is the boot-time wire-up that connects `backup_on_boot()` (which writes `.bak`) to a parser that knows what to do when `config.ini` is unreadable.

### What was missing

Before this change:
- `__main__.py` line 214 does `cfg.read(args.config)` with no try/except.
- `config_migrate.run_migrations` line 213 does the same.
- A power-cut mid-write that leaves `config.ini` truncated turns into `configparser.ParsingError` at boot, the pipeline never starts, and the operator sees a unit that won't boot with no clear next step.
- `Pipeline.start -> backup_on_boot()` had been writing `.bak` at the end of every successful boot since the safety-hardening PR, but no boot-time path consulted it.

### What this PR does

1. New function `attempt_corrupt_recovery(config_path)` in `hydra_detect/web/config_api.py`.
   - Tries to parse `config_path`. If clean, returns True with no side effects.
   - On `configparser.ParsingError` or zero-sections, copies `.bak` over `config.ini` using the same tmp + fsync + os.replace pattern as `write_config` (config_api.py:181-205), logs a loud WARNING, returns True.
   - If neither file is usable, returns False (caller exits 1).

2. Wired into `__main__.main()` as the first thing after argparse, before `_run_boot_migrations`.

### Acceptance criteria status

- [x] Config writes use atomic rename pattern (commit 206196f, config_api.py:181-205)
- [x] Config backed up on successful boot (facade.py:1050)
- [x] **Corrupted config falls back to backup with warning** (THIS PR)
- [x] Factory reset restores defaults from dashboard (PR #212, factory_reset_with_backup)
- [x] verify_log.py handles truncated final record gracefully (verify_log.py:45-57)

### Tests

7 new tests in `TestAttemptCorruptRecovery`:
- `test_valid_config_passes_through` — healthy config, no side effects.
- `test_missing_config_returns_true` — fresh install is not a corruption case.
- `test_truncated_config_restored_from_bak` — restored content matches .bak byte-for-byte, WARNING logged.
- `test_empty_config_with_no_sections_restored_from_bak` — zero-byte file treated as corrupt.
- `test_corrupt_config_no_bak_returns_false` — caller-must-exit branch + CRITICAL log.
- `test_corrupt_config_and_corrupt_bak_returns_false` — both files bad.
- `test_recovery_is_atomic_no_tmp_left` — no `.tmp` leak.

All pass locally. Production change is 97 LOC (under the 200 cap).

### Adversarial review

See `docs/adversarial/222.md`. Three rounds; one finding downgraded; no blockers. Follow-ups filed against this PR body (not done in this commit, all out of scope for #60):

- R3-1: emit a `recovery_from_bak` audit event so the dashboard can show a one-time banner. Today the WARNING goes to log only.
- R3-2: rejection-on-future-schema policy when `.bak` schema_version exceeds `CURRENT_SCHEMA_VERSION` — covers the code-rollback edge.
- R3-3 / R2-2: unify or remove `config_lkg.py` — `.lkg` restore is dead code in production; only `.bak` is used. Two LKG mechanisms is confusing.
- R2-1: orphan `.tmp` cleanup on next-boot recovery (SIGKILL window).

### Why .bak and not .lkg

The repo ships both `config.ini.bak` (rolling, written every boot in `facade.Pipeline.start`) and `config.ini.lkg` (rotates on healthcheck, in `config_lkg.py`). The `.lkg` path is currently called only by tests — no production caller. The corruption case fires before the pipeline (and the `.lkg` health check) ever runs, so `.bak` is the only file guaranteed to be on disk at boot. R3-3 above tracks unification.

## Test plan

- [x] `pytest tests/test_safety_hardening.py::TestAttemptCorruptRecovery` — 7/7 pass
- [x] `pytest tests/test_safety_hardening.py tests/test_verify_log.py tests/test_identity.py` — 77/78 pass; the one fail is pre-existing Windows-only flock+os.replace race, unrelated to this change
- [x] Adversarial doc — greater than 500 bytes (12,201 bytes), contains literal `## Round 3` heading
- [ ] CI green on Linux runner (pending)