### PR TITLE
feat(health): disk_bytes telemetry + partition-resolve hardening (#232)

### DIFF
--- a/docs/adversarial/236.md
+++ b/docs/adversarial/236.md
@@ -1,0 +1,79 @@
+# Adversarial Analysis — PR #236 (disk_bytes + partition-resolve hardening on /api/health)
+
+**Generated:** 2026-05-19T17:30:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/236
+**Closes:** #232 (Wave 3 adversarial follow-ups on #227)
+**Base:** main at 137161a
+**Diff size:** +279 / -18 across 4 files (observability/__init__.py, observability/health.py, scripts/hydra-detect.service, tests/test_observability.py)
+
+## Summary
+
+- **Round 1:** 4 findings (0 high · 2 medium · 2 low). Pattern-match focused on the env-var override surface (mutable global default at module-import time conflicting with monkeypatch in tests), the systemd `WorkingDirectory` change interacting with relative paths in other call sites (storage rotation, log_dir, image_dir), the unbounded growth of bytes integers in JSON (Python int has no overflow; downstream JS consumers cap at `Number.MAX_SAFE_INTEGER` ~9 PB which is fine for now, but document for posterity), and a logging-storm risk if the probe is called at 10 Hz and consistently fails.
+- **Round 2:** 3 second-order findings. **Confirmed all R1 findings**, sharpened R1-2 (WorkingDirectory change implication on storage_rotation invocation) by re-reading the storage_rotation.py default: it uses `REPO_ROOT / "output_data"` which is computed from the script's own `__file__`, not CWD, so it's unaffected. R2 added a finding on the test's reliance on the monkeypatched function signature matching `shutil.disk_usage(path)` exactly (a future stdlib change to add a keyword-only arg would silently break the fake).
+- **Round 3:** 4 findings; framing identified — *the previous PR (#227) was audited on the producer side and surfaced the consumer-side gap (percent-only telemetry). This PR closes the headline gap but the consumer-shape question hasn't been re-asked at the new boundary.* Now there are two ways to read disk pressure (`disk_free_pct` and `disk_bytes`); when the two disagree (one rounding artifact at low-disk), which does the BLOCKED gate trust? Includes one HIGH finding on shape consistency between the two surfaces.
+- **Consolidated:** 0 blockers · 1 gate (R3-1, addressed inline below) · 4 follow-ups · 0 dropped.
+
+## Round 1 — Pattern Match
+
+4 findings. Dominant pattern: an env-var hook is added to an import-time global so the production daemon can override defaults, but the hook is read at function-call time inside `_default_partitions()` while the snapshot `_DISK_FREE_PARTITIONS` tuple is computed once at import. The two are co-located, which makes a future maintainer likely to assume the tuple reflects current env state when it actually doesn't.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | env-snapshot-divergence | health.py:166-185 | `_DISK_FREE_PARTITIONS` is a module-level tuple computed once at import time from `_default_partitions()`. `compute_disk_free` and `compute_disk_bytes` now call `_default_partitions()` directly (env-aware), but the module-level constant is still exported (implicitly via `from health import ...`). A maintainer who reaches for the tuple — for example, to iterate labels in a dashboard helper — gets the import-time snapshot, not the live env. The two values look identical 99% of the time but diverge on the test that monkeypatches the env. |
+| R1-2 | low | systemd-cwd-blast-radius | scripts/hydra-detect.service:11-17 | Adding `WorkingDirectory=/home/sorcc/Hydra` changes CWD for the entire systemd unit, not just the disk probe. `ExecStart` is `docker run`, which doesn't care about CWD because all its paths are absolute. `ExecStartPre` is `docker rm` — also fine. But if anyone later adds a relative-path `ExecStartPre` (e.g., a pre-flight script `./scripts/preflight.sh`), it now starts working when before it would have failed loudly. Behavior change is positive but unannounced. |
+| R1-3 | low | json-int-precision | health.py:compute_disk_bytes | `disk_bytes.<label>.{free,total}` are Python ints — JSON spec allows arbitrary precision but JS `Number` clips at 2^53 ≈ 9.007 PB. On a 9+ PB partition (not happening anytime soon on a Jetson SD card or NVMe) the JS dashboard would read a truncated value. Worth noting in code comments; not a real risk for the deploy target. |
+| R1-4 | low | logging-storm | health.py:_partition_usage | `_log.warning` is emitted on every probe failure. If `/api/health` is scraped at 10 Hz (Prometheus + dashboard polling + Docker HEALTHCHECK + load balancer probe) and `output_data` is genuinely unreadable for an extended outage, that's 36000 WARNING lines per hour. Bounded by log rotation, but noisy. A per-label cooldown (e.g., one WARNING per minute per label) would be friendlier. |
+
+## Round 2 — Counter-Critique
+
+**Confirmed:** All R1 findings hold. Sharpening:
+
+- **R1-1:** Re-read `_default_partitions()` and confirmed: yes, the module-level `_DISK_FREE_PARTITIONS` tuple is now functionally dead inside the module (both consumers call `_default_partitions()` directly). It's preserved for back-compat with anyone who imported it externally — and to satisfy the existing test that reads the constant. Renaming it to `_DEFAULT_DISK_FREE_PARTITIONS_IMPORT_SNAPSHOT` would clarify the divergence, but is bikeshedding. Acceptable as-is with a docstring note.
+- **R1-2:** Confirmed but lower priority. The risk is that future relative-path commands in `ExecStartPre` now silently work — a positive change masquerading as a negative one. No action needed.
+- **R1-3:** Confirmed and not actionable for this PR. The Jetson Orin Nano max single-volume size is bounded by the eMMC + microSD slot + USB NVMe — none reach 9 PB.
+- **R1-4:** Confirmed but the failure-mode is bounded: failures from the `_partition_usage` path only happen when the partition is genuinely missing or unreadable, not on every call. Steady-state log volume is zero. Acceptable defer.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | low | test-stdlib-coupling | tests/test_observability.py | The monkeypatch fakes `shutil.disk_usage(path)` with a one-positional-arg lambda. If a future Python stdlib release adds a keyword-only argument (e.g., `bypass_cache=False`) the fake would silently ignore it and may misbehave. Cost of robustness: `lambda *a, **kw: usage`. Not actionable now; pin Python version in CI is sufficient. |
+| R2-2 | medium | env-var-no-validation | health.py:_default_partitions | `HYDRA_OUTPUT_DATA_PATH` is read with no validation. An operator who sets it to a path that doesn't exist (typo, mount missing) gets the ancestor-walk fallback — which on a Jetson goes all the way up to `/`. So the BLOCKED gate sees the root partition under the `output_data` label, which is the exact bug this PR set out to fix. Mitigation: log at INFO when the override is in effect AND the path doesn't exist, so the operator notices the misconfiguration. Or treat a non-existent override as a hard error. |
+| R2-3 | nit | systemd-comment-density | scripts/hydra-detect.service | The unit now has three multi-line comment blocks adjacent to one-line `Environment=` lines. Readable but dense. Future cleanup: factor the rationale into a comment file or the project README. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited the producer's new surface — "does the env hook work, does the systemd unit anchor CWD correctly, does the bytes field shape make sense" — but did not re-ask the original framing-break question from #227's R3: when the consumer reads the new shape, can it tell what action to take?* This PR adds `disk_bytes` to close the percent-only gap (R3-1 from #227), but the consumer now has two surfaces to reconcile: `disk_free_pct.output_data == 5.0` and `disk_bytes.output_data == {free: 1.6e9, total: 32e9}`. Which is canonical at the BLOCKED-gate boundary? The math derives one from the other, so they should always agree — but rounding (`pct` rounded to 2 dp; `free/total` are integer bytes) means at exactly 5.00% pct the bytes might say 4.997% or 5.003%. The Capability Status gate (#226) needs a clear rule.
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **high** | **dual-surface-reconciliation** | health.py + #226 contract | The PR ships two surfaces (`disk_free_pct`, `disk_bytes`) and recommends consumers compute "absolute headroom" from bytes. But existing dashboards already read `disk_free_pct`. If #226's BLOCKED gate fires on `pct < 5.0` and a future "smart" gate fires on `bytes.free < 1 GB`, the two gates will trigger at slightly different times on a 32 GB SD card (pct rounds to 4.99% when bytes show 1.59 GB free of 32 GB, etc.). No documentation in this PR pins which surface is canonical. **Recommendation (addressed inline):** add a docstring sentence noting `disk_free_pct` is derived from `disk_bytes` and the two are guaranteed to be internally consistent within rounding; consumers should pick one and stick with it. (See "Action" below.) |
+| R3-2 | medium | privacy-fingerprint-amplification | health.py + #154 phone-home | #227 R3-2 flagged that `disk_free_pct.root` is a per-unit fingerprint in phone-home (drive size + install history). Adding `disk_bytes.root.total` makes the fingerprint *exact*: an operator with multiple Hydras under one central server can now identify each unit by its eMMC capacity. Not a vulnerability per se — these are operator-owned units — but worth documenting in the phone-home payload spec. |
+| R3-3 | medium | env-test-import-order | tests/test_observability.py::TestEnvVarOutputDataPath | The env-var test uses `monkeypatch.setenv` AFTER the module has been imported. This works because `_default_partitions()` reads the env at call time, not import time. But the module-level `_DISK_FREE_PARTITIONS` tuple was computed during the import that happened in the test file's import block, before `monkeypatch.setenv` runs. A future test that *expects* `_DISK_FREE_PARTITIONS` to reflect the env would fail silently. Worth a docstring on the constant noting "import-time snapshot, not live." |
+| R3-4 | low | systemd-drop-in-collision | scripts/hydra-detect.service | The unit hardcodes `Environment=HYDRA_OUTPUT_DATA_PATH=/data`. An operator who runs `systemctl edit hydra-detect` and adds a drop-in with `Environment=HYDRA_OUTPUT_DATA_PATH=/mnt/external` will have both env vars set — systemd's behavior is "last wins" (the drop-in), which is the right semantics, but if the operator instead intends to *clear* the variable they need `Environment=HYDRA_OUTPUT_DATA_PATH=` (empty). Not a bug; document in scripts/README. |
+
+### Consistency-bias callouts
+
+- **R1+R2 saw the env hook as an unambiguous improvement** — R3-1 widens to ask "does shipping two surfaces with overlapping semantics create a new reconciliation tax for downstream consumers?" The answer is yes for one rounding cycle; the rest of the time the surfaces agree by construction.
+- **No round flagged the privacy amplification (R3-2)** until the orthogonal sweep — when we added bytes to close the gap on R3-1 from #227, we inadvertently sharpened the fingerprint identified by R3-2 from the same PR. Same finding, new edge.
+
+## Consolidated
+
+### Gates (must close before merge or in immediate follow-up)
+- **R3-1 (high, addressed inline):** Added a docstring sentence in `compute_disk_bytes` noting the two surfaces are derived from the same `shutil.disk_usage` call and are guaranteed internally consistent within rounding; consumers should pick one and stick with it. The #226 BLOCKED gate spec will need to pin its source-of-truth surface explicitly when it lands.
+
+### Follow-ups (track, not blockers)
+- R1-1: Rename `_DISK_FREE_PARTITIONS` to clarify it's an import-time snapshot, or remove it once external imports are confirmed gone.
+- R1-4: Add per-label cooldown on the `_partition_usage` WARNING log to bound log volume during sustained outages.
+- R2-2: Validate `HYDRA_OUTPUT_DATA_PATH` at startup; warn if the path doesn't exist instead of silently falling back to `/`.
+- R3-2: Document the phone-home payload's fingerprint surface in `docs/observability.md` or the phone-home spec (#154 follow-up).
+
+### Dropped
+- None. R1-3 (JS int overflow at 9+ PB) is real but irrelevant for the deploy target.
+
+## Notes on this round
+
+The PR closes the two HIGH findings from #227's R3 (`disk_bytes` and `WorkingDirectory=` + env hook) and addresses two lower-priority follow-ups (low-disk test, WARNING on probe failure). Two follow-ups deferred to keep diff size focused. The new attack surface introduced by this PR — env-var override with no validation, dual telemetry surfaces — is bounded: env validation is a follow-up, surface reconciliation is documented in the new docstring. No blockers for merge.

--- a/hydra_detect/observability/__init__.py
+++ b/hydra_detect/observability/__init__.py
@@ -6,7 +6,7 @@ All members are stdlib-only; no external dependency is introduced.
 
 from __future__ import annotations
 
-from .health import compute_disk_free, health_snapshot, SUBSYSTEMS
+from .health import compute_disk_bytes, compute_disk_free, health_snapshot, SUBSYSTEMS
 from .metrics import (
     ClientErrorSink,
     Counter,
@@ -33,6 +33,7 @@ __all__ = [
     "Gauge",
     "SUBSYSTEMS",
     "attach_audit_counters",
+    "compute_disk_bytes",
     "compute_disk_free",
     "get_client_error_sink",
     "health_snapshot",

--- a/hydra_detect/observability/health.py
+++ b/hydra_detect/observability/health.py
@@ -285,6 +285,14 @@ def compute_disk_bytes(
     downstream Capability Status gates (#226) set platform-aware BLOCKED
     thresholds. (See adversarial finding R3-1 on #227.)
 
+    The bytes and percent surfaces are computed from the same underlying
+    ``shutil.disk_usage`` call and are guaranteed internally consistent
+    within rounding (``disk_free_pct`` is rounded to 2 decimal places;
+    ``disk_bytes`` carries integer bytes). At the rounding boundary the
+    two may report slightly different sides of a threshold — consumers
+    should pick one canonical surface for gating decisions and stick with
+    it. (See adversarial finding R3-1 on PR #236.)
+
     Args:
         partitions: Optional override mapping ``{label: path}``. When None,
             uses ``_DISK_FREE_PARTITIONS`` defaults (root + output_data).

--- a/hydra_detect/observability/health.py
+++ b/hydra_detect/observability/health.py
@@ -9,11 +9,14 @@ Overall status is the worst of the subsystems: ``fail`` > ``warn`` > ``ok``.
 
 from __future__ import annotations
 
+import logging
 import os
 import shutil
 import time
 from pathlib import Path
 from typing import Any, Dict, Optional
+
+_log = logging.getLogger(__name__)
 
 # Subsystems listed in the response, in display order. Dashboards iterate
 # this to render a per-subsystem light.
@@ -160,19 +163,47 @@ def _probe_disk(path: str = "/") -> Dict[str, str]:
 # is (label, default_path). Per-partition pct is in addition to the existing
 # ``subsystems.disk`` status string — phone-home consumers want a number, not
 # a sentence.
-_DISK_FREE_PARTITIONS: tuple[tuple[str, str], ...] = (
-    ("root", "/"),
-    ("output_data", "./output_data"),
-)
+#
+# The ``output_data`` default path is relative — ``_partition_usage`` walks
+# ancestors when it doesn't exist, which means CWD at probe time decides
+# which partition gets reported. Inside the production Docker container,
+# ``output_data/`` lives at ``/data`` (bind-mounted from the host) and the
+# CWD is ``/app`` where ``./output_data`` does not exist, so the probe would
+# silently fall back to ``/app`` (the container root partition) and mislabel
+# it as ``output_data``. Set ``HYDRA_OUTPUT_DATA_PATH`` in the unit/env to
+# anchor the probe at an absolute mount point. See systemd/hydra-detect.service
+# and adversarial finding R3-3 on #227.
+_DEFAULT_OUTPUT_DATA_PATH = "./output_data"
 
 
-def _partition_free_pct(path: str) -> Optional[float]:
-    """Return free-space percentage for ``path``, or None if unreadable.
+def _default_partitions() -> tuple[tuple[str, str], ...]:
+    """Return the default (label, path) tuple, honouring env overrides."""
+    output_path = os.environ.get(
+        "HYDRA_OUTPUT_DATA_PATH", _DEFAULT_OUTPUT_DATA_PATH,
+    )
+    return (
+        ("root", "/"),
+        ("output_data", output_path),
+    )
+
+
+# Static module-level snapshot so existing tests / call sites importing the
+# tuple keep working. Computed once at import time; the env-aware variant
+# above is consulted from compute_disk_free / compute_disk_bytes.
+_DISK_FREE_PARTITIONS: tuple[tuple[str, str], ...] = _default_partitions()
+
+
+def _partition_usage(path: str) -> Optional[tuple[float, int, int]]:
+    """Return ``(free_pct, free_bytes, total_bytes)`` for ``path``, or None.
 
     Falls back to the parent directory when ``path`` does not exist yet
     (output_data/ may not be created on first boot). Returns None only when
     even the fallback fails — the field is omitted in that case, not zeroed,
     so consumers can distinguish "really full" from "no data".
+
+    Emits a single ``logger.warning`` when the probe ultimately fails, so an
+    operator looking at "why did output_data disappear from phone-home" has
+    something to grep for.
     """
     p = Path(path)
     target: Optional[Path] = p if p.exists() else None
@@ -184,14 +215,35 @@ def _partition_free_pct(path: str) -> Optional[float]:
                 target = ancestor
                 break
     if target is None:
+        _log.warning("disk_probe: no existing ancestor for path=%r", path)
         return None
     try:
         usage = shutil.disk_usage(os.fspath(target))
-    except OSError:
+    except OSError as exc:
+        _log.warning(
+            "disk_probe: shutil.disk_usage failed for path=%r target=%r err=%s",
+            path, os.fspath(target), exc,
+        )
         return None
     if usage.total <= 0:
+        _log.warning(
+            "disk_probe: total bytes <= 0 for path=%r target=%r",
+            path, os.fspath(target),
+        )
         return None
-    return round((usage.free / usage.total) * 100.0, 2)
+    pct = round((usage.free / usage.total) * 100.0, 2)
+    return (pct, int(usage.free), int(usage.total))
+
+
+def _partition_free_pct(path: str) -> Optional[float]:
+    """Return free-space percentage for ``path``, or None if unreadable.
+
+    Thin wrapper over :func:`_partition_usage` preserved for callers that
+    only need the percentage. New code should prefer ``_partition_usage`` so
+    it can also surface absolute free/total bytes (see #232).
+    """
+    info = _partition_usage(path)
+    return None if info is None else info[0]
 
 
 def compute_disk_free(
@@ -211,14 +263,46 @@ def compute_disk_free(
         whose disk_usage call fails are omitted, not zeroed.
     """
     if partitions is None:
-        items = _DISK_FREE_PARTITIONS
+        items = _default_partitions()
     else:
         items = tuple(partitions.items())
     out: Dict[str, float] = {}
     for label, path in items:
-        pct = _partition_free_pct(path)
-        if pct is not None:
-            out[label] = pct
+        info = _partition_usage(path)
+        if info is not None:
+            out[label] = info[0]
+    return out
+
+
+def compute_disk_bytes(
+    partitions: Optional[Dict[str, str]] = None,
+) -> Dict[str, Dict[str, int]]:
+    """Return ``{label: {"free": bytes, "total": bytes}}`` per partition.
+
+    Sibling of :func:`compute_disk_free`. Percent-only telemetry can't tell
+    a phone-home consumer if "5% free" means 200 GB on a 4 TB NVMe (plenty)
+    or 1.6 GB on a 32 GB SD card (about to fill). Absolute byte counts let
+    downstream Capability Status gates (#226) set platform-aware BLOCKED
+    thresholds. (See adversarial finding R3-1 on #227.)
+
+    Args:
+        partitions: Optional override mapping ``{label: path}``. When None,
+            uses ``_DISK_FREE_PARTITIONS`` defaults (root + output_data).
+
+    Returns:
+        Dict mapping label → ``{"free": int, "total": int}``. Labels whose
+        ``disk_usage`` call fails are omitted, not zeroed.
+    """
+    if partitions is None:
+        items = _default_partitions()
+    else:
+        items = tuple(partitions.items())
+    out: Dict[str, Dict[str, int]] = {}
+    for label, path in items:
+        info = _partition_usage(path)
+        if info is not None:
+            _pct, free, total = info
+            out[label] = {"free": free, "total": total}
     return out
 
 
@@ -261,12 +345,17 @@ def health_snapshot(
              "disk":     {...},
           },
           "disk_free_pct": {"root": 87.2, "output_data": 64.5},
+          "disk_bytes":    {"root": {"free": 234..., "total": 480...},
+                            "output_data": {"free": ..., "total": ...}},
         }
 
     The ``disk_free_pct`` field is additive — existing consumers reading
-    ``subsystems.disk.status`` keep working unchanged. Partition labels
-    whose disk_usage call fails are omitted (not zeroed) so phone-home can
-    distinguish "really full" from "no data".
+    ``subsystems.disk.status`` keep working unchanged. The sibling
+    ``disk_bytes`` field (added in #232) carries absolute byte counts so
+    consumers can compute platform-aware headroom rather than treating
+    percentages from a 32 GB SD card and a 4 TB NVMe identically.
+    Partition labels whose disk_usage call fails are omitted (not zeroed)
+    in both maps so phone-home can distinguish "really full" from "no data".
     """
     stats = stats or {}
     subsystems: Dict[str, Dict[str, str]] = {}
@@ -284,4 +373,5 @@ def health_snapshot(
         "ts": time.time(),
         "subsystems": subsystems,
         "disk_free_pct": compute_disk_free(disk_partitions),
+        "disk_bytes": compute_disk_bytes(disk_partitions),
     }

--- a/scripts/hydra-detect.service
+++ b/scripts/hydra-detect.service
@@ -7,6 +7,14 @@ Requires=docker.service
 Restart=always
 RestartSec=5s
 
+# Anchor CWD at the Hydra install root so relative-path probes resolve
+# deterministically. The disk-free probe in observability/health.py walks
+# ancestors from CWD when the target path doesn't exist; without an explicit
+# WorkingDirectory= systemd defaults to '/' and the output_data probe would
+# silently report the root partition under the output_data label. See
+# adversarial finding R3-3 on PR #227 (issue #232).
+WorkingDirectory=/home/sorcc/Hydra
+
 # Platform profile — set HYDRA_VEHICLE in /etc/hydra/vehicle.env
 # (the '-' prefix makes the file optional; absence is not an error).
 # Example /etc/hydra/vehicle.env:
@@ -20,6 +28,13 @@ RestartSec=5s
 EnvironmentFile=-/etc/hydra/vehicle.env
 EnvironmentFile=-/etc/hydra/hydra.env
 
+# Anchor the in-container output_data disk probe at the bind-mount path
+# (/data inside the container — see -v /home/sorcc/Hydra/output_data:/data
+# below). Without this, the probe walks ancestors of ./output_data from
+# /app and reports the container root partition under the output_data
+# label. The Hydra process reads HYDRA_OUTPUT_DATA_PATH at import time.
+Environment=HYDRA_OUTPUT_DATA_PATH=/data
+
 # --privileged grants access to all /dev devices (cameras, serial ports)
 # so individual --device flags are not needed and would fail if a device
 # is absent (e.g., /dev/video2 on single-camera setups).
@@ -32,6 +47,7 @@ ExecStart=/usr/bin/docker run --rm --privileged --runtime nvidia \
   -e HYDRA_API_TOKEN=${HYDRA_API_TOKEN} \
   -e HYDRA_MAVLINK_DEVICE=${HYDRA_MAVLINK_DEVICE} \
   -e HYDRA_MAVLINK_BAUD=${HYDRA_MAVLINK_BAUD} \
+  -e HYDRA_OUTPUT_DATA_PATH=${HYDRA_OUTPUT_DATA_PATH} \
   -v /home/sorcc/Hydra/config.ini:/app/config.ini \
   -v /usr/sbin/nvpmodel:/usr/sbin/nvpmodel:ro \
   -v /usr/bin/jetson_clocks:/usr/bin/jetson_clocks:ro \

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import os
+import shutil
 import threading
 
 import pytest
@@ -12,6 +14,7 @@ from hydra_detect.observability import (
     ClientErrorSink,
     SUBSYSTEMS,
     attach_audit_counters,
+    compute_disk_bytes,
     compute_disk_free,
     get_client_error_sink,
     health_snapshot,
@@ -24,6 +27,7 @@ from hydra_detect.observability import (
     render_metrics,
     reset_counters_for_test,
 )
+from hydra_detect.observability import health as health_module
 from hydra_detect.web import server as server_module
 
 
@@ -223,6 +227,135 @@ class TestHealthSnapshotDiskFreePct:
 
 
 # ---------------------------------------------------------------------------
+# disk_bytes sibling field + partition-resolve hardening (issue #232)
+# Adversarial follow-ups R3-1, R3-3, R3-4, R1-5 on PR #227.
+# ---------------------------------------------------------------------------
+
+
+class TestComputeDiskBytes:
+    def test_returns_free_and_total_bytes(self):
+        result = compute_disk_bytes()
+        assert isinstance(result, dict)
+        assert "root" in result
+        root = result["root"]
+        assert isinstance(root, dict)
+        assert "free" in root and "total" in root
+        assert isinstance(root["free"], int)
+        assert isinstance(root["total"], int)
+        # Sanity bounds — total > 0, free <= total.
+        assert root["total"] > 0
+        assert 0 <= root["free"] <= root["total"]
+
+    def test_custom_partitions(self, tmp_path):
+        result = compute_disk_bytes({"workdir": str(tmp_path)})
+        assert "workdir" in result
+        assert result["workdir"]["total"] > 0
+        # Defaults excluded when override supplied.
+        assert "root" not in result
+
+    def test_unreadable_path_is_omitted(self):
+        # Synthetic path with NUL bytes — no ancestor can resolve.
+        result = compute_disk_bytes({"nope": "\x00invalid\x00"})
+        # Omitted (preferred) or fell back; never a zero placeholder.
+        if "nope" in result:
+            assert result["nope"]["total"] > 0
+
+
+class TestPartitionResolvesToCorrectMount:
+    """R3-3: probe must resolve to the partition of the requested path, not
+    walk up to the daemon's cwd when an explicit absolute path is supplied.
+    """
+
+    def test_explicit_path_uses_that_partition_not_cwd(
+        self, tmp_path, monkeypatch,
+    ):
+        # Two distinct fake partitions: tmp_path (the requested one) and
+        # "/" (what a cwd-anchored fallback would pick). The probe must
+        # see the tmp_path numbers, not the root numbers.
+        gb = 1024 ** 3
+        # Distinct totals make "wrong partition" obvious in the assert.
+        fake = {
+            os.fspath(tmp_path): shutil._ntuple_diskusage(
+                total=64 * gb, used=32 * gb, free=32 * gb,
+            ),
+            "/": shutil._ntuple_diskusage(
+                total=4000 * gb, used=100 * gb, free=3900 * gb,
+            ),
+        }
+
+        def fake_disk_usage(path):
+            key = os.fspath(path)
+            if key in fake:
+                return fake[key]
+            raise OSError(f"unexpected path: {key!r}")
+
+        monkeypatch.setattr(health_module.shutil, "disk_usage", fake_disk_usage)
+        result = compute_disk_bytes({"output_data": os.fspath(tmp_path)})
+        assert "output_data" in result
+        # The 64 GB partition, NOT the 4 TB root partition.
+        assert result["output_data"]["total"] == 64 * gb
+        assert result["output_data"]["free"] == 32 * gb
+
+
+class TestLowDiskMonkeypatched:
+    """R3-4: assert producer behaviour at the low-disk end of the range."""
+
+    def test_one_pct_free_renders_as_float_one(self, tmp_path, monkeypatch):
+        gb = 1024 ** 3
+        usage = shutil._ntuple_diskusage(
+            total=100 * gb, used=99 * gb, free=1 * gb,
+        )
+        monkeypatch.setattr(
+            health_module.shutil, "disk_usage", lambda _p: usage,
+        )
+        result = compute_disk_free({"critical": os.fspath(tmp_path)})
+        assert "critical" in result
+        pct = result["critical"]
+        # Strict identity to a float — not "1", not "1.00", not "1%".
+        assert isinstance(pct, float)
+        assert pct == 1.0
+
+
+class TestProbeWarnsOnFailure:
+    """R1-5: a single WARNING per failed probe call so operators have
+    something to grep for when a partition vanishes from phone-home.
+    """
+
+    def test_warns_when_disk_usage_raises(self, tmp_path, monkeypatch, caplog):
+        def boom(_path):
+            raise OSError("simulated I/O error")
+
+        monkeypatch.setattr(health_module.shutil, "disk_usage", boom)
+        with caplog.at_level(logging.WARNING, logger="hydra_detect.observability.health"):
+            result = compute_disk_free({"dead": os.fspath(tmp_path)})
+        # Label is omitted (no zero placeholder)…
+        assert "dead" not in result
+        # …and exactly one WARNING line was emitted naming the probe.
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "disk_probe" in r.getMessage()
+        ]
+        assert len(warnings) == 1, [r.getMessage() for r in caplog.records]
+
+
+class TestEnvVarOutputDataPath:
+    """Defaults honour HYDRA_OUTPUT_DATA_PATH so the in-container probe can
+    point at /data instead of resolving ./output_data from /app.
+    """
+
+    def test_env_override_changes_default_output_path(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setenv("HYDRA_OUTPUT_DATA_PATH", os.fspath(tmp_path))
+        result = compute_disk_free()
+        # With the override active, output_data resolves to a real tmpdir
+        # and is therefore present (not omitted).
+        assert "output_data" in result
+        # And root is still present too.
+        assert "root" in result
+
+
+# ---------------------------------------------------------------------------
 # Prometheus exposition tests
 # ---------------------------------------------------------------------------
 
@@ -330,6 +463,27 @@ class TestHealthEndpoint:
         pct = body["disk_free_pct"]["root"]
         assert isinstance(pct, (int, float))
         assert 0.0 <= pct <= 100.0
+
+    def test_health_endpoint_surfaces_disk_bytes(self, client):
+        # Issue #232 R3-1: percent-only telemetry can't distinguish 5% of a
+        # 32 GB SD card from 5% of a 4 TB NVMe. Absolute byte counts must be
+        # surfaced alongside disk_free_pct so the BLOCKED gate (#226) can
+        # set platform-aware thresholds.
+        server_module.stream_state.update_stats(
+            camera_ok=True, fps=10.0, detector="yolo",
+        )
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "disk_bytes" in body
+        assert isinstance(body["disk_bytes"], dict)
+        assert "root" in body["disk_bytes"]
+        root = body["disk_bytes"]["root"]
+        assert isinstance(root, dict)
+        assert isinstance(root["free"], int)
+        assert isinstance(root["total"], int)
+        assert root["total"] > 0
+        assert 0 <= root["free"] <= root["total"]
 
 
 class TestMetricsEndpoint:


### PR DESCRIPTION
Closes #232

## Summary

Adversarial follow-ups on PR #227 (`disk_free_pct` per-partition on `/api/health`). Two HIGH-severity findings and two lower-priority items addressed; two follow-ups explicitly deferred to keep this PR focused.

## R-IDs addressed

- **R3-1 (HIGH) — disk_bytes sibling field.** Percent-only telemetry can't distinguish 5% of a 32 GB SD card (1.6 GB, near full for a single 4K clip) from 5% of a 4 TB NVMe (200 GB, plenty). The Capability Status BLOCKED gate (#226) would be platform-blind without absolute bytes. Added `compute_disk_bytes()` which returns `{label: {free, total}}` per partition; `/api/health` surfaces it as a sibling `disk_bytes` key. `disk_free_pct` is unchanged for back-compat.
- **R3-3 (HIGH) — partition-resolve hardening.**
  - Added `WorkingDirectory=/home/sorcc/Hydra` to `scripts/hydra-detect.service` so the outer systemd unit has a stable CWD (default would be `/`, which makes the `./output_data` relative-path probe walk up and report the root partition under both labels).
  - Added an `HYDRA_OUTPUT_DATA_PATH` env-var hook plumbed through the `docker run` line so the in-container probe can be anchored at the `/data` bind-mount instead of resolving `./output_data` from the container's `WORKDIR /app` (which doesn't exist, so the prior code silently reported the container root partition).
  - New `TestPartitionResolvesToCorrectMount` monkeypatches `shutil.disk_usage` for two distinct partitions and asserts the probe picks the requested one, not a CWD-anchored fallback.
- **R3-4 (medium) — low-disk test.** `TestLowDiskMonkeypatched` simulates `total=100*GB, free=1*GB` and asserts `disk_free_pct` returns the float `1.0` exactly (not `1`, not `"1%"`, not `1.00`).
- **R1-5 (low) — WARNING on probe failure.** `_partition_usage` emits exactly one `logger.warning` per failed probe call so operators have something to grep when a partition disappears from phone-home. `TestProbeWarnsOnFailure` pins the contract.

## R-IDs deferred (tracked, not blocked)

- **R1-1:** Pin top-level health-body key set in a contract test. Tracked for a future hardening PR; this PR's additive surface stays safe today by convention.
- **R2-1:** Document Prometheus NaN-vs-zero coercion in `docs/observability.md`. Documentation-only; not a code change.

## Backward compatibility

- Existing consumers reading `disk_free_pct.<label>` continue to work without changes.
- `disk_bytes` is additive; no fields renamed or removed.
- Container deploys without `HYDRA_OUTPUT_DATA_PATH` set fall back to the prior `./output_data` behavior (relative-path probe with ancestor walk).

## Diff size

- Production: 124 LOC net (health.py 106, __init__.py 2, systemd unit 16). Tests: 154 LOC.
- Well under the 250 LOC production cap.

## Acceptance criteria

- [x] R3-1 addressed (HIGH): `disk_bytes` sibling field on `/api/health` with `{free, total}` per partition.
- [x] R3-3 addressed (HIGH): systemd unit sets `WorkingDirectory=`; env-var hook lets the container anchor at the bind-mount path; integration test proves the probe resolves to the requested partition.
- [x] R3-4 addressed: monkeypatched low-disk test asserts `disk_free_pct == 1.0` (float).
- [x] R1-5 addressed: `logger.warning` emitted (and tested) when `_partition_usage` returns None.
- [x] R1-1 and R2-1 explicitly deferred in PR body.
- [x] Backward compat: existing `disk_free_pct` consumers unbroken.
- [x] Tests: 40 passed in `tests/test_observability.py` (32 baseline + 8 new).
- [x] Lint: `python -m flake8` clean on all four changed files.
- [x] Adversarial doc to follow once PR number is known.

## Test plan

- [x] `python -m pytest tests/test_observability.py -q` (40 passed)
- [x] `python -m flake8 hydra_detect/observability/ tests/test_observability.py scripts/` (clean on changed files)
- [ ] On Jetson: confirm `systemctl status hydra-detect` shows `Main PID` running with `WorkingDirectory` set; `curl localhost:8080/api/health | jq .disk_bytes` returns non-empty for both `root` and `output_data`.