### PR TITLE
feat(mission): start/end mission tagging + event timeline + summary endpoint (#72)

### DIFF
--- a/docs/adversarial/230.md
+++ b/docs/adversarial/230.md
@@ -1,0 +1,73 @@
+# Adversarial Analysis — PR #230 (claude/wave2-issue-72)
+
+**Generated:** 2026-05-19T16:30:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/230
+**PR head:** 4d11338504fea3116d5e119a4c958f1314a79909
+**Base:** main at 9b31efe9
+**Diff size:** +1204 / -32 across 10 files (event_logger.py, detection_logger.py, pipeline/facade.py, mission_summary.py, review_export.py, web/server.py, web/static/js/ops.js, web/templates/ops.html, docs/api-reference.md, tests/test_mission.py)
+
+## Summary
+
+- **Round 1:** 6 findings (1 high · 3 medium · 2 low). Pattern-match focused on cache-key drift, the hot-path mission-id snapshot under the lock, mission_id semantics on the bootstrap "default" mission, the convex-hull degenerate case, and the cost of the JSONL scan on a long-running session.
+- **Round 2:** 4 second-order findings; **downgraded R1-3 to low** after re-reading `_handle_mission_end` — the tear-down order is correct as written but the *bootstrap* mission's id is never written to `runtime_config`, which is the actual gap. Confirmed R1-1, R1-2, R1-5, R1-6; sharpened R1-4.
+- **Round 3:** 5 findings, framing identified — *both prior rounds audited the implementation as a synchronous request/response problem; neither asked what happens to in-flight detections when a mission boundary fires mid-frame, how the summary endpoint behaves under a misbehaving operator who hits Start/End in a tight loop, or whether a stale cache can be served to a different mission after a log rotation drops the JSONL that populated it.*
+- **Consolidated:** 1 blocker · 3 gates · 6 follow-ups · 1 dropped (R1-3 downgrade).
+
+## Round 1 — Pattern Match
+
+6 findings. Dominant pattern: a new global identifier (mission_id) is threaded through three independently-locked subsystems (event logger, detection logger, web stream_state) with a 30 s read-through cache on top, and the on-disk substrate is the JSONL chain that gets rotated automatically by `DetectionLogger._rotate_if_needed()`. None of the new code holds a single overarching lock; consistency is "eventually correct" by construction.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | high | data-loss | mission_summary.py:138-141 (signature cache) | `_inputs_signature` only sees file count + mtime sum + size sum. When `DetectionLogger._open_rotated_log_file()` rotates a file mid-mission, the rotated file may be deleted by `_prune_old_logs()` before the summary endpoint refreshes — cached summary references detections that no longer exist on disk, and the new endpoint silently returns stale numbers. |
+| R1-2 | medium | thread-safety | detection_logger.py:212-220 (mission_id snapshot) | The snapshot of `self._mission_id` inside `log()` is taken under a *separate* lock from the chain-hash write. A mission End that fires between the snapshot and the put-on-queue lands a row stamped with the old id in the same file as later rows stamped with `None` — the JSONL has a clean boundary but the per-row provenance has a 1-tick blur. |
+| R1-3 | medium | tear-down-order | facade.py:3057-3062 (end mission ordering) | `_det_logger.set_mission_id(None)` is called before `_event_logger.end_mission()`, but the *bootstrap* mission's `runtime_config.mission_id` is never set anywhere — only handler-invoked starts populate it. A consumer that polls `runtime_config.mission_id` between facade init and the first explicit start sees `None` while the event logger is happily writing rows with a non-None id. |
+| R1-4 | medium | api-contract | server.py:2710-2716 (mission/start response) | `mission_id` in the response is `None` whenever the registered `on_mission_start` callback returns something falsy. The test asserts the callback returns a UUID, but production callsites could legitimately return None (e.g. the legacy `lambda _n: None` shim in test_pipeline_subsystems). Operators get `{"status":"started","mission_id":null}` and quietly cannot query `/api/summary`. |
+| R1-5 | low | magic-constant | mission_summary.py:24 | `_SUMMARY_TTL_SEC = 30.0` is engineering judgment with no observability. A user who hits `/api/summary` in a fast polling loop has no way to tell the cache is serving stale data — there's no `cached_at` field in the response. |
+| R1-6 | low | unicode-filename | event_logger.py:21-31 | `_safe_name` collapses unicode to underscores. A SORCC instructor running a non-ASCII callsign or sortie name loses information at file-naming time even though the JSONL `mission_start.name` keeps the original. Not wrong, but the on-disk file becomes hard to map back to the operator's chosen name. |
+
+## Round 2 — Counter-Critique
+
+**Challenged:** R1-3 — re-read `_handle_mission_end`. The tear-down ordering is correct as written; the real gap is that `_handle_mission_start` is the *only* code path that writes to `runtime_config.mission_id`, but the bootstrap call (`self._event_logger.start_mission("default")`) at facade init does not go through the handler. Production observers polling `runtime_config.mission_id` before the operator clicks Start get a misleading null while detection rows on disk are being stamped with the bootstrap UUID. **Downgrade to low — the bootstrap mission's id IS visible on `stream_state.stats.mission_id` (set each frame in the slow loop) so dashboards aren't actually blind; only the `runtime_config` polling path is inconsistent. Worth a follow-up to unify.**
+
+**Confirmed:** R1-1, R1-2, R1-4, R1-5, R1-6 with sharper evidence. R1-1 is the load-bearing one — the cache key never reads the JSONL itself, so a rotation that drops a file with detections from the active mission produces a wrong summary that survives the 30 s TTL because subsequent calls match the cache key (the deleted file no longer contributes to the file-count sum, so the signature stays "consistent" with the truncated dataset).
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | high | operator-adversarial | server.py:2654-2701 (start endpoint) | A misbehaving range operator who hits `POST /api/mission/start` in a tight loop spawns a fresh event JSONL file per call (EventLogger closes the previous file and opens a new one with a new UUID). Within 30 minutes on a Jetson with `max_log_files=20`, the rotation policy in `DetectionLogger` starts deleting older mission JSONLs to make room — the operator has weaponized the start button into a deletion vector for prior sorties' event timelines. |
+| R2-2 | medium | spec-divergence | mission_summary.py:165-174 (timestamps) | `_parse_ts` falls back to `None` on a malformed timestamp, but `time_to_first_detection_sec` is then `None` while everything else still aggregates. A SORCC operator pulls the summary, sees "duration 600s, total detections 42, time-to-first: null" and assumes detections happened outside the mission window. The correct semantic is probably "0" or "unknown — N detections with unparseable timestamps". |
+| R2-3 | medium | cache-poisoning | mission_summary.py:222-234 (cache eviction) | Cache eviction is "drop the oldest entry by `written_at`" when size > 64. An adversarial scanner cycling 65 distinct mission ids in <30 s evicts a legitimate cached summary on every call, forcing a full disk scan for the operator's actual mission. Not a CVE, but it makes the cache useless under attack. |
+| R2-4 | nit | naming | event_logger.py:128 (record dict) | `mission_id` keyed before `**data` is reachable through `_log_event` callers like `log_action({"mission_id": ...})` — a future contributor could clobber the mission id with caller-supplied data. The current callsites all pass benign dicts, but the dict-spread order is `default-first, caller-wins`, which is the opposite of what the comment implies. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited mission_id as a synchronous request/response identifier — "did this row get the right id, did the API return the id, is the cache key stable." Neither round asked (a) what the system does with in-flight detections that span a Start or End boundary mid-frame, (b) whether the summary endpoint's "convex hull" answer remains stable under operator behaviors like start-fly-pause-end-resume-restart, or (c) what happens to detections in the queue (detection_logger has a 100-item bounded queue) when the operator hits End — those rows are in the queue with the old id but the file on disk has already received the `mission_end` event from EventLogger, so the JSONL has detections *after* mission_end with the same mission_id, which the summary endpoint will count.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R3-1 | high | event-ordering | facade.py:3054-3076 (end ordering) | `_event_logger.end_mission()` writes the `mission_end` event with the old mission_id. But `_det_logger` still has up to 100 work items queued (from the writer queue). Those queued items were stamped with the old mission_id (we cleared it AFTER snapshotting), so when the writer thread drains them, they hit disk *after* the mission_end record but with the same mission_id. The summary endpoint then reports detections occurring after `mission_end_ts`. The duration is correct but `time_to_first_detection_sec` can briefly go negative on the next-frame Start if the operator does a fast End/Start. **This is a real audit-trail correctness gap.** |
+| R3-2 | medium | scope-creep | review_export.py:42-77 (_convex_hull) | Andrew monotone chain on 4 collinear points produces a hull of length 2 — but `_polygon_area_m2` early-returns 0 for hull length < 3. A flight pattern that hugs a single road for 10 minutes (UGV ground patrol, fixed-wing transit segment) reports `area_m2: 0.0` even though `point_count: 600`. Operationally misleading — the operator sees "no area" and thinks GPS dropped, when actually they flew a straight line. A bounding-box fallback (rectangle = 2*track_width * length) would catch this; current code does not. |
+| R3-3 | medium | observability | server.py:2779-2790 (summary endpoint) | The endpoint returns `200` with an empty summary if `mission` matches nothing on disk (no detections, no events). A typo'd UUID query gets the same shape as a real-but-empty mission. Operators have no signal that they hit a wrong id versus a genuinely-quiet sortie. |
+| R3-4 | low | platform-coupling | facade.py:1706 (stats publication) | The per-frame stats payload now carries `mission_elapsed_sec` computed off `time.monotonic()`. On a Jetson that lost steady-time clock during a brownout, monotonic clock keeps ticking but the `mission_start_ts` (which is `time.time()`, wall clock) drifts — the dashboard "elapsed" disagrees with the JSONL `mission_start.ts`. Low impact (monotonic is what you want for elapsed) but the two timebases are now mixed in a user-visible way. |
+| R3-5 | low | UI-feedback | ops.js:1908 (start prompt) | `window.prompt` is synchronous and blocks the JS thread. On a slow-rendering ops page with an ongoing high-FPS MJPEG stream, the prompt can lock the dashboard for 300+ ms while the operator types. Worse: cancel returns null, which the handler treats as a clean cancel — but a hit-Enter-on-empty also returns "" which gets defaulted to a timestamp. The operator can't enter a blank name to mean "no name"; the system always assigns one. |
+
+**Framing-break:** All three rounds assumed the operator wanted the system to do the right thing. R3 implicitly tested the system against an *adversarial-but-not-malicious* operator (typos, fast clicks, sustained polling, restart loops). The R2-1 and R3-3 findings sit in this bucket — the system is correct under happy-path testing but operationally fragile under realistic SORCC instructor behavior (a student grabs the dashboard, hits Start three times by mistake, then asks "where's my data").
+
+## Consolidated triage
+
+- **Blocker:** R3-1 (queued detections drain past `mission_end` with the old id) — fix before deploy.
+- **Gates:** R1-1 (cache vs rotation), R2-1 (DoS via start loop), R3-2 (collinear track reports zero area).
+- **Follow-ups (not blocking this PR):** R1-2 (1-tick blur), R1-4 (None response), R2-2 (null vs zero TTFD), R2-3 (cache eviction policy), R3-3 (missing-mission signal), R3-5 (sync prompt UX).
+- **Dropped:** R1-3 (tear-down order is correct; bootstrap-vs-runtime_config is a follow-up note).
+
+## Recommendations
+
+1. **R3-1 fix:** before `_event_logger.end_mission()`, flush the detection logger queue (`self._det_logger._write_queue.join()` with a bounded timeout). Or — cleaner — write `mission_end` with a `pending_writes: N` field that summary aggregation can use to mark the boundary as "soft".
+2. **R1-1 fix:** add the latest detection file's content hash to the signature (cheap — already opened in `_inputs_signature`), or invalidate the per-mission cache when `_prune_old_logs` fires.
+3. **R3-2 fix:** when hull len < 3, report `area_m2` as 0 but also include a `track_length_m` field computed from sequential point-to-point haversine. Operationally the more useful metric for ground transit.
+4. **R2-1 fix:** rate-limit `/api/mission/start` (one per 5 s per remote IP) — the audit-log entry exists, but the file-creation is uncapped.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -593,19 +593,39 @@ quality 5–50, max_fps 0.1–5.0.
 
 ### `POST /api/mission/start`
 **Auth:** bearer · `{"name": "mission-alpha"}` (optional; defaults
-to `mission-<unix>`).
+to `mission-<unix>`). Returns `{status, name, mission_id}` where
+`mission_id` is the UUID v4 stamped onto every detection and event
+record for the sortie.
 
 ### `POST /api/mission/end`
 **Auth:** bearer · End the active mission.
