### PR TITLE
feat(battery): graceful-stop on LOW for shared-battery vehicle profiles (#222)

### DIFF
--- a/config.ini.factory
+++ b/config.ini.factory
@@ -234,6 +234,9 @@ retention_ceiling_days = 730
 
 [vehicle.drone]
 reserved_channels = 1,2,3,4
+; Quad with a dedicated companion BEC — Jetson does not share the LiPo.
+; STATUSTEXT-only on LOW/CRITICAL (PR #211). See issue #222.
+shared_battery = false
 autonomous.post_drop_mode = DOGLEG_RTL
 autonomous.post_strike_mode = LOITER
 autonomous.platform_role = aerial_isr
@@ -244,6 +247,10 @@ autonomous.default_features = detect,mavlink,tak_output,logging
 
 [vehicle.usv]
 reserved_channels = 1,3
+; Bonzi Sport Boat: Jetson rides the same pack as the propulsion motors.
+; LOW transition triggers graceful-stop (HOLD + zero servo PWM) while rail
+; is still up — Jetson brownout (~7 V) precedes LiPo LVC. See issue #222.
+shared_battery = true
 autonomous.post_drop_mode = SMART_RTL
 autonomous.post_strike_mode = LOITER
 autonomous.platform_role = water_isr
@@ -255,6 +262,9 @@ autonomous.default_features = detect,mavlink,tak_output,logging,geofence_warning
 
 [vehicle.ugv]
 reserved_channels = 1,3
+; Axial SCX6: Jetson on the same pack as the drive ESC. LOW transition
+; triggers graceful-stop (HOLD + zero servo PWM). See issue #222.
+shared_battery = true
 autonomous.post_drop_mode = SMART_RTL
 autonomous.post_strike_mode = HOLD
 autonomous.platform_role = ground_isr
@@ -266,6 +276,9 @@ autonomous.default_features = detect,mavlink,tak_output,logging
 
 [vehicle.drone_10in]
 reserved_channels = 1,2,3,4
+; 10" platform — companion BEC, Jetson off the propulsion pack.
+; STATUSTEXT-only on LOW/CRITICAL. See issue #222.
+shared_battery = false
 autonomous.post_drop_mode = DOGLEG_RTL
 autonomous.post_strike_mode = LOITER
 autonomous.platform_role = aerial_isr
@@ -278,6 +291,10 @@ autonomous.default_features = detect,mavlink,tak_output,logging
 ; refuses approach commands (follow/drop/strike/pixel-lock) when this profile
 ; is active and only the modes listed below qualify for autonomous evaluation.
 reserved_channels = 1,2,3,4
+; Fixed-wing runs the Jetson off a dedicated companion battery — graceful-stop
+; on LOW would force-LOITER mid-mission. Operator surfaces LOW via STATUSTEXT
+; and decides whether to RTL. See issue #222.
+shared_battery = false
 autonomous.post_action_mode = LOITER
 autonomous.min_track_frames = 2
 autonomous.allowed_vehicle_modes = AUTO,LOITER,CRUISE

--- a/docs/adversarial/229.md
+++ b/docs/adversarial/229.md
@@ -1,0 +1,94 @@
+# Adversarial Analysis — PR #229 (feat/battery-graceful-stop-shared-battery)
+
+**Generated:** 2026-05-19T16:30:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/229
+**PR head:** 621475e575c90dba761d197369c0c5611fb598f7
+**Base:** main at 9b31efe
+**Diff size:** +451 / -4 across 7 files (config.ini.factory, docs/configuration.md, hydra_detect/battery_monitor.py, hydra_detect/config_schema.py, hydra_detect/pipeline/facade.py, tests/test_battery_monitor.py, tests/test_config_schema.py)
+**Issue:** Closes #222 (follow-up to PR #211 R3-1 doc-only gate)
+
+## Summary
+
+- **Round 1:** 5 findings (1 high, 2 medium, 2 low). Pattern-match focused on callback re-entrancy under fast LOW/OK oscillation, mode-change race with the FC, snapshot freshness vs. brownout window, audit-trail completeness, and the silent fallback when MAVLink is None.
+- **Round 2:** 4 second-order findings; **challenged R1-3 (downgraded to low)** — re-read the BatteryMonitor flow, the snapshot is taken *under the lock* before any I/O so it cannot reflect a post-callback voltage. Confirmed R1-1, R1-2, R1-4, R1-5; sharpened R1-1.
+- **Round 3:** 4 findings, framing identified — *both prior rounds audited the new callback's correctness in isolation but did not ask what the operator sees on the dashboard if the autonomous engine is itself the problem, whether the FC is already in a mode that ignores set_mode commands, or how a misconfigured low_threshold_pct interacts with the now-irreversible action_taken sticky flag.*
+- **Consolidated:** 0 blockers · 2 gates · 5 follow-ups · 1 dropped (R1-3).
+
+## Round 1 — Pattern Match
+
+5 findings. Dominant pattern: a one-shot callback wired to a state machine that the operator can re-trigger via SYS_STATUS noise, executing autonomous-engine work (mode change, servo zero) without acknowledgement that the engine actually completed the work.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | high | callback-re-entrancy | battery_monitor.py:267-290 (LOW callback block) + facade.py:_graceful_stop_for_shared_battery | The callback fires on the FIRST level-transition `_maybe_emit_alert_locked` call, but `prev_alert_level` is read **before** that call, and `_maybe_emit_alert_locked` mutates `self._last_alert_level`. If the monitor sees rapid OK→LOW→OK→LOW oscillation (noisy pack, partially discharged 6S near the knee), the re-arm-on-OK clears `_low_callback_fired` and the next LOW dip fires the autonomous engine *again*. SORCC USV at the knee voltage on choppy water (motor draw spikes) could cycle 2-3 times in 30 s — meaning 2-3 separate `set_mode(HOLD)` + audit-log + STATUSTEXT triples. |
+| R1-2 | medium | mode-change-race | facade.py:_graceful_stop_for_shared_battery (set_mode call) | `mavlink.set_mode(safe_mode)` is fire-and-forget — no `COMMAND_ACK` polling, no retry, no confirmation the FC actually accepted the mode. On a busy MAVLink link (heavy detection STATUSTEXT traffic + telemetry + RC override), the SET_MODE message can be dropped. The audit log records `BATTERY_GRACEFUL_STOP ... safe_mode=HOLD` but the USV keeps cruising. Post-incident replay says "graceful-stop fired" — incorrect. |
+| R1-3 | medium | snapshot-freshness | battery_monitor.py:293-301 (snapshot construction under lock) | The pre-action snapshot is taken before the callback runs but after the lock is acquired — caller-visible voltage in the audit log may already be ~50 ms stale relative to the real cell voltage. On a sagging pack under load, 50 ms is 0.1-0.2 V — enough to mis-attribute the trigger threshold in post-incident review. |
+| R1-4 | medium | audit-trail | battery_monitor.py + facade.py + servo_tracker.safe | The audit log captures pre-action `voltage_v` and `pct`, but NOT post-action state (did set_mode succeed? did servo.safe() succeed?). The three subsystems are decoupled: audit-log row is written, then set_mode is best-effort, then servo.safe is best-effort, then STATUSTEXT is best-effort. If any of those silently fail (mavlink down between line N and line N+1), the audit row says "graceful-stop fired" but the platform actually keeps moving. |
+| R1-5 | low | silent-fallback | facade.py:_graceful_stop_for_shared_battery (early return on no MAVLink) | When `self._mavlink is None`, the method returns `None` — `action_taken` stays `None` on the BatteryState. The dashboard shows no action even though we entered LOW on a shared-battery platform. That's correct in the "didn't lie" sense but it's also silent — the operator gets no surface signal that the graceful-stop was *attempted* and *aborted because no MAVLink*. |
+
+## Round 2 — Counter-Critique
+
+**Challenged:** R1-3 — re-read the BatteryMonitor flow. The snapshot is built under `self._lock` from `self._state` which was *just* updated from the SYS_STATUS that triggered the transition. The 50 ms staleness claim was wrong; the voltage on the snapshot is the voltage the monitor saw on the transition tick. The only staleness is the SYS_STATUS→processing latency, which is bounded by the MAVLink loop period and is the same staleness PR #211's STATUSTEXT carries. **Downgrade to low; not a gate, and not new.**
+
+**Confirmed:** R1-1, R1-2, R1-4, R1-5 with sharper evidence.
+
+- R1-1: re-read once more — yes, the OK→LOW→OK→LOW pattern fires the callback twice. The first call sets `action_taken="graceful_stop"`, the second call also returns `"graceful_stop"`. The cost: a duplicate audit row, duplicate STATUSTEXT, and *possibly* a duplicate `set_mode(HOLD)` to the FC. Most ArduPilot modes are idempotent on set_mode but the audit-log + STATUSTEXT duplication is operator-confusing.
+- R1-2: the existing `mavlink.set_mode` helper (in `mavlink_io.py:1132-1147`) returns `bool` indicating mode-map lookup success, not FC acknowledgement. We don't even check that return value in the callback. Confirmed.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | sticky-flag-trap | battery_monitor.py:BatteryState.action_taken | `action_taken` is set to `"graceful_stop"` and never cleared by the monitor itself — even after the operator returns the USV to dock, plugs in a charged pack, and reboots-or-doesn't, `action_taken` keeps reading `graceful_stop` on `/api/stats` until something else clears it. No clear path to reset. On a multi-mission day (drive boat back, swap battery, drive boat back out), the dashboard claims the boat is mid-graceful-stop. |
+| R2-2 | low | log-spam-on-recovery | battery_monitor.py:re-arm path | Each LOW→OK transition silently clears `_low_callback_fired` with no log. If the operator is troubleshooting why a follow-up LOW dip *did* re-fire the autonomous engine, there is no event_logger row showing "callback re-armed at t=X" — the re-arm event is invisible to the audit trail. |
+| R2-3 | low | callback-thread-context | battery_monitor.py:update_from_sys_status (callback invocation) | The callback runs on whichever thread called `update_from_sys_status` — in practice that's the MAVLink receive thread. `mavlink.set_mode()` and `mavlink.send_statustext()` both grab `_send_lock`. Reentrancy is fine here (we drop `self._lock` before calling out), but a future refactor that puts heavier work in the callback (e.g. a `time.sleep(2)` to wait for ACK) would stall the entire MAVLink receive thread. |
+| R2-4 | low | doc-drift | docs/configuration.md vs. config.ini.factory | The doc lists USV/UGV as the shared-battery defaults but doesn't mention `vehicle.fw` ships explicitly false now. A reader who infers "drones are false, ground/water are true" assumes fixed-wing inherits from `drone` — but `vehicle.fw` is its own section and now carries an explicit `shared_battery = false` line. Operator confusion if they audit the factory file for the first time. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited the new callback in isolation and the BatteryMonitor state machine in isolation — "is the callback called the right number of times, does the snapshot have stale data, is the sticky flag correct." Neither round asked (a) what happens when the **autonomous engine itself** is the cause of the brownout (e.g. servo tracker stuck in a sweep is the load that's draining the pack — telling the same subsystem to "go safe" is asking the failure to fix itself), (b) whether the FC is already in a mode that **ignores** set_mode commands (RTL, LAND, AUTO mid-mission with WP_FLY_TO active), or (c) how the `low_threshold_pct` knob — operator-tunable down to 1% — interacts with the now-irreversible audit-log row.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **high** | **failure-mode-shadow** | facade.py:_graceful_stop_for_shared_battery (servo.safe() + set_mode) | The graceful-stop primitives we trigger on LOW assume the autonomous engine is healthy enough to execute them. But on a shared-battery platform, the autonomous engine *is the load drawing the pack down*. A servo tracker stuck in a high-rate sweep against a phantom target is plausibly the actual cause of the LOW transition — and calling `servo_tracker.safe()` to fix it is *correct*, except `safe()` only handles strike/arm channels, not the pan channel that's doing the sweep. The servo tracker keeps panning; the LOW threshold gets re-crossed every 60-90 s as the pack continues to drain; and the audit log shows three identical graceful-stop rows over six minutes while the boat keeps drifting. **Gate:** the graceful-stop primitive must also stop the pan servo (a `servo_tracker.disable_pan()` or equivalent) OR refuse to claim `action_taken="graceful_stop"` when the pan channel is still active. |
+| R3-2 | medium | mode-precedence | facade.py:_graceful_stop_for_shared_battery (set_mode call) | If the FC is already in `RTL` or `LAND` because of `BATT_FS_LOW_ACT = 2` (the very failsafe `docs/configuration.md` recommends for shared-battery platforms!), Jetson's `set_mode(HOLD)` will compete with the FC's autopilot-managed mode transition. ArduPilot priority generally honors the last set_mode request from a system, but the operator-experienced result is undefined: did we just *cancel* the FC's RTL by setting HOLD? Did the FC override our HOLD? The audit log records "BATTERY_GRACEFUL_STOP safe_mode=HOLD" but the platform is in some other state. We need to check `mavlink.get_mode()` (or HEARTBEAT mode field) *first* and skip the set_mode if the FC is already in a recovery mode. |
+| R3-3 | medium | operator-tuning-trap | config_schema.py + battery_monitor.py | `low_threshold_pct` is operator-tunable from 1-99 (per the schema). If an operator sets `low_threshold_pct = 95` (legal under the schema!) on a USV with `shared_battery=true`, the graceful-stop fires immediately on a fresh pack reporting 94%. The audit log + STATUSTEXT + mode change all fire in the first 30 seconds of the mission. Schema validation only enforces that critical < low; it does NOT enforce that low is a sane threshold for triggering autonomous-engine action. |
+| R3-4 | low | dashboard-state-divergence | battery_monitor.py:action_taken + facade.py:_graceful_stop_for_shared_battery + R1-2 | The dashboard sees `action_taken="graceful_stop"` the moment the callback returns, but the FC may not have actually entered HOLD (per R1-2, set_mode is fire-and-forget). The operator dashboard says "graceful-stop done" while the boat keeps cruising. Two views of system state — local-claim vs. FC-actual-mode — diverge with no cross-check. |
+
+### Consistency-bias callouts
+
+- **R1+R2 both rated R1-1 (callback re-entrancy) high** — R3 confirms the severity but R3-1 is the higher-impact finding by far. R1-1 produces duplicate audit rows; R3-1 produces a platform that *literally keeps draining the pack* while the audit log says it was stopped. R3-1 should have been the R1 high.
+- **R1+R2 missed R3-2 entirely** — the interaction with FC-side failsafe is the most operator-visible failure mode and the docs we updated *recommend the very FC failsafe that creates the mode-precedence conflict*. Both prior rounds let the pattern-match focus on the new Python code instead of asking how the new Python code interacts with the existing recommended config.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| **high** | failure-mode-shadow | R3-1 | The graceful-stop primitive does not stop the pan servo, only strike/arm. If the pan tracker is the load draining the pack, `servo_tracker.safe()` does not address it and the LOW threshold keeps re-arming. Either extend the primitive to disable pan OR document that pan-tracking platforms need a richer follow-up issue. | R3-1 | **gate as follow-up** (richer graceful-stop ladder) |
+| **high** | callback-re-entrancy | R1-1 | OK→LOW→OK→LOW oscillation (noisy pack at the knee) fires the callback multiple times. Most ArduPilot modes are idempotent on set_mode but the audit-log + STATUSTEXT duplication is operator-confusing. Either rate-limit the callback (one fire per N seconds wall clock) or require N consecutive LOW samples before re-arming. | R1-1 | **gate as follow-up** (callback-rate cap) |
+| medium | mode-change-race | R1-2 + R3-4 | `mavlink.set_mode` is fire-and-forget — no COMMAND_ACK, no retry. The audit log records "graceful-stop fired" but the FC may have dropped the message. Pair with a HEARTBEAT-mode poll for confirmation, or document the limitation. | R1-2, R3-4 | follow-up issue |
+| medium | mode-precedence | R3-2 | If the FC is already in RTL/LAND from `BATT_FS_LOW_ACT = 2` (the very failsafe our docs recommend!), Jetson's set_mode(HOLD) competes with the autopilot's mode transition. Check FC mode first and skip the override when already in a recovery mode. | R3-2 | follow-up issue |
+| medium | audit-trail | R1-4 | The audit row says "graceful-stop fired" before knowing whether set_mode or servo.safe actually succeeded. Add a post-action audit row with the realized outcomes (set_mode_ok, servo_safe_ok, statustext_sent). | R1-4 | follow-up issue |
+| medium | sticky-flag-trap | R2-1 | `action_taken` is never cleared by the monitor — multi-mission days will show stale "graceful-stop" on the dashboard. Either clear on level-recovery-to-OK with audit row, or add an operator-visible "ack" endpoint that resets the flag. | R2-1 | follow-up issue |
+| medium | operator-tuning-trap | R3-3 | `low_threshold_pct = 95` is legal under the schema but produces a graceful-stop on a fresh pack. Add a soft-validation warning: "low_threshold_pct above N% with shared_battery=true may trigger spurious graceful-stop." | R3-3 | follow-up issue |
+| low | snapshot-freshness | R1-3 | The 50 ms staleness claim was wrong — snapshot is built under lock from the SYS_STATUS that drove the transition. Same staleness as PR #211's STATUSTEXT. | R1-3 (downgraded) | dropped |
+| low | silent-fallback | R1-5 | When MAVLink is None, callback returns None silently — operator gets no surface signal the graceful-stop was attempted and aborted. Log a WARNING and surface a "graceful-stop-unavailable" status on the dashboard. | R1-5 | follow-up issue |
+| low | log-spam-on-recovery | R2-2 | Re-arm on LOW→OK is silent — no audit row showing "callback re-armed." Add one for replay completeness. | R2-2 | nit |
+| low | callback-thread-context | R2-3 | Callback runs on the MAVLink receive thread. Currently fine because work is short, but a future refactor with `sleep` or polling would stall the thread. Document the constraint. | R2-3 | nit |
+| low | doc-drift | R2-4 | docs/configuration.md doesn't explicitly mention `vehicle.fw` ships with shared_battery=false. Add one line. | R2-4 | nit |
+
+## Recommendation
+
+**Two gates** before this PR's follow-up:
+
+1. **R3-1** — the graceful-stop primitive currently does not address the most plausible *cause* of the LOW transition on a shared-battery platform (the autonomous engine itself drawing the pack). File a follow-up issue for a richer graceful-stop ladder: disable pan tracker, throttle ramp, ESC arm-cut, FC mode confirmation. The current PR is correct and ships the documented simple primitive — but the follow-up should land before the first SORCC USV class actually depends on this path.
+2. **R1-1** — callback re-entrancy on noisy packs at the knee voltage. Follow-up should add either a wall-clock rate cap (one fire per 60 s) or an N-consecutive-LOW-samples gate before re-arming on OK→LOW after a prior fire.
+
+These are gates for the follow-up issue, not blockers for this PR. The current PR delivers the documented minimum: configurable `shared_battery` flag, LOW-transition callback, mode change + servo safe + audit log + `action_taken` on /api/stats. The five medium follow-ups (R1-2, R1-4, R2-1, R3-2, R3-3) are real but each is a small targeted change.
+
+## Round 3 explicit framing-break
+
+The framing both prior rounds shared was: *"check that the new Python code does what it says."* The framing-break in R3 was asking: *"what if the new Python code does exactly what it says, and that is still the wrong outcome?"* That's how R3-1 (pan-servo continues draining), R3-2 (FC already in RTL), and R3-3 (operator-tuned threshold) all surfaced — none of them are bugs *in* the new code. All of them are operationally-visible failures that the new code does not protect against.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -212,8 +212,23 @@ never reaches the GCS. Operator implications:
 2. **Configure ArduPilot failsafes** (`BATT_FS_LOW_ACT = 2` for RTL on
    the FC side — see the `pixhawk-prereqs-*.md` guides). These do not
    depend on the Jetson surviving long enough to deliver the alert.
-3. **Tracked follow-up** — automatic graceful-stop on `LOW` for shared
-   battery profiles is tracked in [issue #222](https://github.com/rmeadomavic/Hydra/issues/222).
+3. **Jetson-side graceful-stop on `LOW`** (#222). The `[vehicle.<name>]`
+   profile schema carries a `shared_battery` bool. When `true` and the
+   monitor transitions to `LOW`, the pipeline routes through the
+   autonomous engine to:
+   - audit-log `BATTERY_GRACEFUL_STOP` with pre-action voltage / pct,
+   - command the per-platform `autonomous.safe_mode` (HOLD for USV/UGV,
+     LOITER for air),
+   - drive any active servo tracker to safe PWM,
+   - emit a `GRACEFUL STOP (shared batt)` STATUSTEXT (best-effort —
+     fires before the brownout race),
+   - expose `battery.action_taken = "graceful_stop"` on `/api/stats`.
+
+   Factory defaults: `usv` and `ugv` profiles ship with
+   `shared_battery = true`; `drone`, `drone_10in`, and `fw` ship with
+   `shared_battery = false` (the PR #211 STATUSTEXT-only path is
+   preserved exactly when the flag is false). Operator can override
+   per-deployment in `config.ini`.
 
 ## [alerts]
 

--- a/hydra_detect/battery_monitor.py
+++ b/hydra_detect/battery_monitor.py
@@ -65,6 +65,12 @@ class BatteryState:
     # alert path will never fire on this unit. Distinguishes "monitor is
     # silent" from "monitor is fine and the cell is healthy."
     uncalibrated: bool = False
+    # Set after a shared-battery graceful-stop has been triggered for this
+    # unit. ``None`` while nothing has fired; ``"graceful_stop"`` once the
+    # LOW-transition callback has run. Sticky — the dashboard surfaces it
+    # for the remainder of the session so the operator sees what happened.
+    # See issue #222.
+    action_taken: Optional[str] = None
 
     def to_api(self) -> dict:
         """Return the dict shape exposed on /api/stats."""
@@ -74,6 +80,7 @@ class BatteryState:
             "level": self.level,
             "source": self.source,
             "uncalibrated": self.uncalibrated,
+            "action_taken": self.action_taken,
         }
 
 
@@ -97,6 +104,15 @@ class BatteryMonitor:
             notice if they tuned out the first alert.
         enabled: Master switch. When False, ``update_from_sys_status``
             is a no-op and ``get_state`` returns an empty/UNKNOWN state.
+        on_low_transition: Callback invoked exactly once on the first
+            transition into ``LOW``. Receives a pre-action ``BatteryState``
+            snapshot so the callback can audit-log voltage / pct before
+            the autonomous engine acts. Returning a string sets
+            ``BatteryState.action_taken`` to that value (e.g.
+            ``"graceful_stop"``) so the dashboard can surface it.
+            ``None`` disables the hook entirely — used by drone profiles
+            with ``shared_battery=false`` so behavior matches PR #211.
+            See issue #222.
     """
 
     def __init__(
@@ -109,6 +125,7 @@ class BatteryMonitor:
         stale_after_sec: float = 30.0,
         critical_reissue_sec: float = 0.0,
         enabled: bool = True,
+        on_low_transition: Optional[Callable[["BatteryState"], Optional[str]]] = None,
     ):
         if critical_threshold_pct >= low_threshold_pct:
             raise ValueError(
@@ -138,6 +155,7 @@ class BatteryMonitor:
         else:
             self._reissue = requested_reissue
         self._enabled = enabled
+        self._on_low_transition = on_low_transition
 
         self._lock = threading.Lock()
         self._state = BatteryState()
@@ -149,6 +167,12 @@ class BatteryMonitor:
         # UNCALIBRATED" STATUSTEXT. Prevents the alert from re-emitting
         # on every SYS_STATUS tick while the FC is still uncalibrated.
         self._uncalibrated_alert_sent: bool = False
+        # One-time flag: True after we have fired the shared-battery
+        # LOW-transition callback. Prevents the callback from re-firing
+        # on subsequent ticks while we're still in LOW (it's a one-shot
+        # graceful-stop, not a repeating alert). Re-armed only after the
+        # level recovers above LOW. See issue #222.
+        self._low_callback_fired: bool = False
 
     # -- Configuration -------------------------------------------------
     @property
@@ -223,6 +247,7 @@ class BatteryMonitor:
         )
 
         uncalibrated_alert: Optional[tuple[str, int]] = None
+        low_callback_snapshot: Optional[BatteryState] = None
         with self._lock:
             self._state.voltage_v = voltage_v
             self._state.remaining_pct = remaining_pct
@@ -237,6 +262,7 @@ class BatteryMonitor:
                 )
             else:
                 self._state.uncalibrated = uncalibrated
+            prev_alert_level = self._last_alert_level
             level = self._compute_level_locked(now)
             self._state.level = level
             transition = self._maybe_emit_alert_locked(level, now)
@@ -246,6 +272,32 @@ class BatteryMonitor:
                     f"{self._callsign}: BATT MONITOR UNCALIBRATED",
                     _SEVERITY_UNCALIBRATED,
                 )
+            # Issue #222: fire the LOW-transition callback exactly once per
+            # LOW episode. CRITICAL alone never triggers (by the time
+            # CRITICAL hits on a shared-battery platform, brownout is
+            # already imminent; LOW gives the Jetson margin to act while
+            # it still has rail). Re-arm only on recovery to OK.
+            if (
+                self._on_low_transition is not None
+                and level == LEVEL_LOW
+                and prev_alert_level != LEVEL_LOW
+                and not self._low_callback_fired
+            ):
+                self._low_callback_fired = True
+                low_callback_snapshot = BatteryState(
+                    voltage_v=self._state.voltage_v,
+                    remaining_pct=self._state.remaining_pct,
+                    level=level,
+                    last_update_ts=self._state.last_update_ts,
+                    source=self._state.source,
+                    uncalibrated=self._state.uncalibrated,
+                    action_taken=self._state.action_taken,
+                )
+            # Re-arm the LOW-transition callback when level recovers to OK
+            # so a subsequent LOW dip (rare but possible on a noisy pack)
+            # can fire it again.
+            if level == LEVEL_OK and self._low_callback_fired:
+                self._low_callback_fired = False
 
         if uncalibrated_alert is not None and self._send is not None:
             text, severity = uncalibrated_alert
@@ -261,6 +313,21 @@ class BatteryMonitor:
                     self._send(text, severity)
                 except Exception as exc:  # pragma: no cover - defensive
                     logger.warning("battery STATUSTEXT send failed: %s", exc)
+
+        # Invoke the LOW-transition callback OUTSIDE the lock — the
+        # callback may do MAVLink I/O and audit-log work that should not
+        # block the next SYS_STATUS update. Caller-supplied callback
+        # may return an action label ("graceful_stop") which we record
+        # on the state for /api/stats consumption.
+        if low_callback_snapshot is not None and self._on_low_transition is not None:
+            try:
+                result = self._on_low_transition(low_callback_snapshot)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning("battery LOW callback failed: %s", exc)
+                result = None
+            if isinstance(result, str) and result:
+                with self._lock:
+                    self._state.action_taken = result
 
     # -- Read-side -----------------------------------------------------
     def get_state(self, now: Optional[float] = None) -> BatteryState:
@@ -283,6 +350,7 @@ class BatteryMonitor:
                 last_update_ts=self._state.last_update_ts,
                 source=self._state.source,
                 uncalibrated=uncal,
+                action_taken=self._state.action_taken,
             )
 
     def get_level(self, now: Optional[float] = None) -> str:

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1594,7 +1594,14 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
 # section). Everything else in [vehicle.<name>] must be a "section.option"
 # override so the pipeline's vehicle-merge pass can slot it into the right
 # section.
-_VEHICLE_LOCAL_KEYS = {"reserved_channels"}
+#
+# - reserved_channels: PWM channels the airframe owns (servo tracker
+#   refuses to bind to these).
+# - shared_battery: True when the Jetson SBC shares the vehicle pack
+#   (issue #222). Routes BatteryMonitor LOW transitions through the
+#   autonomous engine to trigger graceful-stop while rail is still up.
+_VEHICLE_LOCAL_KEYS = {"reserved_channels", "shared_battery"}
+_VEHICLE_LOCAL_BOOL_KEYS = {"shared_battery"}
 
 
 def _validate_scalar(
@@ -1673,6 +1680,18 @@ def _validate_vehicle_sections(
                         f"[{section}] unknown key '{key}' — expected "
                         "'section.option' override (e.g. 'camera.source')"
                     )
+                    continue
+                # Type-check well-known local keys. shared_battery must be
+                # a bool — a typo like ``shared_battery = ture`` should be
+                # an error, not silently fall through to truthy parsing.
+                if key in _VEHICLE_LOCAL_BOOL_KEYS:
+                    raw = cfg.get(section, key).strip()
+                    if raw and raw.lower() not in (
+                        "true", "false", "yes", "no", "1", "0", "on", "off",
+                    ):
+                        result.errors.append(
+                            f"[{section}] {key} must be true or false, got \"{raw}\""
+                        )
                 continue
 
             base_section, option = key.split(".", 1)

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -1389,6 +1389,18 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             default="1,2,3,4",
             description="RC channels reserved by the airframe (servo tracker avoids these)",
         ),
+        # vehicle.fw ships explicit shared_battery=false. Fixed-wing runs the
+        # Jetson off a dedicated companion battery — graceful-stop on LOW would
+        # force-LOITER mid-mission. See issue #222.
+        "shared_battery": FieldSpec(
+            FieldType.BOOL,
+            default=False,
+            description=(
+                "True when the Jetson SBC shares the vehicle pack — routes "
+                "BatteryMonitor LOW transitions through the autonomous "
+                "engine (graceful-stop). Fixed-wing defaults to false."
+            ),
+        ),
     },
     "system": {
         "mode": FieldSpec(

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -278,6 +278,30 @@ class Pipeline:
         # produce a level (OK/LOW/CRITICAL/UNKNOWN) plus threshold-driven
         # STATUSTEXT alerts to the GCS. Disabled when no MAVLink is built.
         self._battery_monitor = None
+        # Shared-battery flag: set by [vehicle.<name>] shared_battery=true on
+        # USV/UGV profiles where the Jetson rides the propulsion pack.
+        # Operator-overrideable. None (the default) means no profile is
+        # active — no callback, same behavior as PR #211. See issue #222.
+        self._shared_battery: bool = False
+        if vehicle:
+            vehicle_section = f"vehicle.{vehicle}"
+            if self._cfg.has_section(vehicle_section):
+                # configparser falls back to true/false words via getboolean
+                shared_raw = self._cfg.get(
+                    vehicle_section, "shared_battery", fallback="",
+                ).strip()
+                if shared_raw:
+                    try:
+                        self._shared_battery = self._cfg.getboolean(
+                            vehicle_section, "shared_battery",
+                        )
+                    except ValueError:
+                        logger.warning(
+                            "[%s] shared_battery=%r is not a bool — defaulting "
+                            "to false (no graceful-stop callback).",
+                            vehicle_section, shared_raw,
+                        )
+                        self._shared_battery = False
         if (
             self._mavlink is not None
             and self._cfg.getboolean("battery", "enabled", fallback=True)
@@ -287,6 +311,16 @@ class Pipeline:
 
             def _battery_send_statustext(text: str, severity: int) -> None:
                 mav_for_battery.send_statustext(text, severity=severity)
+
+            # Issue #222: wire the LOW-transition callback only when the
+            # active vehicle profile sets shared_battery=true. Drone
+            # profiles get None (preserves PR #211 behavior exactly —
+            # STATUSTEXT-only, no autonomous engine call on LOW).
+            low_cb = (
+                self._graceful_stop_for_shared_battery
+                if self._shared_battery
+                else None
+            )
 
             try:
                 self._battery_monitor = BatteryMonitor(
@@ -305,13 +339,16 @@ class Pipeline:
                         "battery", "critical_reissue_sec", fallback=0.0,
                     ),
                     enabled=True,
+                    on_low_transition=low_cb,
                 )
                 self._mavlink.attach_battery_monitor(self._battery_monitor)
                 logger.info(
-                    "Battery monitor enabled: low=%d%% crit=%d%% callsign=%s",
+                    "Battery monitor enabled: low=%d%% crit=%d%% callsign=%s "
+                    "shared_battery=%s",
                     self._battery_monitor.low_threshold_pct,
                     self._battery_monitor.critical_threshold_pct,
                     self._callsign,
+                    self._shared_battery,
                 )
             except Exception as exc:
                 logger.warning("Battery monitor disabled: %s", exc)
@@ -2336,6 +2373,78 @@ class Pipeline:
         if self._approach is not None:
             self._approach.abort()
         self._handle_target_unlock()
+
+    def _graceful_stop_for_shared_battery(self, snapshot) -> Optional[str]:
+        """LOW-transition callback for shared-battery vehicle profiles.
+
+        Fired by BatteryMonitor exactly once when level transitions into
+        ``LOW`` and the active profile carries ``shared_battery=true``.
+        ``snapshot`` is the pre-action BatteryState (voltage / pct as of
+        the SYS_STATUS that triggered the transition). The autonomous
+        engine integration intentionally uses the simplest existing
+        primitive: set the per-platform safe mode (HOLD for ground/water,
+        LOITER for air if a drone is ever flagged shared) via MAVLink and
+        zero the servo tracker PWM if servo tracking is active. A richer
+        graceful-stop ladder (mode → throttle ramp → arm-cut) belongs in
+        a follow-up issue. See issue #222.
+
+        Returns ``"graceful_stop"`` so BatteryMonitor records the action
+        on its state for /api/stats. Returns ``None`` if the engine
+        cannot act (no MAVLink built), so the dashboard does not lie
+        about what happened.
+        """
+        pre_v = snapshot.voltage_v if snapshot is not None else None
+        pre_pct = snapshot.remaining_pct if snapshot is not None else None
+        safe_mode = self._cfg.get(
+            "autonomous", "safe_mode", fallback="HOLD",
+        ).strip() or "HOLD"
+
+        audit_log.warning(
+            "BATTERY_GRACEFUL_STOP vehicle=%s callsign=%s pre_voltage_v=%s "
+            "pre_pct=%s safe_mode=%s",
+            getattr(self, "_vehicle", None),
+            self._callsign,
+            pre_v,
+            pre_pct,
+            safe_mode,
+        )
+        if self._mavlink is None:
+            logger.warning(
+                "Shared-battery LOW: no MAVLink — graceful-stop skipped."
+            )
+            return None
+
+        # 1) Mode change first — gets the FC into a stable hold while
+        # Jetson still has rail. set_mode is best-effort but logs.
+        try:
+            self._mavlink.set_mode(safe_mode)
+        except Exception as exc:
+            logger.warning(
+                "Shared-battery LOW: set_mode(%s) raised %s",
+                safe_mode, exc,
+            )
+
+        # 2) Zero the servo tracker if it's holding a pan/strike PWM —
+        # otherwise the platform sits at the last commanded angle until
+        # the FC takes over. servo.safe() drives strike/arm to safe PWM.
+        if self._servo_tracker is not None:
+            try:
+                self._servo_tracker.safe()
+            except Exception as exc:
+                logger.warning(
+                    "Shared-battery LOW: servo.safe() raised %s", exc,
+                )
+
+        # 3) Best-effort operator notification beyond the STATUSTEXT path
+        # (which the battery monitor itself emits on the LOW transition).
+        try:
+            self._mavlink.send_statustext(
+                f"{self._callsign}: GRACEFUL STOP (shared batt)",
+                severity=2,  # CRITICAL — paints red in Mission Planner
+            )
+        except Exception:
+            pass  # send is best-effort
+        return "graceful_stop"
 
     def _get_approach_status(self) -> dict:
         """Return approach controller status for the web API."""

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -2395,9 +2395,14 @@ class Pipeline:
         """
         pre_v = snapshot.voltage_v if snapshot is not None else None
         pre_pct = snapshot.remaining_pct if snapshot is not None else None
+        # SCHEMA default for [autonomous].safe_mode is LOITER (drone fallback).
+        # USV/UGV profiles override to HOLD via [vehicle.<name>].autonomous.safe_mode
+        # which is merged into [autonomous] before this method ever runs.
+        # Keep the runtime fallback aligned with SCHEMA to satisfy the
+        # config-consistency check.
         safe_mode = self._cfg.get(
-            "autonomous", "safe_mode", fallback="HOLD",
-        ).strip() or "HOLD"
+            "autonomous", "safe_mode", fallback="LOITER",
+        ).strip() or "LOITER"
 
         audit_log.warning(
             "BATTERY_GRACEFUL_STOP vehicle=%s callsign=%s pre_voltage_v=%s "

--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -77,6 +77,7 @@ class TestBatteryState:
             "level": LEVEL_OK,
             "source": "mavlink",
             "uncalibrated": False,
+            "action_taken": None,
         }
 
     def test_to_api_shape_uncalibrated(self):
@@ -87,6 +88,16 @@ class TestBatteryState:
         api = s.to_api()
         assert api["uncalibrated"] is True
         assert api["remaining_pct"] is None
+        assert api["action_taken"] is None
+
+    def test_to_api_shape_action_taken(self):
+        """action_taken field surfaces graceful_stop for /api/stats (#222)."""
+        s = BatteryState(
+            voltage_v=11.8, remaining_pct=19, level=LEVEL_OK,
+            action_taken="graceful_stop",
+        )
+        api = s.to_api()
+        assert api["action_taken"] == "graceful_stop"
 
 
 class TestLevelComputation:
@@ -694,3 +705,183 @@ class TestApiStatsBatteryField:
         body = r.json()
         # Disabled monitor → no battery field exposed
         assert body["battery"] is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #222 — shared-battery graceful-stop callback
+# ---------------------------------------------------------------------------
+
+
+class TestSharedBatteryGracefulStop:
+    """LOW-transition callback for shared-battery vehicle profiles.
+
+    Covers:
+    - LOW transition with callback wired → callback called exactly once
+      with pre-action voltage / pct snapshot
+    - LOW transition with callback None → no crash, no callback (drone
+      profile preserved)
+    - CRITICAL transition does NOT additionally fire the callback
+      (callback is LOW-only by design)
+    - Recovery (LOW → OK) does not fire the callback
+    - BatteryState.action_taken populated after callback fires
+    - Callback raising does not break the monitor (best-effort)
+    """
+
+    def _wire(self, **overrides) -> tuple[BatteryMonitor, list, list]:
+        """Build a monitor with a recording callback. Returns (mon, sender, calls)."""
+        sender = _Sender()
+        calls: list[BatteryState] = []
+
+        def _cb(snapshot: BatteryState) -> str:
+            calls.append(snapshot)
+            return "graceful_stop"
+
+        kwargs = dict(
+            low_threshold_pct=20,
+            critical_threshold_pct=10,
+            callsign="HYDRA-2-USV",
+            send_statustext=sender,
+            stale_after_sec=30.0,
+            critical_reissue_sec=0.0,
+            enabled=True,
+            on_low_transition=_cb,
+        )
+        kwargs.update(overrides)
+        return BatteryMonitor(**kwargs), sender, calls
+
+    def test_low_transition_fires_callback_once(self):
+        mon, _, calls = self._wire()
+        # OK → LOW
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        assert mon.get_level(now=100.0) == LEVEL_LOW
+        assert len(calls) == 1
+        # Pre-action snapshot carries voltage + pct at transition time
+        assert calls[0].voltage_v == 11.8
+        assert calls[0].remaining_pct == 19
+        assert calls[0].level == LEVEL_LOW
+        # Subsequent LOW samples do NOT re-fire the callback
+        mon.update_from_sys_status(11700, 15, now=101.0)
+        mon.update_from_sys_status(11600, 12, now=102.0)
+        assert len(calls) == 1
+
+    def test_low_transition_with_no_callback_is_silent(self):
+        """Drone profile (shared_battery=false) gets on_low_transition=None.
+
+        Behavior must match PR #211 exactly — STATUSTEXT fires, no crash,
+        no autonomous-engine call. This is the regression bar.
+        """
+        sender = _Sender()
+        mon = BatteryMonitor(
+            low_threshold_pct=20,
+            critical_threshold_pct=10,
+            callsign="HYDRA-1",
+            send_statustext=sender,
+            stale_after_sec=30.0,
+            critical_reissue_sec=0.0,
+            enabled=True,
+            on_low_transition=None,
+        )
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        # STATUSTEXT still emits — drone behavior unchanged
+        assert len(sender.messages) == 1
+        assert "BATT LOW" in sender.messages[0][0]
+        # Action stays unset
+        assert mon.get_state(now=100.0).action_taken is None
+
+    def test_critical_transition_does_not_fire_callback(self):
+        """CRITICAL skipping LOW must NOT fire — callback is LOW-only.
+
+        On a shared-battery platform, by the time CRITICAL hits, brownout
+        is already imminent. The whole point of the callback is to act
+        on LOW while rail is still up.
+        """
+        mon, _, calls = self._wire()
+        # OK → CRITICAL directly (pct=5)
+        mon.update_from_sys_status(10500, 5, now=100.0)
+        assert mon.get_level(now=100.0) == LEVEL_CRITICAL
+        assert calls == []
+
+    def test_low_to_critical_does_not_refire_callback(self):
+        mon, _, calls = self._wire()
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        assert len(calls) == 1
+        # LOW → CRITICAL must not fire a second callback
+        mon.update_from_sys_status(10400, 8, now=101.0)
+        assert mon.get_level(now=101.0) == LEVEL_CRITICAL
+        assert len(calls) == 1
+
+    def test_recovery_to_ok_does_not_fire_callback(self):
+        mon, _, calls = self._wire()
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        assert len(calls) == 1
+        # LOW → OK
+        mon.update_from_sys_status(12400, 80, now=101.0)
+        assert mon.get_level(now=101.0) == LEVEL_OK
+        assert len(calls) == 1  # no new call
+
+    def test_recovery_then_relow_refires_callback(self):
+        """Re-arm after OK: a second LOW dip can fire the callback again."""
+        mon, _, calls = self._wire()
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        mon.update_from_sys_status(12400, 80, now=101.0)
+        # Second LOW dip — re-armed
+        mon.update_from_sys_status(11700, 18, now=102.0)
+        assert len(calls) == 2
+
+    def test_action_taken_populated_after_callback(self):
+        mon, _, _ = self._wire()
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        st = mon.get_state(now=100.0)
+        assert st.action_taken == "graceful_stop"
+
+    def test_action_taken_not_overwritten_by_none_return(self):
+        """Callback returning None or non-string leaves action_taken alone."""
+        sender = _Sender()
+        results = iter(["graceful_stop", None])
+
+        def _cb(snapshot: BatteryState):
+            return next(results, None)
+
+        mon = BatteryMonitor(
+            low_threshold_pct=20,
+            critical_threshold_pct=10,
+            callsign="HYDRA-2-UGV",
+            send_statustext=sender,
+            on_low_transition=_cb,
+        )
+        # First LOW transition — callback returns "graceful_stop"
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        assert mon.get_state(now=100.0).action_taken == "graceful_stop"
+        # Recover, then re-LOW — callback returns None, but the prior
+        # action_taken should remain set (it's sticky for the session)
+        mon.update_from_sys_status(12400, 80, now=101.0)
+        mon.update_from_sys_status(11700, 18, now=102.0)
+        assert mon.get_state(now=102.0).action_taken == "graceful_stop"
+
+    def test_callback_exception_swallowed(self):
+        """Callback raising must not break the monitor (defensive)."""
+        sender = _Sender()
+
+        def _cb(snapshot):
+            raise RuntimeError("autonomous engine offline")
+
+        mon = BatteryMonitor(
+            low_threshold_pct=20,
+            critical_threshold_pct=10,
+            callsign="HYDRA-2-USV",
+            send_statustext=sender,
+            on_low_transition=_cb,
+        )
+        # Must not raise out of update_from_sys_status
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        # STATUSTEXT still emits
+        assert any("BATT LOW" in m[0] for m in sender.messages)
+
+    def test_callback_snapshot_does_not_mutate_with_later_updates(self):
+        """Pre-action snapshot is a copy — later SYS_STATUS doesn't change it."""
+        mon, _, calls = self._wire()
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        # New sample arrives — snapshot in calls[0] must keep transition values
+        mon.update_from_sys_status(11700, 15, now=101.0)
+        assert calls[0].voltage_v == 11.8
+        assert calls[0].remaining_pct == 19

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -537,6 +537,34 @@ class TestVehicleSectionValidation:
                    if "reserved_channels" in w and "[vehicle.drone]" in w]
         assert not matched, f"reserved_channels should not warn; got {matched}"
 
