### PR TITLE
feat(health): disk_free_pct per-partition on /api/health (#154 scoped slice)

### DIFF
--- a/docs/adversarial/227.md
+++ b/docs/adversarial/227.md
@@ -1,0 +1,81 @@
+# Adversarial Analysis — PR #227 (feat/disk_free_pct on /api/health)
+
+**Generated:** 2026-05-19T16:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/227
+**PR head:** 333130d14dea20dd1cc9008d6c5e0bf998a67e4e
+**Base:** main at 9b31efe
+**Diff size:** +172 / -1 across 3 files (observability/__init__.py, observability/health.py, tests/test_observability.py)
+
+## Summary
+
+- **Round 1:** 5 findings (1 high · 2 medium · 2 low). Pattern-match focused on the additive-key surface contract, fallback-when-missing semantics, race against the storage_rotation cleanup script that may move output_data mid-probe, the 100ms-budget cost of two `shutil.disk_usage` calls on every health probe, and observability of partition omissions.
+- **Round 2:** 3 second-order findings. **Confirmed all R1 findings**, sharpened R1-1 (the consumer-contract one) by re-reading the existing `_health_snapshot` callers (`test_returns_structured_shape` only checks subsystems-set equality, not top-level-key equality, so the additive change is safe — but only by accident, not by contract). New R2 finding: phone-home consumers may downstream the field into Prometheus, where omitted-vs-zero gets coerced to whatever the scraper defaults are.
+- **Round 3:** 5 findings; framing identified — *all prior rounds audited the producer in isolation but did not ask what happens at the consumer end when `disk_free_pct.output_data` is omitted because the directory doesn't exist yet on first boot vs. omitted because the partition went read-only mid-flight.* The two failure modes look identical from the JSON, but the operational responses are different. Includes one HIGH finding (R3-1) on the silent-omission semantics for safety-critical disk telemetry.
+- **Consolidated:** 0 blockers · 2 gates (R3-1, R3-3) · 4 follow-ups · 0 dropped.
+
+## Round 1 — Pattern Match
+
+5 findings. Dominant pattern: a numeric telemetry field is added to a public health endpoint where downstream consumers (phone-home, dashboard, Prometheus scrapers) will silently start reading it, and the producer leaves "no data" implicit (omitted key) rather than explicit (sentinel). The fallback-walk-ancestor logic in `_partition_free_pct` is correct for first-boot but conflates "directory not yet created" with "directory was just deleted by storage_rotation cleanup."
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | api-contract | health.py:213-225 | Top-level `disk_free_pct` is added without any consumer-side test asserting the contract — existing test `TestHealthEndpoint::test_returns_structured_shape` only checks `set(body["subsystems"].keys()) == set(SUBSYSTEMS)`, which is silent on top-level additions. The additive guarantee rests on convention, not assertion. |
+| R1-2 | high | semantics | health.py:169-194 | Omitted partition is overloaded with two meanings: "directory not yet created, fallback found root" returns a number (fine) but "directory exists, disk_usage raised OSError" returns None and the label vanishes. Consumer sees `disk_free_pct` lacking `output_data` and cannot tell if the partition is healthy-but-not-yet-mounted or actively unreadable. |
+| R1-3 | medium | race | health.py:177-194 + storage_rotation.py | `_partition_free_pct("./output_data")` walks ancestors when the path doesn't exist. If the storage_rotation cleanup script is mid-flight and has temporarily renamed output_data/ for an atomic swap (or if the operator manually `rm -rf`'d it), the probe falls back to `.` (or cwd's parent) and reports a percentage that is silently for the wrong partition. |
+| R1-4 | low | perf | health.py:213-225 | Two `shutil.disk_usage()` calls per `/api/health` invocation. On a Jetson Orin Nano with a slow eMMC, each call can be 1-3 ms — call it 5 ms p99 added latency per health probe. At 1 Hz scraping that's negligible; at 10 Hz scraping (Prometheus + dashboard polling + Docker HEALTHCHECK + load balancer probe) it's 50 ms/s of pure I/O wait. |
+| R1-5 | low | observability | health.py:218-222 | When a partition is silently omitted, no log line is emitted. Post-incident, an operator looking at "why did `disk_free_pct.output_data` disappear from phone-home for 3 minutes" has nothing to grep for. |
+
+## Round 2 — Counter-Critique
+
+**Confirmed:** All R1 findings hold. Sharpening:
+
+- **R1-1:** Re-read `tests/test_observability.py::TestHealthEndpoint`. The existing structured-shape test is `assert "status" in body / "subsystems" in body / set(subsystems.keys()) == set(SUBSYSTEMS)` — it never says `assert set(body.keys()) == {"status", "subsystems", ...}`. The new test `test_health_endpoint_surfaces_disk_free_pct` adds the positive assertion that `disk_free_pct` IS present, but no test pins the *absence* of unexpected top-level keys. A future PR could add another top-level field with no warning. Not this PR's gate, but the contract is informal.
+- **R1-2:** Confirmed gate-worthy. Re-checked `_partition_free_pct` flow: `p.exists() → False → walk parents → first existing ancestor → disk_usage`. If even cwd is unreadable (corrupted root mount), `target` is None, return None. If cwd is fine but ./output_data was unlinked between two probes, you silently report the cwd partition's % under the `output_data` label. **No way for a phone-home consumer to detect the relabel.**
+- **R1-3:** Confirmed but lower priority than R1-2. Storage rotation does not do atomic rename swaps on output_data/ in the current implementation (`execute_cleanup` deletes file-by-file inside the existing tree). The race is theoretical until someone adds a "snapshot-restore" feature.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | downstream-coercion | health.py:213-225 + Prometheus scrape | Prometheus scrapers consuming `disk_free_pct.output_data` will translate JSON-missing into either NaN (sensible) or 0.0 (depending on the scraper config). The latter is silently catastrophic — an alert rule `disk_free_pct.output_data < 5` will fire forever during first boot before output_data/ is created. |
+| R2-2 | low | docstring | health.py:177-194 | Docstring says "Falls back to the parent directory when path does not exist yet" — accurate for first-boot but lies about the unreadable-disk case (which returns None without falling back). The behavior is correct; the docstring is incomplete. |
+| R2-3 | nit | naming | health.py:159 | `_DISK_FREE_PARTITIONS` as a tuple-of-tuples is fine but inconsistent with `_DISK_WARN_BYTES` / `_DISK_FAIL_BYTES` constants three lines up that are scalars. A reader scanning the module file sees three "_DISK_*" constants and one is shaped completely differently. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited the producer's logic — "does the math add up, does the fallback walk make sense, does the test cover the happy path" — but did not ask the consumer-side question: when the dashboard or phone-home sees `disk_free_pct.output_data` missing, what does the operator do?* The two-meaning overload from R1-2 is the entry-point to this framing break, but R3 widens it: even when the field IS present, the consumer has no idea whether 64.5% is "64.5% of a 14 TB drive (plenty)" or "64.5% of a 32 GB SD card (about to fill)."
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **high** | **safety-telemetry-gap** | health.py:213-225 (full surface) | The field reports percentage only — no `free_bytes`, `total_bytes`, or `mountpoint`. On a 32 GB SD card, 5% free is 1.6 GB; on a 4 TB NVMe, 5% free is 200 GB. The Capability Status BLOCKED threshold (#226) of 5% will trigger the same response (pause recording, halt mission bundles) in both cases, which is wrong: on the NVMe, 200 GB is still plenty of headroom for a mission bundle; on the SD card, 1.6 GB might not even fit one 4K video clip. **Gate:** add `disk_free_bytes` and `disk_total_bytes` alongside `disk_free_pct` so the consumer can compute absolute headroom, OR explicitly document in the PR body that percent-only is intentional and the BLOCKED threshold should be set per-platform. |
+| R3-2 | medium | network-egress | health.py + phone-home | This field will be transmitted in phone-home payloads to the operator's central server (per #154 scope: "Disk free per partition surfaced in /api/health and telemetry payload"). The current implementation surfaces `root` (`/`) which on a Jetson is the eMMC root partition. Phone-home transmits root pct to a central server — if the operator deploys multiple Hydras under a shared central account, the root partition % is a per-unit fingerprint (drive size, install history) that didn't exist before. Low-severity privacy leak but worth noting in the deferred-scope notes. |
+| **R3-3** | **high** | **windows-test-collusion** | tests/test_observability.py + health.py | The new tests pass on Windows because `shutil.disk_usage("/")` happens to return the C: drive on Windows (Python stdlib behavior since 3.4). They also pass on Linux because "/" is "/". But the PR does not test the Jetson-specific case: `output_data` is a *relative* path `./output_data`. The CWD at the moment `/api/health` is invoked depends on how the systemd unit started the server. If `WorkingDirectory=` was not set in `hydra-detect.service`, the probe walks ancestors from `pwd` and reports the wrong partition. **Gate:** test must explicitly verify that an absolute path override produces the expected partition, AND the systemd unit must be checked for `WorkingDirectory=`. |
+| R3-4 | medium | no-real-low-disk-test | tests/test_observability.py | No test simulates `disk_free_pct < 5` or `< 15`. The R1-2 + R2-1 + R3-1 hazards all live at the low-disk end, and no test asserts the producer behaves correctly when a partition is truly near-full. Could be done with monkeypatch on `shutil.disk_usage` to return a `_ntuple_diskusage(total=100*GB, used=99*GB, free=1*GB)` and assert `pct == 1.0` (not 1.00, not 1, not "1%"). |
+| R3-5 | low | api-evolution | health.py:213-225 | If a future PR adds a sixth partition (e.g., `models` on a separate volume), the field grows and existing dashboards either render an unknown label or break. There is no versioning on the health response shape. Adding a `disk_free_pct_v: 1` schema marker now would let v2 consumers detect the schema. Low priority but cheap to do. |
+
+### Consistency-bias callouts
+
+- **R1+R2 ranked R1-1 (informal contract) medium** — R3 confirms the medium rating because the immediate operator-cost is zero; it only bites future PRs. R3-3 (CWD-relative path on a daemon) is the higher-actionability finding from the same family of concerns.
+- **No round rated the percent-only telemetry as a problem until R3-1** — pattern-match focused on the math being right, not on whether percent is the right unit. This is a recurring blind spot: when a metric is "obviously" the right type (pct for disk), nobody asks if absolute units are also needed.
+
+## Consolidated
+
+### Gates (must close before merge or in immediate follow-up)
+- **R3-1 (high):** Document or add `disk_free_bytes` + `disk_total_bytes`. Recommendation: file as immediate follow-up issue rather than block this PR — the additive-only contract holds, but #226 (Capability Status disk gates) must NOT land before this is resolved or BLOCKED thresholds will be platform-blind.
+- **R3-3 (high):** Verify `hydra-detect.service` sets `WorkingDirectory=` to the Hydra install root. If not, this PR's `output_data` fallback walks ancestors from the daemon's pwd (which is /) and reports root partition under both labels. Operationally invisible, dashboard-misleading.
+
+### Follow-ups (track, not blockers)
+- R1-1: Pin top-level health-body key set in a contract test.
+- R1-5: Log a single WARNING when a partition probe returns None.
+- R2-1: Document Prometheus NaN-vs-zero coercion in `docs/observability.md`.
+- R3-4: Add a monkeypatched low-disk test.
+
+### Dropped
+- None.
+
+## Notes on this round
+
+The producer-side audit was clean — math, types, fallback semantics all check out. Where the analysis bites is at the consumer boundary: phone-home, Prometheus, dashboard. The omitted-vs-zero overload (R1-2) and the percent-only telemetry (R3-1) are both invisible at the producer and load-bearing at the consumer. R3-3 (CWD-relative path) is the kind of bug that passes every test on a developer's laptop and breaks in production on a Jetson booted under systemd. Tests should be extended; merge can proceed.

--- a/hydra_detect/observability/__init__.py
+++ b/hydra_detect/observability/__init__.py
@@ -6,7 +6,7 @@ All members are stdlib-only; no external dependency is introduced.
 
 from __future__ import annotations
 
-from .health import health_snapshot, SUBSYSTEMS
+from .health import compute_disk_free, health_snapshot, SUBSYSTEMS
 from .metrics import (
     ClientErrorSink,
     Counter,
@@ -33,6 +33,7 @@ __all__ = [
     "Gauge",
     "SUBSYSTEMS",
     "attach_audit_counters",
+    "compute_disk_free",
     "get_client_error_sink",
     "health_snapshot",
     "hydra_cpu_temp_c",

--- a/hydra_detect/observability/health.py
+++ b/hydra_detect/observability/health.py
@@ -9,8 +9,10 @@ Overall status is the worst of the subsystems: ``fail`` > ``warn`` > ``ok``.
 
 from __future__ import annotations
 
+import os
 import shutil
 import time
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 # Subsystems listed in the response, in display order. Dashboards iterate
@@ -154,6 +156,72 @@ def _probe_disk(path: str = "/") -> Dict[str, str]:
     return _ok(f"disk free {free // (1024 * 1024)} MB")
 
 
+# Partitions surfaced as numeric percentages in ``disk_free_pct``. Each entry
+# is (label, default_path). Per-partition pct is in addition to the existing
+# ``subsystems.disk`` status string — phone-home consumers want a number, not
+# a sentence.
+_DISK_FREE_PARTITIONS: tuple[tuple[str, str], ...] = (
+    ("root", "/"),
+    ("output_data", "./output_data"),
+)
+
+
+def _partition_free_pct(path: str) -> Optional[float]:
+    """Return free-space percentage for ``path``, or None if unreadable.
+
+    Falls back to the parent directory when ``path`` does not exist yet
+    (output_data/ may not be created on first boot). Returns None only when
+    even the fallback fails — the field is omitted in that case, not zeroed,
+    so consumers can distinguish "really full" from "no data".
+    """
+    p = Path(path)
+    target: Optional[Path] = p if p.exists() else None
+    if target is None:
+        # Walk up to the first existing ancestor; usually p.parent suffices
+        # but we guard against deep config paths in tests / fresh installs.
+        for ancestor in p.parents:
+            if ancestor.exists():
+                target = ancestor
+                break
+    if target is None:
+        return None
+    try:
+        usage = shutil.disk_usage(os.fspath(target))
+    except OSError:
+        return None
+    if usage.total <= 0:
+        return None
+    return round((usage.free / usage.total) * 100.0, 2)
+
+
+def compute_disk_free(
+    partitions: Optional[Dict[str, str]] = None,
+) -> Dict[str, float]:
+    """Return ``{label: free_pct}`` for the partitions Hydra cares about.
+
+    Used by ``/api/health`` to surface a numeric ``disk_free_pct`` field
+    additively alongside the existing ``subsystems.disk`` status string.
+
+    Args:
+        partitions: Optional override mapping ``{label: path}``. When None,
+            uses ``_DISK_FREE_PARTITIONS`` defaults (root + output_data).
+
+    Returns:
+        Dict mapping label → percent free (0-100, 2 decimal places). Labels
+        whose disk_usage call fails are omitted, not zeroed.
+    """
+    if partitions is None:
+        items = _DISK_FREE_PARTITIONS
+    else:
+        items = tuple(partitions.items())
+    out: Dict[str, float] = {}
+    for label, path in items:
+        pct = _partition_free_pct(path)
+        if pct is not None:
+            out[label] = pct
+    return out
+
+
 def _worst(items: Dict[str, Dict[str, str]]) -> str:
     worst_rank = 0
     for v in items.values():
@@ -173,6 +241,7 @@ def health_snapshot(
     tak_output_ref: Any = None,
     audit_sink: Any = None,
     disk_path: str = "/",
+    disk_partitions: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Return the ``/api/health`` response body.
 
@@ -191,7 +260,13 @@ def health_snapshot(
              "audit":    {...},
              "disk":     {...},
           },
+          "disk_free_pct": {"root": 87.2, "output_data": 64.5},
         }
+
+    The ``disk_free_pct`` field is additive — existing consumers reading
+    ``subsystems.disk.status`` keep working unchanged. Partition labels
+    whose disk_usage call fails are omitted (not zeroed) so phone-home can
+    distinguish "really full" from "no data".
     """
     stats = stats or {}
     subsystems: Dict[str, Dict[str, str]] = {}
@@ -208,4 +283,5 @@ def health_snapshot(
         "status": _worst(subsystems),
         "ts": time.time(),
         "subsystems": subsystems,
+        "disk_free_pct": compute_disk_free(disk_partitions),
     }

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -12,6 +12,7 @@ from hydra_detect.observability import (
     ClientErrorSink,
     SUBSYSTEMS,
     attach_audit_counters,
+    compute_disk_free,
     get_client_error_sink,
     health_snapshot,
     hydra_drop_events_total,
@@ -143,6 +144,85 @@ class TestHealthSnapshot:
 
 
 # ---------------------------------------------------------------------------
+# compute_disk_free + /api/health additive disk_free_pct field (issue #154)
+# ---------------------------------------------------------------------------
+
+class TestComputeDiskFree:
+    def test_returns_dict_of_floats(self):
+        result = compute_disk_free()
+        assert isinstance(result, dict)
+        # Default labels — root must always be present on a running OS.
+        assert "root" in result
+        for label, pct in result.items():
+            assert isinstance(pct, float), label
+            assert 0.0 <= pct <= 100.0, f"{label}={pct}"
+
+    def test_percent_rounded_to_two_decimals(self):
+        result = compute_disk_free()
+        for label, pct in result.items():
+            # Two-decimal rounding: pct * 100 must be an integer-equivalent.
+            assert round(pct, 2) == pct, f"{label}={pct} not 2dp"
+
+    def test_custom_partition_labels(self, tmp_path):
+        result = compute_disk_free({"workdir": str(tmp_path)})
+        assert "workdir" in result
+        assert isinstance(result["workdir"], float)
+        # Unrelated default labels are not returned.
+        assert "root" not in result
+        assert "output_data" not in result
+
+    def test_missing_path_falls_back_to_existing_ancestor(self, tmp_path):
+        # Deeply non-existent path under a real tmpdir — falls back to tmpdir.
+        nonexistent = tmp_path / "does" / "not" / "exist"
+        result = compute_disk_free({"phantom": str(nonexistent)})
+        # Fallback found tmp_path; we get a real number, not a missing key.
+        assert "phantom" in result
+        assert 0.0 <= result["phantom"] <= 100.0
+
+    def test_unreadable_path_is_omitted_not_zeroed(self):
+        # An absolute path whose parents also don't exist returns nothing.
+        # Use a label so completely synthetic that no ancestor can match.
+        result = compute_disk_free({"nope": "\x00invalid\x00"})
+        # Either omitted (preferred) or a real number. Never a zero placeholder
+        # that would falsely trigger "disk full" alarms.
+        if "nope" in result:
+            assert result["nope"] > 0.0
+
+
+class TestHealthSnapshotDiskFreePct:
+    def test_health_snapshot_includes_disk_free_pct(self):
+        snap = health_snapshot(stats={"camera_ok": True, "fps": 10.0})
+        assert "disk_free_pct" in snap
+        assert isinstance(snap["disk_free_pct"], dict)
+        # Root partition is always present.
+        assert "root" in snap["disk_free_pct"]
+
+    def test_health_snapshot_preserves_existing_keys(self):
+        # The additive change MUST NOT remove status/ts/subsystems/disk subsystem.
+        snap = health_snapshot(stats={"camera_ok": True, "fps": 10.0})
+        assert "status" in snap
+        assert "ts" in snap
+        assert "subsystems" in snap
+        assert "disk" in snap["subsystems"]  # existing string-status field
+
+    def test_disk_free_pct_independent_of_subsystem_disk(self):
+        # The string status and the numeric pct are computed separately.
+        snap = health_snapshot(stats={"camera_ok": True, "fps": 10.0})
+        assert snap["subsystems"]["disk"]["status"] in ("ok", "warn", "fail")
+        # Pct is a number even if status is ok.
+        assert isinstance(snap["disk_free_pct"]["root"], float)
+
+    def test_custom_disk_partitions_overrides_defaults(self, tmp_path):
+        snap = health_snapshot(
+            stats={"camera_ok": True, "fps": 10.0},
+            disk_partitions={"scratch": str(tmp_path)},
+        )
+        assert "scratch" in snap["disk_free_pct"]
+        # Defaults are excluded when override supplied.
+        assert "root" not in snap["disk_free_pct"]
+
+
+# ---------------------------------------------------------------------------
 # Prometheus exposition tests
 # ---------------------------------------------------------------------------
 
@@ -236,6 +316,20 @@ class TestHealthEndpoint:
         body = resp.json()
         assert body["status"] == "fail"
         assert body["subsystems"]["camera"]["status"] == "fail"
+
+    def test_health_endpoint_surfaces_disk_free_pct(self, client):
+        server_module.stream_state.update_stats(
+            camera_ok=True, fps=10.0, detector="yolo",
+        )
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "disk_free_pct" in body
+        assert isinstance(body["disk_free_pct"], dict)
+        assert "root" in body["disk_free_pct"]
+        pct = body["disk_free_pct"]["root"]
+        assert isinstance(pct, (int, float))
+        assert 0.0 <= pct <= 100.0
 
 
 class TestMetricsEndpoint:


### PR DESCRIPTION
## Summary

Adds an **additive** numeric `disk_free_pct` field to `/api/health` so phone-home and dashboard consumers can read disk pressure without parsing the existing `subsystems.disk` status sentence. Scoped slice of #154 — retention config, cleanup script, and systemd timer already landed in #166.

## What changes

### `/api/health` (additive)
New top-level key, existing keys untouched:
```
"disk_free_pct": {"root": 87.2, "output_data": 64.5}
```

- Per-partition `free / total * 100`, rounded to two decimals
- Defaults: `root` (`/`) + `output_data` (`./output_data`)
- Custom partitions supported via `health_snapshot(disk_partitions=...)`
- Partitions whose `disk_usage` call fails are **omitted, not zeroed** — consumers can distinguish "really full" from "no data"
- `output_data` falls back to nearest existing ancestor when the directory has not been created yet (first boot, fresh Jetson)

### Files
- `hydra_detect/observability/health.py` — `compute_disk_free()`, `_partition_free_pct()`, `_DISK_FREE_PARTITIONS` constant, additive `disk_partitions` kwarg on `health_snapshot()`
- `hydra_detect/observability/__init__.py` — re-export `compute_disk_free`
- `tests/test_observability.py` — 9 new tests (5 for `compute_disk_free`, 4 for `health_snapshot` / `/api/health`)

### Diff stat
```
hydra_detect/observability/__init__.py |  3 +-
hydra_detect/observability/health.py   | 76 ++++++++++++++++++++++++++
tests/test_observability.py            | 94 ++++++++++++++++++++++++++++++++++
3 files changed, 172 insertions(+), 1 deletion(-)
```

## Acceptance bullets closed (from #154)
- [x] Disk free per partition surfaced in `/api/health`

## Deferred — tracked in #226
- [ ] `disk_free_pct < 15` → Capability Status WARN
- [ ] `disk_free_pct < 5` → Capability Status BLOCKED (pause recording, keep metadata)
- [ ] Recovery: auto-clear when back above threshold

These depend on the Capability Status framework (#146). `hydra_detect/storage_rotation.disk_status()` already returns READY/WARN/BLOCKED on the same thresholds — once #146 is wired in, plugging this into the dashboard header is mechanical.

## Out of scope (separate issues)
- "Wipe All Mission Data" dashboard button — depends on log-privacy issue, not yet open
- Docker image history pruning to last 2 versions — depends on #152 OTA path
- Per-category size on settings page — pending settings-page reshape

## Compatibility
- Existing consumers reading `subsystems.disk.status` keep working unchanged
- `set(body["subsystems"].keys()) == set(SUBSYSTEMS)` assertion in `TestHealthEndpoint::test_returns_structured_shape` still passes — the new key is at the top level, not inside `subsystems`
- Back-compat fields (`healthy`, `camera_ok`, `fps`) untouched

## Test plan
- [x] `python -m pytest tests/test_observability.py -v` — 32/32 pass (9 new)
- [x] `python -m pytest tests/test_storage_rotation.py -v` — 33/33 pass, no regressions
- [x] `python -m pytest tests/test_web_api.py tests/test_require_auth_control.py tests/test_capability_status.py` — 0 regressions
- [x] LOC budget: 172 / 500
- [ ] CI green
- [ ] Adversarial review doc filed (3 rounds, ≥1 HIGH in R3)

Refs #154 (scoped slice; full closure requires #226 + log-privacy issue + #152)