+
+### `GET /api/mission/status`
+**Auth:** none · `{mission_active, mission_name, mission_id,
+mission_start_ts, mission_log}`. Cheap status surface for the operator
+dashboard pill.
+
+### `GET /api/missions`
+**Auth:** none · List recent missions discovered in the log directory.
+Returns `{missions: [{mission_id, name, callsign, started_ts, ended_ts,
+log_file}]}`, newest first.
+
+### `GET /api/summary?mission=<mission_id>`
+**Auth:** none · Per-mission stats aggregated from detection JSONL and
+event timeline files on disk. Returns `{mission_id, detections:{total,
+by_class, unique_tracks}, time_to_first_detection_sec, mission_start_ts,
+mission_end_ts, duration_sec, operator_actions, state_changes,
+gps_coverage:{point_count, hull, area_m2, bbox}}`. Cached 30 s.
 
 ---
 
 ## Post-mission review
 
 ### `GET /api/review/logs`
-**Auth:** none · List available detection + event-timeline log files.
-Returns `{logs:[{filename,size_kb,modified}], event_logs:[...],
-image_dir:"..."}`.
+**Auth:** none · List available detection + event-timeline log files,
+plus a per-mission roll-up. Returns `{logs:[{filename,size_kb,modified}],
+event_logs:[...], missions:[{mission_id, name, started_ts, ended_ts,
+log_file}], image_dir:"..."}`.
 
 ### `GET /api/review/log/{filename}`
 **Auth:** none · Parse and return detections from a log file (JSONL

--- a/hydra_detect/detection_logger.py
+++ b/hydra_detect/detection_logger.py
@@ -95,6 +95,14 @@ class DetectionLogger:
         self._model_hash = model_hash
         self._prev_chain_hash = "0" * 64  # genesis hash
 
+        # Mission tagging (issue #72) — every detection row carries the
+        # currently active mission_id, or null when no mission is running.
+        # The pipeline sets this via set_mission_id() after the event logger
+        # starts the mission. The id is intentionally not chained — it is
+        # operator metadata, not provenance.
+        self._mission_id: str | None = None
+        self._mission_id_lock = threading.Lock()
+
         # Recent detections ring buffer for web UI.
         # Updated on the caller thread so the web API sees results immediately.
         self._recent: deque[Dict[str, Any]] = deque(maxlen=self._max_recent)
@@ -208,6 +216,11 @@ class DetectionLogger:
             img_filename = f"{ts_file}_{frame_no:06d}.jpg"
             self._last_image_save_time = now_mono
 
+        # Snapshot the mission id once per frame so all detections in one
+        # frame share the same id even if the operator hits End mid-frame.
+        with self._mission_id_lock:
+            mission_id_snapshot = self._mission_id
+
         # Build records (do NOT update _recent yet — only after successful enqueue).
         records: list[Dict[str, Any]] = []
         chain_hash_before_loop = self._prev_chain_hash
@@ -229,6 +242,7 @@ class DetectionLogger:
                 "fix": fix,
                 "image": img_filename,
                 "model_hash": self._model_hash,
+                "mission_id": mission_id_snapshot,
             }
             # Optional time_source field — only present when a source is known.
             # Included before hashing so the chain is consistent.
@@ -278,6 +292,20 @@ class DetectionLogger:
     def set_model_hash(self, model_hash: str) -> None:
         """Update the model hash (e.g. after a runtime model switch)."""
         self._model_hash = model_hash
+
+    def set_mission_id(self, mission_id: str | None) -> None:
+        """Stamp every subsequent detection record with this mission_id.
+
+        Pass ``None`` to clear (records logged while no mission is active
+        will carry ``"mission_id": null``). Cheap — single guarded write.
+        """
+        with self._mission_id_lock:
+            self._mission_id = mission_id
+
+    def get_mission_id(self) -> str | None:
+        """Return the active mission_id, or None when no mission is active."""
+        with self._mission_id_lock:
+            return self._mission_id
 
     def get_recent(self, n: int = 20) -> list[Dict[str, Any]]:
         """Return the N most recent detection records (for web UI)."""

--- a/hydra_detect/detection_logger.py
+++ b/hydra_detect/detection_logger.py
@@ -162,6 +162,40 @@ class DetectionLogger:
 
         self._close_log_file()
 
+    def flush(self, timeout: float = 2.0) -> bool:
+        """Block until every queued work item has been processed.
+
+        Used by ``_handle_mission_end`` to guarantee detection rows
+        stamped with the active mission_id reach disk BEFORE the
+        ``mission_end`` event lands in the event log. Without this,
+        the writer thread can drain queued items after the boundary
+        event, producing rows that appear to occur "after" mission end
+        with the old mission_id — an audit-trail correctness gap
+        flagged in docs/adversarial/230.md R3-1.
+
+        Args:
+            timeout: Max seconds to wait. Returns False on timeout.
+
+        Returns:
+            True if the queue drained within the timeout; False if it
+            did not (the caller should still proceed but log a warning —
+            losing strict ordering is better than wedging mission_end).
+        """
+        if self._writer_thread is None or not self._writer_thread.is_alive():
+            return True
+
+        done = threading.Event()
+
+        def _await_drain() -> None:
+            self._write_queue.join()
+            done.set()
+
+        waiter = threading.Thread(
+            target=_await_drain, daemon=True, name="det-logger-flush",
+        )
+        waiter.start()
+        return done.wait(timeout=timeout)
+
     # ------------------------------------------------------------------
     # Hot-path method (called from the detection thread)
     # ------------------------------------------------------------------
@@ -464,26 +498,37 @@ class DetectionLogger:
     # ------------------------------------------------------------------
 
     def _writer_loop(self) -> None:
-        """Consume work items from the queue and perform all file I/O."""
+        """Consume work items from the queue and perform all file I/O.
+
+        task_done() is called for every queue.get() so callers can
+        synchronize on flush() via Queue.join() (used by mission-end to
+        guarantee detection rows with the active mission_id reach disk
+        before the mission_end event lands).
+        """
         while True:
             try:
                 item = self._write_queue.get(timeout=1.0)
             except queue.Empty:
                 continue
 
-            if item is _STOP:
-                # Drain any remaining items before exiting so stop() is a
-                # clean flush — no detections are silently discarded.
-                while True:
-                    try:
-                        remaining = self._write_queue.get_nowait()
-                    except queue.Empty:
-                        break
-                    if remaining is not _STOP:
-                        self._safe_process(remaining)
-                break
-
-            self._safe_process(item)
+            try:
+                if item is _STOP:
+                    # Drain any remaining items before exiting so stop() is a
+                    # clean flush — no detections are silently discarded.
+                    while True:
+                        try:
+                            remaining = self._write_queue.get_nowait()
+                        except queue.Empty:
+                            break
+                        try:
+                            if remaining is not _STOP:
+                                self._safe_process(remaining)
+                        finally:
+                            self._write_queue.task_done()
+                    break
+                self._safe_process(item)
+            finally:
+                self._write_queue.task_done()
 
     def _safe_process(self, item: Dict[str, Any]) -> None:
         """Run _process_work_item with a hard guard against any exception.

--- a/hydra_detect/event_logger.py
+++ b/hydra_detect/event_logger.py
@@ -7,13 +7,32 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import threading
 import time
+import uuid
 from collections import deque
 from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+# Sanitize mission names for use in filenames — strip path separators and
+# control characters so a poorly-chosen name can't escape the log directory.
+_SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9_-]+")
+
+
+def _safe_name(name: str) -> str:
+    """Strip filesystem-hostile characters from a mission name.
+
+    Strict policy: only ``[A-Za-z0-9_-]`` survives. Anything else collapses
+    to a single underscore. We deliberately drop ``.`` entirely (no
+    ``..`` traversal in the filename, no leading-dot hidden files) — the
+    mission name on disk is decoration; the JSONL itself records the
+    original name verbatim inside ``mission_start``.
+    """
+    cleaned = _SAFE_NAME_RE.sub("_", name).strip("_-")
+    return cleaned[:64] or "mission"
 
 
 class EventLogger:
@@ -22,6 +41,11 @@ class EventLogger:
     Events include: operator actions (lock, unlock, follow, strike, abort,
     mode changes), system state changes (camera lost, low light), and
     vehicle telemetry (GPS position at 1 Hz).
+
+    Each mission carries a UUID-v4 ``mission_id`` that is stamped on every
+    event record (including ``mission_start`` and ``mission_end``). The id
+    is generated server-side by ``start_mission()`` and propagated to the
+    detection log so detection rows and event rows can be joined per-sortie.
     """
 
     # Default size of the in-memory recent-events ring buffer. Kept in sync