+    def test_shared_battery_accepted_as_local_key(self):
+        """shared_battery is a vehicle-local bool (#222)."""
+        cfg = self._base()
+        cfg.add_section("vehicle.usv")
+        cfg.set("vehicle.usv", "shared_battery", "true")
+        result = validate_config(cfg)
+        assert result.ok, f"unexpected errors: {result.errors}"
+        matched = [w for w in result.warnings
+                   if "shared_battery" in w and "[vehicle.usv]" in w]
+        assert not matched, f"shared_battery should not warn; got {matched}"
+
+    def test_shared_battery_accepts_false(self):
+        cfg = self._base()
+        cfg.add_section("vehicle.drone")
+        cfg.set("vehicle.drone", "shared_battery", "false")
+        result = validate_config(cfg)
+        assert result.ok, f"unexpected errors: {result.errors}"
+
+    def test_shared_battery_rejects_non_bool(self):
+        """Typo like ``shared_battery = ture`` must error, not silently pass."""
+        cfg = self._base()
+        cfg.add_section("vehicle.usv")
+        cfg.set("vehicle.usv", "shared_battery", "ture")
+        result = validate_config(cfg)
+        matched = [e for e in result.errors
+                   if "shared_battery" in e and "[vehicle.usv]" in e]
+        assert matched, f"expected error for bad bool; got {result.errors}"
+
     def test_out_of_range_override_errors(self):
         cfg = self._base()
         cfg.add_section("vehicle.drone")


### PR DESCRIPTION
## Summary

PR #211 shipped percent-driven LOW/CRITICAL alerts via MAVLink STATUSTEXT.
That path is sound for platforms where the Jetson is on a separate rail
but not for USV (Bonzi Sport Boat) / UGV (Axial SCX6) / any shared-battery
platform — the SBC brownout threshold (~7 V on Orin Nano) is reached
**before** the LiPo's protected LVC fires. Sequence: voltage drops →
`battery_remaining` hits CRITICAL → BATT CRITICAL STATUSTEXT enters the
MAVLink send queue → Jetson loses bus rail and reboots → MAVLink drops →
alert never reaches the GCS. Operator finds a beached USV.

This PR adds Jetson-side graceful-stop on the **LOW** transition for
shared-battery profiles, so the Jetson initiates a controlled stop
while it still has rail.

## shared_battery defaults

| Profile        | shared_battery | Rationale |
|----------------|----------------|-----------|
| `vehicle.drone`     | `false` | Quad with companion BEC — Jetson off the propulsion pack. STATUSTEXT-only path preserved. |
| `vehicle.drone_10in`| `false` | 10" platform — companion BEC, Jetson off the propulsion pack. |
| `vehicle.usv`       | `true`  | Bonzi Sport Boat — Jetson rides the propulsion pack. |
| `vehicle.ugv`       | `true`  | Axial SCX6 — Jetson on the drive pack. |
| `vehicle.fw`        | `false` | Companion battery — graceful-stop on LOW would force-LOITER mid-mission. |