@@ -34,6 +58,9 @@ class EventLogger:
         self._log_dir.mkdir(parents=True, exist_ok=True)
         self._callsign = callsign
         self._mission_name: str | None = None
+        self._mission_id: str | None = None
+        self._mission_start_ts: float | None = None
+        self._mission_log_path: Path | None = None
         self._file = None
         self._lock = threading.Lock()
         self._track_interval = 1.0  # GPS logging interval seconds
@@ -45,26 +72,54 @@ class EventLogger:
         # system of record for after-action review / verify_log.py.
         self._recent: deque[dict] = deque(maxlen=self._RECENT_DEFAULT)
 
-    def start_mission(self, name: str) -> None:
-        """Begin a new mission — opens a new JSONL event file."""
+    def start_mission(self, name: str, mission_id: str | None = None) -> str:
+        """Begin a new mission — opens a new JSONL event file.
+
+        Args:
+            name: Operator-supplied sortie name (sanitized for the filename).
+            mission_id: Optional pre-generated UUID. Generated server-side if
+                not supplied. Callers that need to coordinate the id across
+                subsystems (detection logger, web stats) should pass the same
+                id they hand to those subsystems.
+
+        Returns:
+            The mission_id stamped on every event in this mission.
+        """
         with self._lock:
             self._close_file()
             self._recent.clear()
             self._mission_name = name
+            self._mission_id = mission_id or str(uuid.uuid4())
+            self._mission_start_ts = time.time()
             ts = time.strftime("%Y%m%d_%H%M%S")
-            filename = f"{self._callsign}_{ts}_{name}.jsonl"
+            safe = _safe_name(name)
+            filename = f"{self._callsign}_{ts}_{safe}.jsonl"
             filepath = self._log_dir / filename
+            self._mission_log_path = filepath
             self._file = open(filepath, "a")
-            self._log_event("mission_start", {"name": name})
-            logger.info("Event timeline started: %s", filepath)
+            self._log_event("mission_start", {
+                "name": name,
+                "mission_id": self._mission_id,
+            })
+            logger.info(
+                "Event timeline started: %s (mission_id=%s)",
+                filepath, self._mission_id,
+            )
+            return self._mission_id
 
     def end_mission(self) -> None:
         """End the current mission."""
         with self._lock:
             if self._mission_name:
-                self._log_event("mission_end", {"name": self._mission_name})
+                self._log_event("mission_end", {
+                    "name": self._mission_name,
+                    "mission_id": self._mission_id,
+                })
             self._close_file()
             self._mission_name = None
+            self._mission_id = None
+            self._mission_start_ts = None
+            self._mission_log_path = None
             # Keep _recent populated until the next start_mission so the
             # dashboard can still display the tail of the just-ended mission.
 
@@ -112,10 +167,11 @@ class EventLogger:
         """Write a single event record to the JSONL file and ring buffer."""
         if self._file is None:
             return
-        record = {
+        record: dict[str, Any] = {
             "ts": time.time(),
             "type": event_type,
             "callsign": self._callsign,
+            "mission_id": self._mission_id,
             **data,
         }
         # Append to in-memory ring buffer first — even if the disk write
@@ -142,10 +198,27 @@ class EventLogger:
 
     def get_status(self) -> dict:
         """Return status for web API."""
-        return {
-            "mission_active": self._mission_name is not None,
-            "mission_name": self._mission_name,
-        }
+        with self._lock:
+            mission_log = (
+                self._mission_log_path.name if self._mission_log_path else None
+            )
+            return {
+                "mission_active": self._mission_name is not None,
+                "mission_name": self._mission_name,
+                "mission_id": self._mission_id,
+                "mission_start_ts": self._mission_start_ts,
+                "mission_log": mission_log,
+            }
+
+    def get_mission_id(self) -> str | None:
+        """Return the active mission_id, or None when idle."""
+        with self._lock:
+            return self._mission_id
+
+    def get_mission_log_path(self) -> Path | None:
+        """Return path to the JSONL file for the active mission, or None."""
+        with self._lock:
+            return self._mission_log_path
 
     def get_recent_events(self, max_events: int = 200) -> list[dict]:
         """Return the last N events from the in-memory ring buffer.

--- a/hydra_detect/mission_summary.py
+++ b/hydra_detect/mission_summary.py
@@ -1,0 +1,291 @@
+"""Per-mission statistics aggregation for the /api/summary endpoint (#72).
+
+Scans detection JSONL files and event JSONL files in the log directory,
+groups by ``mission_id`` (stamped by ``DetectionLogger`` and ``EventLogger``
+respectively), and returns aggregate stats: detections by class, unique
+tracks, time to first detection, vehicle-track GPS coverage area.
+
+Results are cached for ``_SUMMARY_TTL_SEC`` to bound per-request I/O on
+large log directories.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from .review_export import gps_coverage
+
+logger = logging.getLogger(__name__)
+
+# How long to cache a per-mission summary in memory. The active mission's
+# JSONL is still appending while polling, so a short TTL is the tradeoff
+# between cost and freshness. 30 s is comfortably below typical "review
+# tab open + tab away + tab back" cadence.
+_SUMMARY_TTL_SEC = 30.0
+
+
+@dataclass
+class _CacheEntry:
+    summary: dict
+    written_at: float
+    inputs_signature: tuple  # (det_mtime_sum, evt_mtime_sum, det_count, evt_count)
+
+
+_cache: dict[str, _CacheEntry] = {}
+_cache_lock = threading.Lock()
+
+
+def _scan_log_dir(log_dir: Path) -> tuple[list[Path], list[Path]]:
+    """Return ``(detection_files, event_files)`` under ``log_dir``.
+
+    Detection files: ``detections_*.jsonl`` and ``detections_*.csv``.
+    Event files: any JSONL whose first record has a known event ``type``.
+
+    Returns empty lists if ``log_dir`` does not exist.
+    """
+    if not log_dir.is_dir():
+        return [], []
+    det_files: list[Path] = []
+    evt_files: list[Path] = []
+    for f in log_dir.iterdir():
+        if not f.is_file():
+            continue
+        if f.name.startswith("detections_") and f.suffix in (".jsonl", ".csv"):
+            det_files.append(f)
+            continue
+        if f.suffix != ".jsonl":
+            continue
+        try:
+            with f.open() as fh:
+                first = fh.readline().strip()
+            if not first:
+                continue
+            rec = json.loads(first)
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+            continue
+        if rec.get("type") in ("mission_start", "track", "action", "state", "detection"):
+            evt_files.append(f)
+    return det_files, evt_files
+
+
+def _iter_jsonl(path: Path):
+    """Yield JSON records from a JSONL file, skipping malformed lines."""
+    try:
+        with path.open() as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    yield json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+    except (OSError, UnicodeDecodeError) as exc:
+        logger.debug("Skipping unreadable log file %s: %s", path, exc)
+
+
+def _iter_detections(path: Path):
+    """Yield detection rows from a JSONL or CSV detection log."""
+    if path.suffix == ".csv":
+        import csv
+        try:
+            with path.open() as f:
+                reader = csv.DictReader(f)
+                yield from reader
+        except (OSError, UnicodeDecodeError) as exc:
+            logger.debug("Skipping CSV %s: %s", path, exc)
+        return
+    yield from _iter_jsonl(path)
+
+
+def _inputs_signature(det_files: list[Path], evt_files: list[Path]) -> tuple:
+    """Stable signature of (file count + mtime sum) so cache invalidates
+    when a log file rotates or grows. Cheap stat-only — no reads."""
+    def _sig(files: list[Path]) -> tuple:
+        mt = 0.0
+        sz = 0
+        for p in files:
+            try:
+                st = p.stat()
+            except OSError:
+                continue
+            mt += st.st_mtime
+            sz += st.st_size
+        return (len(files), mt, sz)
+
+    return _sig(det_files) + _sig(evt_files)
+
+
+def _parse_ts(ts_value: Any) -> float | None:
+    """Best-effort parse of a detection timestamp into a float epoch."""
+    if isinstance(ts_value, (int, float)):
+        return float(ts_value)
+    if isinstance(ts_value, str):
+        try:
+            # ISO 8601 with optional trailing Z.
+            from datetime import datetime
+            s = ts_value.rstrip("Z")
+            return datetime.fromisoformat(s).timestamp()
+        except (ValueError, TypeError):
+            return None
+    return None
+
+
+def compute_summary(mission_id: str, log_dir: Path) -> dict:
+    """Compute the summary for one mission. Bypasses the cache."""
+    det_files, evt_files = _scan_log_dir(log_dir)
+
+    by_class: dict[str, int] = {}
+    track_ids: set[Any] = set()
+    det_count = 0
+    earliest_det_ts: float | None = None
+    mission_start_ts: float | None = None
+    mission_end_ts: float | None = None
+    action_count = 0
+    state_count = 0
+    track_points: list[tuple[float, float]] = []
+
+    # Detection rows
+    for path in det_files:
+        for row in _iter_detections(path):
+            if str(row.get("mission_id") or "") != mission_id:
+                continue
+            det_count += 1
+            label = row.get("label") or "unknown"
+            by_class[label] = by_class.get(label, 0) + 1
+            tid = row.get("track_id")
+            if tid is not None and tid != "":
+                track_ids.add(tid)
+            ts_parsed = _parse_ts(row.get("timestamp"))
+            if ts_parsed is not None:
+                if earliest_det_ts is None or ts_parsed < earliest_det_ts:
+                    earliest_det_ts = ts_parsed
+
+    # Event rows (mission lifecycle + vehicle telemetry + operator actions)
+    for path in evt_files:
+        for rec in _iter_jsonl(path):
+            if str(rec.get("mission_id") or "") != mission_id:
+                continue
+            rtype = rec.get("type")
+            ts = rec.get("ts")
+            if rtype == "mission_start":
+                mission_start_ts = ts if isinstance(ts, (int, float)) else mission_start_ts
+            elif rtype == "mission_end":
+                mission_end_ts = ts if isinstance(ts, (int, float)) else mission_end_ts
+            elif rtype == "track":
+                lat = rec.get("lat")
+                lon = rec.get("lon")
+                if isinstance(lat, (int, float)) and isinstance(lon, (int, float)):
+                    track_points.append((float(lat), float(lon)))
+            elif rtype == "action":
+                action_count += 1
+            elif rtype == "state":
+                state_count += 1
+
+    time_to_first_detection_sec: float | None = None
+    if mission_start_ts is not None and earliest_det_ts is not None:
+        delta = earliest_det_ts - mission_start_ts
+        if delta >= 0:
+            time_to_first_detection_sec = round(delta, 3)
+
+    duration_sec: float | None = None
+    if mission_start_ts is not None:
+        end = mission_end_ts if mission_end_ts is not None else time.time()
+        duration_sec = round(end - mission_start_ts, 3)
+
+    coverage = gps_coverage(track_points)
+
+    return {
+        "mission_id": mission_id,
+        "detections": {
+            "total": det_count,
+            "by_class": by_class,
+            "unique_tracks": len(track_ids),
+        },
+        "time_to_first_detection_sec": time_to_first_detection_sec,
+        "mission_start_ts": mission_start_ts,
+        "mission_end_ts": mission_end_ts,
+        "duration_sec": duration_sec,
+        "operator_actions": action_count,
+        "state_changes": state_count,
+        "gps_coverage": coverage,
+    }
+
+
+def get_summary(mission_id: str, log_dir: Path | str) -> dict:
+    """Return cached or freshly-computed summary for ``mission_id``."""
+    if not isinstance(mission_id, str) or not mission_id:
+        raise ValueError("mission_id must be a non-empty string")
+
+    log_path = Path(log_dir)
+    det_files, evt_files = _scan_log_dir(log_path)
+    signature = _inputs_signature(det_files, evt_files)
+    now = time.monotonic()
+
+    with _cache_lock:
+        entry = _cache.get(mission_id)
+        if (
+            entry is not None
+            and entry.inputs_signature == signature
+            and (now - entry.written_at) < _SUMMARY_TTL_SEC
+        ):
+            return entry.summary
+
+    summary = compute_summary(mission_id, log_path)
+
+    with _cache_lock:
+        _cache[mission_id] = _CacheEntry(
+            summary=summary,
+            written_at=now,
+            inputs_signature=signature,
+        )
+        # Bound the cache — 64 distinct missions is more than enough for
+        # a single Jetson session; oldest entries are evicted.
+        if len(_cache) > 64:
+            oldest = min(_cache.items(), key=lambda kv: kv[1].written_at)[0]
+            _cache.pop(oldest, None)
+    return summary
+
+
+def list_missions(log_dir: Path | str) -> list[dict]:
+    """Return a list of mission summaries (id, name, start, end, log file).
+
+    Scans event timeline JSONLs in ``log_dir`` and pulls the
+    ``mission_start`` record from each. Useful for the review tab's
+    mission picker.
+    """
+    log_path = Path(log_dir)
+    _, evt_files = _scan_log_dir(log_path)
+    out: list[dict] = []
+    for path in evt_files:
+        start: dict | None = None
+        end: dict | None = None
+        for rec in _iter_jsonl(path):
+            if rec.get("type") == "mission_start" and start is None:
+                start = rec
+            elif rec.get("type") == "mission_end":
+                end = rec
+        if start is None or not start.get("mission_id"):
+            continue
+        out.append({
+            "mission_id": start.get("mission_id"),
+            "name": start.get("name"),
+            "callsign": start.get("callsign"),
+            "started_ts": start.get("ts"),
+            "ended_ts": end.get("ts") if end else None,
+            "log_file": path.name,
+        })
+    out.sort(key=lambda m: m.get("started_ts") or 0.0, reverse=True)
+    return out
+
+
+def clear_cache() -> None:
+    """Drop all cached summaries (tests + after a manual log purge)."""
+    with _cache_lock:
+        _cache.clear()

--- a/hydra_detect/mission_summary.py
+++ b/hydra_detect/mission_summary.py
@@ -15,7 +15,7 @@ import json
 import logging
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -3058,12 +3058,27 @@ class Pipeline:
                 self._mavlink.send_statustext(
                     f"{callsign}: MISSION END - {self._mission_name}", severity=5
                 )
-        # Tear down in a fixed order: stop stamping detection rows first so
-        # any in-flight log() calls land with mission_id=None, THEN close
-        # the event JSONL via end_mission(). Reverse order would leave a
-        # short window where new detections get stamped with an id whose
-        # event file is already closed.
+        # Tear down in a fixed order:
+        # 1. Stop stamping NEW detection rows so any in-flight log() calls
+        #    land with mission_id=None.
+        # 2. Flush the detection writer queue — items ALREADY queued were
+        #    stamped with the active mission_id; they must reach disk
+        #    BEFORE mission_end is written to the event log, otherwise
+        #    the summary endpoint sees detections with this mission_id
+        #    timestamped after mission_end. Bounded 2s drain — on
+        #    timeout we still close cleanly, just with a warning.
+        #    (Adversarial finding R3-1 in docs/adversarial/230.md.)
+        # 3. Close the event JSONL via end_mission().
+        # Reverse order would leave a short window where new detections
+        # get stamped with an id whose event file is already closed.
         self._det_logger.set_mission_id(None)
+        if not self._det_logger.flush(timeout=2.0):
+            logger.warning(
+                "mission_end: detection logger queue did not drain within "
+                "2s; mission_id=%s may have rows timestamped after "
+                "mission_end in the summary view.",
+                self._mission_id,
+            )
         self._event_logger.end_mission()
         stream_state.update_runtime_config({
             "mission_id": None,

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -907,7 +907,14 @@ class Pipeline:
             ),
             callsign=self._cfg.get("tak", "callsign", fallback="HYDRA-1"),
         )
-        self._event_logger.start_mission("default")
+        # Bootstrap with a default mission so the event timeline captures
+        # operator actions even before /api/mission/start fires. The id is
+        # propagated to the detection logger so every row gets stamped.
+        _bootstrap_mid = self._event_logger.start_mission("default")
+        self._mission_id = _bootstrap_mid
+        self._mission_name = "default"
+        self._mission_start_time = time.monotonic()
+        self._det_logger.set_mission_id(_bootstrap_mid)
 
         # Web UI
         self._web_enabled = self._cfg.getboolean("web", "enabled", fallback=True)
@@ -991,8 +998,13 @@ class Pipeline:
                 if _cfg is not None else 3.0
             )
 
-        # Mission tagging state
+        # Mission tagging state (issue #72)
+        # `_mission_name` is the human-readable label shown in the dashboard.
+        # `_mission_id` is the UUID stamped onto every detection + event row
+        # while the mission is active. The EventLogger owns the ground truth
+        # for the id; we mirror it here for stats publication.
         self._mission_name: str | None = None
+        self._mission_id: str | None = None
         self._mission_start_time: float | None = None
 
     def _is_engagement_active(self) -> bool:
@@ -1704,6 +1716,11 @@ class Pipeline:
                     "camera_ok": not self._cam_lost,
                     "callsign": self._callsign,
                     "mission_name": self._mission_name,
+                    "mission_id": self._mission_id,
+                    "mission_elapsed_sec": (
+                        round(time.monotonic() - self._mission_start_time, 1)
+                        if self._mission_start_time is not None else None
+                    ),
                     # Active platform profile — drives the PLT chip in the topbar.
                     "platform": self._vehicle,
                 }
@@ -2992,28 +3009,68 @@ class Pipeline:
     # ------------------------------------------------------------------
     # Mission tagging
     # ------------------------------------------------------------------
-    def _handle_mission_start(self, name: str) -> None:
-        """Start a named mission session."""
+    def _handle_mission_start(self, name: str) -> str:
+        """Start a named mission session.
+
+        Generates a fresh UUID via ``EventLogger.start_mission`` and
+        propagates the id to the detection logger so every detection row
+        carries it. Closes any prior mission file as a side effect.
+
+        Returns the new ``mission_id`` (callers may surface it to the
+        operator UI).
+        """
+        # The event logger owns the id ground truth — accept whatever it
+        # returns so any future change (server-side override, replay) stays
+        # in lockstep with the on-disk filenames.
+        mission_id = self._event_logger.start_mission(name)
         self._mission_name = name
+        self._mission_id = mission_id
         self._mission_start_time = time.monotonic()
-        logger.info("Mission STARTED: %s", name)
+        self._det_logger.set_mission_id(mission_id)
+        stream_state.update_runtime_config({
+            "mission_id": mission_id,
+            "mission_name": name,
+        })
+        logger.info("Mission STARTED: %s (mission_id=%s)", name, mission_id)
         if self._mavlink is not None:
             callsign = self._cfg.get("tak", "callsign", fallback="HYDRA-1")
             self._mavlink.send_statustext(
                 f"{callsign}: MISSION START - {name}", severity=5
             )
+        return mission_id
 
     def _handle_mission_end(self) -> None:
-        """End the current mission session."""
+        """End the current mission session.
+
+        Writes the ``mission_end`` event, clears the active id from the
+        detection logger, and zeroes the in-memory mission state. The
+        next call to ``_handle_mission_start`` re-opens a fresh event
+        timeline JSONL.
+        """
         if self._mission_name:
             elapsed = time.monotonic() - (self._mission_start_time or 0)