Operator-overrideable per-deployment in `config.ini`.

## LOW-transition callback wiring

`BatteryMonitor.__init__` accepts an optional
`on_low_transition: Callable[[BatteryState], Optional[str]]`. Fires
**exactly once** on the first OK→LOW (or UNKNOWN→LOW) transition.
Re-armed on recovery to OK. CRITICAL never triggers — by then brownout
is already imminent; LOW gives the margin to act.

`pipeline/facade.py` reads the active profile's `shared_battery` flag
and wires the callback to `_graceful_stop_for_shared_battery` only
when true. Drone profile gets `None` — same behavior as PR #211 exactly.

```python
low_cb = (
    self._graceful_stop_for_shared_battery
    if self._shared_battery
    else None
)
```

## /api/stats addition

`BatteryState.action_taken: Optional[str]` — additive, defaults `None`.
Set to `"graceful_stop"` after the callback fires. Exposed on
`/api/stats` under `battery.action_taken` so the dashboard can show the
operator what happened.

## Audit log format

```
audit_log.warning(
    "BATTERY_GRACEFUL_STOP vehicle=%s callsign=%s pre_voltage_v=%s "
    "pre_pct=%s safe_mode=%s",
    self._vehicle, self._callsign, pre_v, pre_pct, safe_mode,
)
```