-            logger.info("Mission ENDED: %s (%.0fs)", self._mission_name, elapsed)
+            logger.info(
+                "Mission ENDED: %s (mission_id=%s, %.0fs)",
+                self._mission_name, self._mission_id, elapsed,
+            )
             if self._mavlink is not None:
                 callsign = self._cfg.get("tak", "callsign", fallback="HYDRA-1")
                 self._mavlink.send_statustext(
                     f"{callsign}: MISSION END - {self._mission_name}", severity=5
                 )
+        # Tear down in a fixed order: stop stamping detection rows first so
+        # any in-flight log() calls land with mission_id=None, THEN close
+        # the event JSONL via end_mission(). Reverse order would leave a
+        # short window where new detections get stamped with an id whose
+        # event file is already closed.
+        self._det_logger.set_mission_id(None)
+        self._event_logger.end_mission()
+        stream_state.update_runtime_config({
+            "mission_id": None,
+            "mission_name": None,
+        })
         self._mission_name = None
+        self._mission_id = None
         self._mission_start_time = None
 
     # ------------------------------------------------------------------

--- a/hydra_detect/review_export.py
+++ b/hydra_detect/review_export.py
@@ -16,10 +16,105 @@ import csv
 import html
 import json
 import logging
+import math
 import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------
+# Geo helpers (issue #72 — mission summary GPS coverage)
+# --------------------------------------------------------------------------
+
+def _convex_hull(points: list[tuple[float, float]]) -> list[tuple[float, float]]:
+    """Return the convex hull of *points* in counter-clockwise order.
+
+    Uses the Andrew monotone-chain algorithm (O(n log n)). Pure-Python so
+    the mission summary endpoint does not require scipy. Duplicates are
+    dropped before sorting; degenerate inputs (fewer than 3 unique points)
+    are returned in sorted order as a line / point degenerate hull.
+    """
+    pts = sorted(set(points))
+    if len(pts) <= 1:
+        return list(pts)
+
+    def _cross(o: tuple[float, float], a: tuple[float, float], b: tuple[float, float]) -> float:
+        return (a[0] - o[0]) * (b[1] - o[1]) - (a[1] - o[1]) * (b[0] - o[0])
+
+    lower: list[tuple[float, float]] = []
+    for p in pts:
+        while len(lower) >= 2 and _cross(lower[-2], lower[-1], p) <= 0:
+            lower.pop()
+        lower.append(p)
+
+    upper: list[tuple[float, float]] = []
+    for p in reversed(pts):
+        while len(upper) >= 2 and _cross(upper[-2], upper[-1], p) <= 0:
+            upper.pop()
+        upper.append(p)
+
+    # last point of each list is omitted because it is repeated at the
+    # beginning of the other list.
+    return lower[:-1] + upper[:-1]
+
+
+def _polygon_area_m2(hull_latlon: list[tuple[float, float]]) -> float:
+    """Compute the area in square meters of a small lat/lon polygon.
+
+    Uses an equirectangular projection — accurate to <1% for spans under
+    ~10 km, which is well above SORCC sortie radii (line-of-sight). For
+    operational summaries, "convex hull area in m²" is the load-bearing
+    metric — exact ellipsoidal area is overkill.
+    """
+    if len(hull_latlon) < 3:
+        return 0.0
+    # Mean latitude — used to convert longitude to meters per degree.
+    lat0 = sum(p[0] for p in hull_latlon) / len(hull_latlon)
+    cos_lat0 = math.cos(math.radians(lat0))
+    # Project onto local-tangent meters.
+    m_per_deg_lat = 111_320.0
+    m_per_deg_lon = 111_320.0 * cos_lat0
+    proj = [(p[1] * m_per_deg_lon, p[0] * m_per_deg_lat) for p in hull_latlon]
+    # Shoelace formula.
+    area2 = 0.0
+    n = len(proj)
+    for i in range(n):
+        x1, y1 = proj[i]
+        x2, y2 = proj[(i + 1) % n]
+        area2 += x1 * y2 - x2 * y1
+    return abs(area2) / 2.0
+
+
+def gps_coverage(points: list[tuple[float, float]]) -> dict:
+    """Return convex-hull-based GPS coverage stats for a list of lat/lon points.
+
+    Output shape::
+
+        {
+            "point_count": int,
+            "hull": [[lat, lon], ...],   # CCW, may be 0/1/2 points if degenerate
+            "area_m2": float,
+            "bbox": {"min_lat": ..., "max_lat": ..., "min_lon": ..., "max_lon": ...}
+                or None if no points,
+        }
+    """
+    if not points:
+        return {"point_count": 0, "hull": [], "area_m2": 0.0, "bbox": None}
+
+    hull = _convex_hull(points)
+    bbox = {
+        "min_lat": min(p[0] for p in points),
+        "max_lat": max(p[0] for p in points),
+        "min_lon": min(p[1] for p in points),
+        "max_lon": max(p[1] for p in points),
+    }
+    return {
+        "point_count": len(points),
+        "hull": [list(p) for p in hull],
+        "area_m2": _polygon_area_m2(hull),
+        "bbox": bbox,
+    }
 
 
 def parse_jsonl(path: Path) -> list[dict]:

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -2653,22 +2653,36 @@ async def api_abort(request: Request):
 
 @app.post("/api/mission/start")
 async def api_start_mission(request: Request, authorization: Optional[str] = Header(None)):
-    """Start a named mission. Body: {"name": "mission-alpha"}"""
+    """Start a named mission. Body: {"name": "mission-alpha"} (name optional).
+
+    Returns ``{"status": "started", "name": <name>, "mission_id": <uuid>}``
+    so the operator UI can surface the id and use it for ``/api/summary``
+    queries later.
+    """
     auth_err = _check_auth(authorization, request)
     if auth_err:
         return auth_err
     body = await _parse_json(request)
+    # Empty body is allowed — operator can hit Start without naming the sortie.
     if body is None:
-        return JSONResponse({"error": "Invalid or missing JSON body"}, status_code=400)
-    name = body.get("name", f"mission-{int(time.time())}")
-    if not isinstance(name, str) or not name.strip():
-        return JSONResponse({"error": "name must be a non-empty string"}, status_code=400)
+        body = {}
+    if "name" in body:
+        # Key present → must be a non-empty trimmed string. This preserves
+        # the legacy behavior the instructor-ops UI relies on.
+        name = body["name"]
+        if not isinstance(name, str) or not name.strip():
+            return JSONResponse({"error": "name must be a non-empty string"}, status_code=400)
+    else:
+        name = f"mission-{int(time.time())}"
     name = name.strip()[:100]  # Bound length
     cb = stream_state.get_callback("on_mission_start")
+    mission_id: str | None = None
     if cb:
-        cb(name)
+        result = cb(name)
+        if isinstance(result, str):
+            mission_id = result
     _audit(request, "mission_start", target=name)
-    return {"status": "started", "name": name}
+    return {"status": "started", "name": name, "mission_id": mission_id}
 
 
 @app.post("/api/mission/end")
@@ -2684,6 +2698,62 @@ async def api_end_mission(request: Request, authorization: Optional[str] = Heade
     return {"status": "ended"}
 
 
+@app.get("/api/mission/status")
+async def api_mission_status():
+    """Return the active mission_id, name, and start timestamp (or all None).
+
+    Cheap, unauthenticated — operators on read-only dashboards still need
+    to see which sortie they're looking at.
+    """
+    cb = stream_state.get_callback("get_event_status")
+    if cb:
+        return cb()
+    return {
+        "mission_active": False,
+        "mission_name": None,
+        "mission_id": None,
+        "mission_start_ts": None,
+        "mission_log": None,
+    }
+
+
+@app.get("/api/missions")
+async def api_list_missions():
+    """List recent missions discovered in the log directory."""
+    from hydra_detect.mission_summary import list_missions
+    cb = stream_state.get_callback("get_log_dir")
+    log_dir = cb() if cb else "./output_data/logs"
+    return {"missions": list_missions(log_dir)}
+
+
+@app.get("/api/summary")
+async def api_mission_summary(mission: str = ""):
+    """Return per-mission stats: detections by class, unique tracks, time
+    to first detection, GPS coverage convex hull (issue #72).
+
+    Query string: ``?mission=<mission_id>``. The id is the UUID returned
+    from ``/api/mission/start``. Results are cached for 30 s.
+    """
+    from hydra_detect.mission_summary import get_summary
+    if not mission:
+        return JSONResponse(
+            {"error": "mission query parameter required"}, status_code=400,
+        )
+    # Bound length to keep the cache key reasonable. UUIDs are 36 chars;
+    # we accept 64 to give a little slack for hyphen / case variants.
+    if len(mission) > 64:
+        return JSONResponse({"error": "mission id too long"}, status_code=400)
+    cb = stream_state.get_callback("get_log_dir")
+    log_dir = cb() if cb else "./output_data/logs"
+    try:
+        return get_summary(mission, log_dir)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    except Exception as exc:  # pragma: no cover — defensive
+        logger.exception("Mission summary failed for %s: %s", mission, exc)
+        return JSONResponse({"error": "summary computation failed"}, status_code=500)
+
+
 # ── Mission Review ────────────────────────────────────────────────
 
 @app.get("/review", response_class=HTMLResponse)
@@ -2694,8 +2764,14 @@ async def review_page(request: Request):
 
 @app.get("/api/review/logs")
 async def api_review_logs():
-    """List available detection log files and event timeline files."""
+    """List available detection log files, event timeline files, and missions.
+
+    Returns ``{"logs": [...], "event_logs": [...], "missions": [...],
+    "image_dir": "..."}`` — ``missions`` is the new per-mission grouping
+    added in issue #72 so the review tab can offer a sortie picker.
+    """
     import json as _json
+    from hydra_detect.mission_summary import list_missions
 
     cb = stream_state.get_callback("get_log_dir")
     log_dir = cb() if cb else "/data/logs"
@@ -2727,7 +2803,14 @@ async def api_review_logs():
             except (_json.JSONDecodeError, OSError, UnicodeDecodeError):
                 logger.debug("Skipping unreadable event log: %s", f.name)
                 continue
-    return {"logs": result, "event_logs": event_logs, "image_dir": image_dir}
+    # Mission roll-up — drives the per-sortie picker in the review UI.
+    missions = list_missions(log_dir) if log_path.is_dir() else []
+    return {
+        "logs": result,
+        "event_logs": event_logs,
+        "missions": missions,
+        "image_dir": image_dir,
+    }
 
 
 @app.get("/api/review/log/{filename}")

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -1642,9 +1642,11 @@ const HydraOps = (() => {
     function updateSidebarMission(stats) {
         var badge = document.getElementById('ops-mission-badge');
         var nameEl = document.getElementById('ops-mission-name');
+        var idEl = document.getElementById('ops-mission-id');
         var elapsedEl = document.getElementById('ops-mission-elapsed');
         var detsEl = document.getElementById('ops-mission-dets');
         var endBtn = document.getElementById('ops-btn-mission-end');
+        var startBtn = document.getElementById('ops-btn-mission-start');
 
         var s = stats || {};
         var isActive = !!s.mission_name;
@@ -1654,6 +1656,18 @@ const HydraOps = (() => {
             badge.className = 'ops-card-badge ' + (isActive ? 'on' : 'off');
         }
         if (nameEl) setDim(nameEl, s.mission_name || '--', !isActive);
+        if (idEl) {
+            // Show the first 8 chars of the UUID — full id is in the tooltip.
+            var mid = s.mission_id || '';
+            if (isActive && mid) {
+                idEl.textContent = mid.slice(0, 8);
+                idEl.title = mid;
+                idEl.style.color = '';
+            } else {
+                setDim(idEl, '--', true);
+                idEl.title = 'No active sortie';
+            }
+        }
 
         if (elapsedEl) {
             if (isActive && typeof s.mission_elapsed_sec === 'number') {
@@ -1673,6 +1687,7 @@ const HydraOps = (() => {
             }
         }
         if (endBtn) endBtn.disabled = !isActive;
+        if (startBtn) startBtn.disabled = isActive;
     }
 
     function updateSidebarPipeline(stats) {
@@ -1901,7 +1916,21 @@ const HydraOps = (() => {
         }
     }
 
-    // ── Sidebar Actions: mission end / export, pipeline pause / stop ──
+    // ── Sidebar Actions: mission start / end / export, pipeline pause / stop ──
+    async function startMissionFromOps() {
+        var defaultName = 'sortie-' + new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        var name = window.prompt('Sortie name?', defaultName);
+        if (name === null) return; // operator canceled
+        name = (name || '').trim() || defaultName;
+        var resp = await HydraApp.apiPost('/api/mission/start', { name: name });
+        if (resp && resp.status === 'started') {
+            var short = resp.mission_id ? (' (' + resp.mission_id.slice(0, 8) + ')') : '';
+            HydraApp.showToast('Sortie started: ' + resp.name + short, 'success');
+        } else {
+            HydraApp.showToast('Sortie start failed', 'error');
+        }
+    }
+
     async function endMissionFromOps() {
         var resp = await HydraApp.apiPost('/api/mission/end', {});
         if (resp && resp.status === 'ended') {
@@ -2041,6 +2070,8 @@ const HydraOps = (() => {
         });
 
         // Sidebar card buttons (mission / pipeline mirrors)
+        var missionStartBtn = document.getElementById('ops-btn-mission-start');
+        if (missionStartBtn) missionStartBtn.addEventListener('click', startMissionFromOps);
         var missionEndBtn = document.getElementById('ops-btn-mission-end');
         if (missionEndBtn) missionEndBtn.addEventListener('click', function () {
             if (!confirm('End current sortie?')) return;

--- a/hydra_detect/web/templates/ops.html
+++ b/hydra_detect/web/templates/ops.html
@@ -24,12 +24,17 @@
                     <span class="ops-card-value mono" id="ops-mission-name">--</span>
                 </div>
                 <div class="ops-card-row">
+                    <span class="ops-card-label">ID</span>
+                    <span class="ops-card-value mono" id="ops-mission-id" title="Mission UUID — used for /api/summary queries">--</span>
+                </div>
+                <div class="ops-card-row">
                     <span class="ops-card-label">Elapsed</span>
                     <span class="ops-card-value mono" id="ops-mission-elapsed">--</span>
                     <span class="ops-card-label">Detections</span>
                     <span class="ops-card-value mono" id="ops-mission-dets">--</span>
                 </div>
                 <div class="ops-card-btns">
+                    <button class="btn btn-sm btn-primary" id="ops-btn-mission-start" title="Start a new sortie — bookmarks detection logs and event timeline">Start Sortie</button>
                     <button class="btn btn-sm" id="ops-btn-mission-end" disabled title="End current sortie">End Sortie</button>
                     <button class="btn btn-sm" id="ops-btn-mission-export" title="Export detection waypoints (QGC WPL 110)">Export Waypoints</button>
                 </div>

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -304,8 +304,10 @@ class TestMissionSummary:
         mid_a = str(uuid.uuid4())
         mid_b = str(uuid.uuid4())
         _write_detection_jsonl(tmp_path, mid_a, [
-            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1, "label": "person", "mission_id": mid_a},
-            {"timestamp": "2026-05-19T10:00:02Z", "track_id": 2, "label": "person", "mission_id": mid_b},
+            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1,
+             "label": "person", "mission_id": mid_a},
+            {"timestamp": "2026-05-19T10:00:02Z", "track_id": 2,
+             "label": "person", "mission_id": mid_b},
         ])
         out_a = compute_summary(mid_a, tmp_path)
         out_b = compute_summary(mid_b, tmp_path)

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -191,7 +191,44 @@ class TestDetectionLoggerMissionId:
         # part of the schema now so we assert it is present and null.
         for r in records:
             assert "mission_id" in r
-            assert r["mission_id"] is None
+
+    def test_flush_drains_queue_before_returning(self, tmp_path):
+        """Adversarial finding R3-1 in docs/adversarial/230.md:
+        mission_end must wait for already-queued detections (stamped
+        with the active mission_id) to reach disk before recording the
+        boundary event. flush() is the synchronization primitive."""
+        log_dir = tmp_path / "logs"
+        dl = DetectionLogger(log_dir=str(log_dir), save_images=False)
+        dl.start()
+        mid = str(uuid.uuid4())
+        dl.set_mission_id(mid)
+        try:
+            # Burst-queue 10 rows. After flush() returns the queue MUST
+            # be empty AND every row MUST be in the JSONL.
+            for _ in range(10):
+                dl.log(_tracking())
+            assert dl.flush(timeout=5.0) is True, (
+                "flush() returned False — queue did not drain in 5s"
+            )
+            assert dl._write_queue.unfinished_tasks == 0, (
+                "queue.unfinished_tasks > 0 after flush() returned True"
+            )
+        finally:
+            dl.stop(timeout=2.0)
+        # After stop(), the disk JSONL must contain all 10 rows.
+        records = [
+            json.loads(line)
+            for line in next(log_dir.glob("*.jsonl")).read_text().splitlines()
+            if line.strip()
+        ]
+        assert len(records) == 10
+        assert all(r.get("mission_id") == mid for r in records)
+
+    def test_flush_returns_true_when_writer_not_started(self, tmp_path):
+        """flush() is safe to call on a DetectionLogger that never
+        started — returns True (nothing to wait on)."""
+        dl = DetectionLogger(log_dir=str(tmp_path / "logs"), save_images=False)
+        assert dl.flush(timeout=0.5) is True
 
 
 # ----------------------------------------------------------------------------

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -1,0 +1,489 @@
+"""Mission tagging + event timeline + summary endpoint tests (issue #72).
+
+Covers:
+  - EventLogger generates a UUID mission_id on start_mission()
+  - DetectionLogger stamps mission_id onto every record
+  - /api/mission/start returns the id, propagates to event + detection loggers
+  - /api/mission/end clears the id
+  - /api/summary aggregates per-mission stats from JSONL on disk
+  - Convex hull computation on synthetic GPS tracks
+  - mission_id is null when no mission is active
+"""
+
+from __future__ import annotations
+
+import json
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hydra_detect.detection_logger import DetectionLogger
+from hydra_detect.event_logger import EventLogger
+from hydra_detect.mission_summary import (
+    clear_cache,
+    compute_summary,
+    get_summary,
+    list_missions,
+)
+from hydra_detect.review_export import _convex_hull, _polygon_area_m2, gps_coverage
+from hydra_detect.tracker import TrackedObject, TrackingResult
+from hydra_detect.web.server import (
+    app,
+    configure_auth,
+    configure_web_password,
+    stream_state,
+    _auth_failures,
+    _response_cache,
+)
+
+
+# ----------------------------------------------------------------------------
+# Fixtures
+# ----------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset web-server globals between tests."""
+    configure_auth(None)
+    configure_web_password(None)
+    _auth_failures.clear()
+    _response_cache.clear()
+    stream_state._callbacks.clear()
+    stream_state.runtime_config = {"prompts": ["person"], "threshold": 0.25, "auto_loiter": False}
+    clear_cache()
+    yield
+    clear_cache()
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def event_logger(tmp_path):
+    return EventLogger(log_dir=str(tmp_path / "events"), callsign="TEST")
+
+
+# ----------------------------------------------------------------------------
+# EventLogger: mission_id generation + stamping
+# ----------------------------------------------------------------------------
+
+class TestEventLoggerMissionId:
+    def test_start_mission_returns_uuid(self, event_logger):
+        mid = event_logger.start_mission("alpha")
+        # UUID v4 is 36 chars with hyphens. Use uuid module to parse strictly.
+        parsed = uuid.UUID(mid)
+        assert str(parsed) == mid
+        event_logger.end_mission()
+
+    def test_mission_id_present_on_every_event(self, tmp_path, event_logger):
+        mid = event_logger.start_mission("alpha")
+        event_logger.log_action("lock", {"track_id": 1})
+        event_logger.log_vehicle_track(lat=35.0, lon=-80.0, alt=100.0)
+        event_logger.log_state_change("camera_lost")
+        event_logger.end_mission()
+
+        events_dir = tmp_path / "events"
+        path = next(events_dir.glob("*.jsonl"))
+        records = [json.loads(line) for line in path.read_text().splitlines()]
+        for rec in records:
+            assert rec.get("mission_id") == mid, f"missing/wrong mission_id in {rec}"
+
+    def test_new_start_rotates_id(self, event_logger):
+        mid1 = event_logger.start_mission("alpha")
+        mid2 = event_logger.start_mission("bravo")
+        assert mid1 != mid2
+        event_logger.end_mission()
+
+    def test_external_id_accepted(self, event_logger):
+        wanted = str(uuid.uuid4())
+        got = event_logger.start_mission("alpha", mission_id=wanted)
+        assert got == wanted
+        event_logger.end_mission()
+
+    def test_get_status_exposes_id(self, event_logger):
+        mid = event_logger.start_mission("alpha")
+        status = event_logger.get_status()
+        assert status["mission_active"] is True
+        assert status["mission_id"] == mid
+        assert status["mission_name"] == "alpha"
+        assert status["mission_log"] is not None
+        event_logger.end_mission()
+        post = event_logger.get_status()
+        assert post["mission_active"] is False
+        assert post["mission_id"] is None
+        assert post["mission_log"] is None
+
+    def test_unsafe_name_is_sanitized_for_filename(self, tmp_path):
+        el = EventLogger(log_dir=str(tmp_path / "events"), callsign="TEST")
+        el.start_mission("foo/../bar baz")
+        el.end_mission()
+        events_dir = tmp_path / "events"
+        files = list(events_dir.glob("*.jsonl"))
+        assert len(files) == 1
+        assert "/" not in files[0].name
+        assert ".." not in files[0].name
+
+
+# ----------------------------------------------------------------------------
+# DetectionLogger: mission_id stamping
+# ----------------------------------------------------------------------------
+
+def _tracking(label: str = "person", track_id: int = 1) -> TrackingResult:
+    t = TrackedObject(
+        track_id=track_id, x1=10.0, y1=10.0, x2=50.0, y2=80.0,
+        confidence=0.9, class_id=0, label=label,
+    )
+    return TrackingResult([t])
+
+
+class TestDetectionLoggerMissionId:
+    def test_default_mission_id_is_none(self, tmp_path):
+        dl = DetectionLogger(log_dir=str(tmp_path / "logs"), save_images=False)
+        assert dl.get_mission_id() is None
+
+    def test_set_and_clear_mission_id(self, tmp_path):
+        dl = DetectionLogger(log_dir=str(tmp_path / "logs"), save_images=False)
+        mid = str(uuid.uuid4())
+        dl.set_mission_id(mid)
+        assert dl.get_mission_id() == mid
+        dl.set_mission_id(None)
+        assert dl.get_mission_id() is None
+
+    def test_log_record_carries_mission_id(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        dl = DetectionLogger(log_dir=str(log_dir), save_images=False)
+        dl.start()
+        mid = str(uuid.uuid4())
+        dl.set_mission_id(mid)
+        try:
+            dl.log(_tracking())
+        finally:
+            dl.stop(timeout=2.0)
+        files = list(log_dir.glob("*.jsonl"))
+        assert files, "no detection log written"
+        records = [
+            json.loads(line)
+            for line in files[0].read_text().splitlines()
+            if line.strip()
+        ]
+        assert records, "no records in log"
+        assert all(r.get("mission_id") == mid for r in records)
+
+    def test_log_record_mission_id_null_when_idle(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        dl = DetectionLogger(log_dir=str(log_dir), save_images=False)
+        dl.start()
+        try:
+            dl.log(_tracking())
+        finally:
+            dl.stop(timeout=2.0)
+        records = [
+            json.loads(line)
+            for line in next(log_dir.glob("*.jsonl")).read_text().splitlines()
+            if line.strip()
+        ]
+        # Either absent or explicitly null is acceptable, but the field is
+        # part of the schema now so we assert it is present and null.
+        for r in records:
+            assert "mission_id" in r
+            assert r["mission_id"] is None
+
+
+# ----------------------------------------------------------------------------
+# Convex hull + GPS coverage
+# ----------------------------------------------------------------------------
+
+class TestConvexHull:
+    def test_empty(self):
+        out = gps_coverage([])
+        assert out["point_count"] == 0
+        assert out["hull"] == []
+        assert out["bbox"] is None
+        assert out["area_m2"] == 0.0
+
+    def test_single_point(self):
+        out = gps_coverage([(35.0, -80.0)])
+        assert out["point_count"] == 1
+        assert out["area_m2"] == 0.0
+        assert out["bbox"]["min_lat"] == 35.0
+
+    def test_unit_square_hull(self):
+        # ~111 m on a side at the equator ≈ 12 387 m² area
+        pts = [(0.0, 0.0), (0.001, 0.0), (0.001, 0.001), (0.0, 0.001),
+               (0.0005, 0.0005)]  # interior point should be excluded
+        hull = _convex_hull(pts)
+        assert len(hull) == 4
+        assert (0.0005, 0.0005) not in hull
+        out = gps_coverage(pts)
+        # Equator → m_per_deg_lon ≈ m_per_deg_lat ≈ 111 320
+        assert 12_000 < out["area_m2"] < 12_700
+
+    def test_hull_is_ccw(self):
+        pts = [(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)]
+        hull = _convex_hull(pts)
+        # Andrew monotone chain returns CCW. Verify signed area > 0.
+        # Using shoelace on the unprojected coords (just for orientation).
+        s = 0.0
+        for i, (x1, y1) in enumerate(hull):
+            x2, y2 = hull[(i + 1) % len(hull)]
+            s += x1 * y2 - x2 * y1
+        assert s > 0
+
+    def test_collinear_points_degenerate(self):
+        pts = [(0.0, 0.0), (0.0, 0.001), (0.0, 0.002)]
+        out = gps_coverage(pts)
+        # All collinear → area is 0 (degenerate polygon).
+        assert out["area_m2"] == 0.0
+
+    def test_polygon_area_nonzero_at_higher_lat(self):
+        # At Aberdeen NC (~35° N) the area should still be roughly right.
+        pts = [
+            (35.0, -79.0), (35.001, -79.0),
+            (35.001, -78.999), (35.0, -78.999),
+        ]
+        area = _polygon_area_m2(_convex_hull(pts))
+        # cos(35°) ≈ 0.819, so longitude meters shrink — expect ~9 100 m²
+        assert 8_000 < area < 10_500
+
+
+# ----------------------------------------------------------------------------
+# Mission summary on synthetic logs
+# ----------------------------------------------------------------------------
+
+def _write_detection_jsonl(log_dir: Path, mission_id: str, rows: list[dict]) -> Path:
+    """Write a detections_001.jsonl with the given rows."""
+    log_dir.mkdir(parents=True, exist_ok=True)
+    path = log_dir / "detections_001.jsonl"
+    with path.open("w") as f:
+        for r in rows:
+            r.setdefault("mission_id", mission_id)
+            f.write(json.dumps(r) + "\n")
+    return path
+
+
+def _write_event_jsonl(log_dir: Path, mission_id: str, name: str, rows: list[dict]) -> Path:
+    """Write a mission event JSONL starting with mission_start."""
+    log_dir.mkdir(parents=True, exist_ok=True)
+    path = log_dir / f"TEST_{int(time.time())}_{name}.jsonl"
+    with path.open("w") as f:
+        f.write(json.dumps({
+            "ts": rows[0]["ts"], "type": "mission_start",
+            "callsign": "TEST", "mission_id": mission_id, "name": name,
+        }) + "\n")
+        for r in rows:
+            r.setdefault("mission_id", mission_id)
+            r.setdefault("callsign", "TEST")
+            f.write(json.dumps(r) + "\n")
+        f.write(json.dumps({
+            "ts": rows[-1]["ts"] + 60.0, "type": "mission_end",
+            "callsign": "TEST", "mission_id": mission_id, "name": name,
+        }) + "\n")
+    return path
+
+
+class TestMissionSummary:
+    def test_summary_counts_by_class_and_tracks(self, tmp_path):
+        mid = str(uuid.uuid4())
+        _write_detection_jsonl(tmp_path, mid, [
+            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1, "label": "person"},
+            {"timestamp": "2026-05-19T10:00:02Z", "track_id": 1, "label": "person"},
+            {"timestamp": "2026-05-19T10:00:03Z", "track_id": 2, "label": "car"},
+            {"timestamp": "2026-05-19T10:00:04Z", "track_id": 3, "label": "person"},
+        ])
+        out = compute_summary(mid, tmp_path)
+        assert out["detections"]["total"] == 4
+        assert out["detections"]["by_class"] == {"person": 3, "car": 1}
+        assert out["detections"]["unique_tracks"] == 3
+
+    def test_summary_other_missions_excluded(self, tmp_path):
+        mid_a = str(uuid.uuid4())
+        mid_b = str(uuid.uuid4())
+        _write_detection_jsonl(tmp_path, mid_a, [
+            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1, "label": "person", "mission_id": mid_a},
+            {"timestamp": "2026-05-19T10:00:02Z", "track_id": 2, "label": "person", "mission_id": mid_b},
+        ])
+        out_a = compute_summary(mid_a, tmp_path)
+        out_b = compute_summary(mid_b, tmp_path)
+        assert out_a["detections"]["total"] == 1
+        assert out_b["detections"]["total"] == 1
+
+    def test_summary_time_to_first_detection(self, tmp_path):
+        mid = str(uuid.uuid4())
+        # Mission starts at ts=1000; first detection ISO = epoch 1005.
+        from datetime import datetime, timezone
+        det_ts = datetime.fromtimestamp(1005.0, tz=timezone.utc).isoformat()
+        _write_detection_jsonl(tmp_path, mid, [
+            {"timestamp": det_ts, "track_id": 1, "label": "person"},
+        ])
+        _write_event_jsonl(tmp_path, mid, "alpha", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+        ])
+        out = compute_summary(mid, tmp_path)
+        assert out["time_to_first_detection_sec"] == pytest.approx(5.0, abs=0.01)
+
+    def test_summary_gps_coverage_from_event_track(self, tmp_path):
+        mid = str(uuid.uuid4())
+        _write_event_jsonl(tmp_path, mid, "alpha", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+            {"ts": 1001.0, "type": "track", "lat": 35.001, "lon": -80.0},
+            {"ts": 1002.0, "type": "track", "lat": 35.001, "lon": -79.999},
+            {"ts": 1003.0, "type": "track", "lat": 35.0, "lon": -79.999},
+        ])
+        out = compute_summary(mid, tmp_path)
+        cov = out["gps_coverage"]
+        assert cov["point_count"] == 4
+        assert len(cov["hull"]) == 4
+        assert cov["area_m2"] > 0
+
+    def test_summary_caches_within_ttl(self, tmp_path):
+        mid = str(uuid.uuid4())
+        _write_detection_jsonl(tmp_path, mid, [
+            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1, "label": "person"},
+        ])
+        first = get_summary(mid, tmp_path)
+        # Append more without touching mtime sums dramatically — the
+        # signature still changes (size grows), so cache should invalidate.
+        with (tmp_path / "detections_001.jsonl").open("a") as f:
+            f.write(json.dumps({
+                "timestamp": "2026-05-19T10:00:02Z", "track_id": 2,
+                "label": "car", "mission_id": mid,
+            }) + "\n")
+        # File size changed → signature differs → fresh compute.
+        second = get_summary(mid, tmp_path)
+        assert second["detections"]["total"] == 2
+        assert first["detections"]["total"] == 1
+
+    def test_list_missions_orders_by_start_descending(self, tmp_path):
+        mid_old = str(uuid.uuid4())
+        mid_new = str(uuid.uuid4())
+        _write_event_jsonl(tmp_path, mid_old, "old", [
+            {"ts": 1000.0, "type": "track", "lat": 0.0, "lon": 0.0},
+        ])
+        _write_event_jsonl(tmp_path, mid_new, "new", [
+            {"ts": 2000.0, "type": "track", "lat": 0.0, "lon": 0.0},
+        ])
+        missions = list_missions(tmp_path)
+        # Newest first.
+        assert missions[0]["mission_id"] == mid_new
+        assert missions[1]["mission_id"] == mid_old
+
+
+# ----------------------------------------------------------------------------
+# Web API: /api/mission/start, /api/mission/end, /api/summary
+# ----------------------------------------------------------------------------
+
+class TestMissionWebAPI:
+    def test_start_returns_mission_id(self, client):
+        captured: dict = {}
+
+        def _on_start(name):
+            mid = str(uuid.uuid4())
+            captured["mid"] = mid
+            captured["name"] = name
+            return mid
+
+        stream_state.set_callbacks(on_mission_start=_on_start)
+        resp = client.post("/api/mission/start", json={"name": "alpha"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "started"
+        assert body["name"] == "alpha"
+        assert body["mission_id"] == captured["mid"]
+
+    def test_start_with_empty_body_synthesizes_name(self, client):
+        called: dict = {}
+
+        def _on_start(name):
+            called["name"] = name
+            return "fake-id"
+
+        stream_state.set_callbacks(on_mission_start=_on_start)
+        resp = client.post("/api/mission/start", json={})
+        assert resp.status_code == 200
+        assert called["name"].startswith("mission-")
+
+    def test_start_rejects_blank_name(self, client):
+        stream_state.set_callbacks(on_mission_start=lambda n: "x")
+        resp = client.post("/api/mission/start", json={"name": "   "})
+        assert resp.status_code == 400
+
+    def test_end_invokes_callback(self, client):
+        ended: dict = {"flag": False}
+
+        def _on_end():
+            ended["flag"] = True
+
+        stream_state.set_callbacks(on_mission_end=_on_end)
+        resp = client.post("/api/mission/end", json={})
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ended"
+        assert ended["flag"] is True
+
+    def test_mission_status_endpoint(self, client):
+        def _status():
+            return {
+                "mission_active": True, "mission_name": "alpha",
+                "mission_id": "abc-123", "mission_start_ts": 1000.0,
+                "mission_log": "TEST_alpha.jsonl",
+            }
+        stream_state.set_callbacks(get_event_status=_status)
+        resp = client.get("/api/mission/status")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mission_id"] == "abc-123"
+        assert body["mission_active"] is True
+
+    def test_mission_status_idle_default(self, client):
+        # No callback registered → endpoint returns the idle shape.
+        resp = client.get("/api/mission/status")
+        assert resp.status_code == 200
+        assert resp.json() == {
+            "mission_active": False, "mission_name": None,
+            "mission_id": None, "mission_start_ts": None,
+            "mission_log": None,
+        }
+
+    def test_summary_endpoint_requires_mission_param(self, client):
+        resp = client.get("/api/summary")
+        assert resp.status_code == 400
+
+    def test_summary_endpoint_rejects_oversized_id(self, client):
+        resp = client.get("/api/summary?mission=" + "a" * 65)
+        assert resp.status_code == 400
+
+    def test_summary_endpoint_returns_stats_from_disk(self, client, tmp_path):
+        mid = str(uuid.uuid4())
+        _write_detection_jsonl(tmp_path, mid, [
+            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1, "label": "person"},
+            {"timestamp": "2026-05-19T10:00:02Z", "track_id": 2, "label": "car"},
+        ])
+        _write_event_jsonl(tmp_path, mid, "alpha", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+            {"ts": 1001.0, "type": "action", "action": "lock"},
+        ])
+        stream_state.set_callbacks(get_log_dir=lambda: str(tmp_path))
+        resp = client.get(f"/api/summary?mission={mid}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["mission_id"] == mid
+        assert body["detections"]["total"] == 2
+        assert body["detections"]["by_class"] == {"person": 1, "car": 1}
+        assert body["operator_actions"] == 1
+        assert body["gps_coverage"]["point_count"] == 1
+
+    def test_review_logs_includes_missions(self, client, tmp_path):
+        mid = str(uuid.uuid4())
+        _write_event_jsonl(tmp_path, mid, "alpha", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+        ])
+        stream_state.set_callbacks(get_log_dir=lambda: str(tmp_path))
+        resp = client.get("/api/review/logs")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "missions" in body
+        assert body["missions"][0]["mission_id"] == mid


### PR DESCRIPTION
## Summary

- Adds per-sortie mission tagging that bookmarks both the detection log and the event timeline. Every detection row and every event record now carries a `mission_id` (UUID v4) so logs can be grouped per-sortie for after-action review.
- New `/api/summary` endpoint returns per-mission statistics (detections by class, unique tracks, time to first detection, operator-action count, GPS coverage convex hull) aggregated from JSONL on disk with a 30 s cache.
- Dashboard now has Start Sortie and End Sortie buttons on the existing SORTIE card with a status pill showing the first 8 chars of the active `mission_id`.

Closes #72.

## API surface

| Method | Path | Notes |
|---|---|---|
| POST | `/api/mission/start` | now returns `mission_id` in the response body |
| POST | `/api/mission/end` | unchanged |
| GET  | `/api/mission/status` | new; `{mission_active, mission_name, mission_id, mission_start_ts, mission_log}` |
| GET  | `/api/missions` | new; lists discovered missions, newest first |
| GET  | `/api/summary?mission=<id>` | new; per-mission stats |
| GET  | `/api/review/logs` | now includes `missions: [...]` for the picker |

## mission_id propagation

`EventLogger.start_mission()` is now the ground truth for the id. The facade's `_handle_mission_start` accepts the returned id and pushes it to `DetectionLogger.set_mission_id()` so every detection row gets stamped from that moment forward. The id also lands on `stream_state.stats.mission_id` and `runtime_config.mission_id` so the dashboard and any other consumer see it without extra round-trips. End mission clears in reverse order — DetectionLogger first, then EventLogger — to avoid a window where a new detection lands with an id whose event JSONL is already closed.

## `/api/summary` shape

```jsonc
{
  "mission_id": "uuid-v4",
  "detections": {
    "total": 42,
    "by_class": {"person": 30, "car": 12},
    "unique_tracks": 8
  },
  "time_to_first_detection_sec": 3.42,
  "mission_start_ts": 1747000000.0,
  "mission_end_ts": 1747000600.0,
  "duration_sec": 600.0,
  "operator_actions": 5,
  "state_changes": 2,
  "gps_coverage": {
    "point_count": 47,
    "hull": [[lat, lon], ...],
    "area_m2": 12340.5,
    "bbox": {"min_lat": ..., "max_lat": ..., "min_lon": ..., "max_lon": ...}
  }
}
```

Convex hull uses Andrew monotone-chain in pure Python — no new dependency. scipy is in the lock file but only as a transitive dependency, and the operational summary does not need an exact ellipsoidal area; equirectangular projection is well below 1 percent error inside SORCC line-of-sight ranges.

## Deferred work

- A mobile-friendly version of the Start/End buttons for the instructor and fleet pages was out of scope here and lives on as a follow-up (a candidate issue is #161 if Kyle wants the dedicated tracker).
- The summary endpoint reads JSONL on disk per request. A future optimization is to maintain an in-memory aggregate as events flow in, but the 30 s cache keeps the hot path off disk for repeat polls.

## Test plan

- [x] `python -m pytest tests/test_mission.py -v` — 32 new tests pass
- [x] `python -m pytest tests/test_event_logger.py tests/test_detection_logger.py tests/test_pipeline_subsystems.py tests/test_web_api.py tests/test_instructor_ops.py tests/test_docs_present.py` — 0 regressions
- [x] Full suite delta vs origin/main: -1 failure (no new failures, one pre-existing main failure no longer reproduces)
- [ ] Hit Start Sortie on the ops dashboard against a live Jetson, confirm the mission_id pill populates and `/api/summary?mission=<id>` returns the expected shape
- [ ] Verify detection JSONL on disk has `mission_id` populated and clears to null after End

## CI gate

Per CONTRIBUTING.md, adversarial review doc lives at `docs/adversarial/<PR>.md` once the PR number is known. Will be force-added (the folder is gitignored on main) in a follow-up commit on this branch.