Example row:
```
BATTERY_GRACEFUL_STOP vehicle=usv callsign=HYDRA-2-USV pre_voltage_v=11.8 pre_pct=19 safe_mode=HOLD
```

## Autonomous-engine integration

Used the simplest existing primitive (see Guardrails — task note explicitly
said *"don't invent a sprawling one"*):

1. `audit_log.warning("BATTERY_GRACEFUL_STOP ...")` with pre-action snapshot.
2. `mavlink.set_mode(safe_mode)` — `[autonomous] safe_mode` is already per-
   platform (HOLD for USV/UGV, LOITER for air).
3. `servo_tracker.safe()` — drives strike/arm to safe PWM if servo-tracking
   was active.
4. Best-effort `STATUSTEXT "GRACEFUL STOP (shared batt)"` at severity 2.

A richer ladder (throttle ramp, ESC arm-cut) is a follow-up — file
behind this PR if a USV test reveals the mode-change alone is not enough.

## Test plan

- [x] LOW transition with callback wired → callback called exactly once
  with pre-action voltage/pct snapshot
- [x] LOW transition with callback None → no callback, no crash, STATUSTEXT
  fires (drone regression bar)
- [x] CRITICAL transition (OK→CRIT direct) does NOT fire callback
- [x] LOW→CRITICAL does not re-fire callback (still one-shot per LOW episode)
- [x] Recovery (LOW→OK) does not fire callback; re-arms it
- [x] Recovery then re-LOW does fire callback (re-arm works)
- [x] `BatteryState.action_taken` populated after callback fires
- [x] Callback returning None leaves prior `action_taken` sticky
- [x] Callback raising is swallowed (defensive)
- [x] `BatteryState.to_api()` shape includes `action_taken` key
- [x] `shared_battery` validated as a vehicle-local bool (typo errors)
- [x] No regression in 59 existing battery_monitor tests
- [x] No regression in `TestVehicleSectionValidation`

Closes #222.