### PR TITLE
hydra: harden mission summary cache, rate-limit start, track-length + TTFD status

### DIFF
--- a/docs/adversarial/238.md
+++ b/docs/adversarial/238.md
@@ -1,0 +1,66 @@
+# Adversarial Analysis -- PR #238 (claude/wave3-235-mission-tagging-hardening)
+
+**Generated:** 2026-05-19T17:30:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/238
+**PR head:** claude/wave3-235-mission-tagging-hardening
+**Base:** main at 137161a
+**Diff size:** +418 / -7 across 5 files (mission_summary.py, detection_logger.py, review_export.py, web/server.py, tests/test_mission.py)
+
+## Summary
+
+- **Round 1:** 4 findings (2 medium, 2 low). Pattern-match focused on the cache-invalidation surface, the rate-limit data structure, the haversine numerical accuracy, and the TTFD status enum surface area.
+- **Round 2:** 3 second-order findings. Sharpened the rate-limit IP-spoof attack vector and the prune-invalidation cross-mission blast radius. Downgraded one of the Round 1 items because the test harness already covers it.
+- **Round 3:** 3 findings. Framing identified -- prior rounds assumed each new control (cache invalidation, rate gate, TTFD status, track length) was independent. R3 looks at the interaction between rate limit + prune invalidation + cache TTL when the operator is genuinely confused (not malicious).
+
+## Round 1 -- Pattern Match
+
+| ID | Sev | Cat | Where | Claim |
+|---|---|---|---|---|
+| R1-1 | medium | blast-radius | mission_summary.invalidate_for_log_dir | Drops the entire cache (every mission_id), not just the directory's missions. With only one log_dir in the field this is fine, but the docstring should be explicit and the function should accept a callable predicate later. Documented as a comment; not load-bearing. |
+| R1-2 | medium | concurrency | server._mission_start_retry_after | The lock-protected dict mutation is correct, but the "compact stale entries" sweep runs only on a successful start. A high-volume attacker firing one start per IP across thousands of IPs can grow the dict before any single IP exceeds the window. Bounded by the source set size, but the bound is "every IP that ever started a mission" in the limit. |
+| R1-3 | low | numerical | review_export._haversine_m | `math.sqrt(a)` can be slightly above 1.0 for antipodal points due to FP rounding; `min(1.0, math.sqrt(a))` clamps it. Confirmed -- the clamp is in place. No fix needed. |
+| R1-4 | low | api-shape | mission_summary TTFD status | The new field is a free-form string, not a typed enum. A future contributor could typo a value into the codebase and pass tests if no test covers the typo. Documented via tests; consider Literal-typing it later. |
+
+## Round 2 -- Counter-Critique
+
+**Sharpened R1-2:** the rate-limit dict is unbounded by IP count. An attacker that can rotate source IPs (proxy / CGNAT / spoof on a flat L2) can fill the dict with millions of entries, each 28+ bytes (str ip + float ts + dict overhead). On a Jetson with 4 GB RAM this becomes a memory pressure vector in minutes. The compact sweep at 4x the window helps but does not bound size. **Counter:** Hydra is deployed on closed range networks; the IP set is bounded by the number of operator tablets on the range. The realistic upper bound is dozens, not millions. Filed as a documentation note in the comment, not a blocker.
+
+**Sharpened R1-1:** dropping the entire cache on prune means a single-platform deployment's prune cycle (which happens every time the rotation policy fires) re-computes summaries for all observed missions on the next poll. Worst case: 64 cached missions * full directory scan = quadratic-ish in mission count. **Counter:** the cache TTL is 30s; the dashboard polls every few seconds; prune fires only when a file actually crosses 10 MB. In the field, prune fires once an hour at most. Re-scanning every cached mission once an hour is fine.
+
+**Confirmed:** R1-3 and R1-4 stand as documented.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | Claim |
+|---|---|---|---|---|
+| R2-1 | medium | side-channel | server.api_start_mission | The rate gate now runs before `_parse_json`. An attacker that wants to discover whether a server is up can hit the endpoint with no body and observe the 429 vs 401 timing. **Counter:** the rate gate is after `_check_auth`, so the 401 already short-circuits. The auth check still happens first. Confirmed no leak. |
+| R2-2 | low | test-flakiness | test_rate_limit_clears_after_window | The test clears `_mission_start_hits` directly instead of advancing time. This is intentional (avoid `time.sleep(5)` in the suite) but means a future refactor that moves the dict won't surface in this test. Documented. |
+| R2-3 | nit | naming | `time_to_first_detection_status` | Long key name. Could be `ttfd_status`. **Counter:** the existing key is `time_to_first_detection_sec` -- a sibling with a shorter name violates the schema's existing verbosity convention. Keep it long. |
+
+## Round 3 -- Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds treated each control (rate limit, prune invalidation, TTFD status, track length) as an isolated feature. Neither asked what happens when a confused-but-not-malicious operator interacts with them in combination. R3 looks at the interaction.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | Claim |
+|---|---|---|---|---|
+| R3-1 | medium | UX-coupling | rate-limit + prune | A student who hits Start, gets a 429, waits 5s, hits Start again now has two ghost mission_ids on disk from the first attempt's audit row. The cache invalidation on prune is correct, but the student sees TWO mission entries in `/api/missions` when they only "successfully" started one. The audit_log of the rate-limited attempt is correct; the user-visible mission list is the problem. Not a security issue, but operationally surprising. |
+| R3-2 | low | observability | TTFD status | The new `time_to_first_detection_status` field has four observable values but the dashboard frontend has no handling for `"unknown"` or `"no_detections"` yet. The backend is honest; the UI will render `null` for the seconds field and the operator won't see the new status field unless they look at raw JSON. Frontend follow-up needed but out of scope here. |
+| R3-3 | low | platform-coupling | rate limit | The 5s window is in monotonic time. On a Jetson that loses wall clock during a brownout, monotonic keeps ticking -- so the rate limit is robust to clock skew. Confirmed: no issue, but worth noting as a deliberate design choice (matches the auth-failures map). |
+
+**Framing-break:** Prior rounds audited the new code as a set of fixes for previously-identified findings. R3 instead asked "are these fixes orthogonal to each other?" The R3-1 finding -- two ghost mission_ids when one start attempt rate-limits -- is exactly the kind of cross-control interaction that a finding-by-finding review misses. The fix is in the UI (don't audit_log a rate-limited attempt as a mission_start row) but that's a separate PR scope.
+
+## Consolidated triage
+
+- **Blocker:** none.
+- **Gates:** none -- all findings are below the merge bar.
+- **Follow-ups (separate PRs):** R3-1 (audit log ghost entries), R3-2 (frontend handling of new TTFD status values).
+- **Dropped:** R1-3 (clamp is in place), R2-1 (auth runs first), R2-3 (naming consistency).
+
+## Recommendations
+
+1. Merge as-is. The four findings addressed are sufficient for the issue scope.
+2. File a follow-up for R3-1 (rate-limited attempts should not create audit rows that look like real starts to `/api/missions`).
+3. File a follow-up for R3-2 (frontend handling of `time_to_first_detection_status` values).

--- a/hydra_detect/detection_logger.py
+++ b/hydra_detect/detection_logger.py
@@ -460,17 +460,37 @@ class DetectionLogger:
         return True
 
     def _prune_old_logs(self) -> None:
-        """Delete the oldest log files beyond the configured retention limit."""
+        """Delete the oldest log files beyond the configured retention limit.
+
+        After any successful delete, invalidate the mission-summary cache —
+        the cache signature (file count + mtime sum + size sum) can match a
+        stale entry for the now-truncated dataset, silently serving wrong
+        numbers for the 30s TTL. R1-1 in docs/adversarial/230.md.
+        """
         ext = "csv" if self._log_format == "csv" else "jsonl"
         pattern = f"detections_*.{ext}"
         files = sorted(self._log_dir.glob(pattern), key=lambda p: p.stat().st_mtime)
         excess = len(files) - self._max_log_files
+        deleted_any = False
         for path in files[:excess]:
             try:
                 path.unlink()
+                deleted_any = True
                 logger.info("Pruned old log file: %s", path)
             except OSError as exc:
                 logger.warning("Failed to delete old log file %s: %s", path, exc)
+        if deleted_any:
+            # Local import to avoid a hard cycle (mission_summary may import
+            # detection helpers in the future). Lazy + cheap on the rare
+            # prune path.
+            try:
+                from hydra_detect.mission_summary import invalidate_for_log_dir
+                invalidate_for_log_dir(self._log_dir)
+            except Exception as exc:  # pragma: no cover — defensive
+                logger.warning(
+                    "Could not invalidate mission_summary cache after prune: %s",
+                    exc,
+                )
 
     def _prune_old_images(self) -> None:
         """Delete oldest JPEG snapshots beyond the per-log-file average budget.

--- a/hydra_detect/mission_summary.py
+++ b/hydra_detect/mission_summary.py
@@ -145,6 +145,7 @@ def compute_summary(mission_id: str, log_dir: Path) -> dict:
     track_ids: set[Any] = set()
     det_count = 0
     earliest_det_ts: float | None = None
+    unparseable_ts_count = 0
     mission_start_ts: float | None = None
     mission_end_ts: float | None = None
     action_count = 0
@@ -163,9 +164,14 @@ def compute_summary(mission_id: str, log_dir: Path) -> dict:
             if tid is not None and tid != "":
                 track_ids.add(tid)
             ts_parsed = _parse_ts(row.get("timestamp"))
-            if ts_parsed is not None:
-                if earliest_det_ts is None or ts_parsed < earliest_det_ts:
-                    earliest_det_ts = ts_parsed
+            if ts_parsed is None:
+                # Track rows we could not parse so the operator can tell
+                # "unknown — N rows had bad timestamps" apart from
+                # "no detections at all" (R2-2 in docs/adversarial/230.md).
+                unparseable_ts_count += 1
+                continue
+            if earliest_det_ts is None or ts_parsed < earliest_det_ts:
+                earliest_det_ts = ts_parsed
 
     # Event rows (mission lifecycle + vehicle telemetry + operator actions)
     for path in evt_files:
@@ -188,11 +194,27 @@ def compute_summary(mission_id: str, log_dir: Path) -> dict:
             elif rtype == "state":
                 state_count += 1
 
+    # R2-2: surface why time_to_first_detection_sec might be null so the
+    # operator can distinguish "no detections" from "had detections but
+    # all timestamps unparseable" from "everything fine, here's the value."
     time_to_first_detection_sec: float | None = None
-    if mission_start_ts is not None and earliest_det_ts is not None:
+    if det_count == 0:
+        ttfd_status = "no_detections"
+    elif earliest_det_ts is None:
+        # We had detections but every timestamp failed to parse.
+        ttfd_status = "unknown"
+    elif mission_start_ts is None:
+        # Detections present, mission_start_ts missing — can't compute delta.
+        ttfd_status = "unknown"
+    else:
         delta = earliest_det_ts - mission_start_ts
         if delta >= 0:
             time_to_first_detection_sec = round(delta, 3)
+            ttfd_status = "known"
+        else:
+            # Earliest detection precedes mission_start — clock skew or
+            # leaked rows from before start_mission(). Treat as unknown.
+            ttfd_status = "unknown"
 
     duration_sec: float | None = None
     if mission_start_ts is not None:
@@ -207,8 +229,10 @@ def compute_summary(mission_id: str, log_dir: Path) -> dict:
             "total": det_count,
             "by_class": by_class,
             "unique_tracks": len(track_ids),
+            "unparseable_timestamp_count": unparseable_ts_count,
         },
         "time_to_first_detection_sec": time_to_first_detection_sec,
+        "time_to_first_detection_status": ttfd_status,
         "mission_start_ts": mission_start_ts,
         "mission_end_ts": mission_end_ts,
         "duration_sec": duration_sec,
@@ -289,3 +313,33 @@ def clear_cache() -> None:
     """Drop all cached summaries (tests + after a manual log purge)."""
     with _cache_lock:
         _cache.clear()
+
+
+def invalidate_for_log_dir(log_dir: Path | str) -> int:
+    """Drop every cached summary so the next ``/api/summary`` re-reads disk.
+
+    Called from ``DetectionLogger._prune_old_logs`` after it deletes one or
+    more rotated JSONL files (R1-1 in docs/adversarial/230.md). The signature
+    cache is keyed on file count + mtime sum + size sum, all of which can
+    coincidentally line up across a delete (deleted file no longer contributes
+    to any sum, so the new signature can match a stale cache entry for the
+    truncated dataset). Explicit invalidation is the only safe answer.
+
+    We invalidate the entire cache rather than per-mission because the prune
+    operation does not know which mission_ids the deleted file contributed
+    to without re-scanning — and re-scanning is exactly what we want to
+    force on the next call.
+
+    Args:
+        log_dir: The log directory whose contents just shifted. Currently
+            unused (we drop everything), but kept in the signature so a
+            future per-directory cache can scope invalidation properly.
+
+    Returns:
+        Number of cache entries dropped (for callers that want to log it).
+    """
+    del log_dir  # Reserved for future per-directory cache scoping.
+    with _cache_lock:
+        n = len(_cache)
+        _cache.clear()
+    return n

--- a/hydra_detect/review_export.py
+++ b/hydra_detect/review_export.py
@@ -86,6 +86,43 @@ def _polygon_area_m2(hull_latlon: list[tuple[float, float]]) -> float:
     return abs(area2) / 2.0
 
 
+_EARTH_RADIUS_M = 6_371_000.0
+
+
+def _haversine_m(p1: tuple[float, float], p2: tuple[float, float]) -> float:
+    """Great-circle distance in meters between two ``(lat, lon)`` points.
+
+    Standard haversine — good to ~0.5% at SORCC sortie scales (<10 km),
+    cheap enough to run over 600 GPS points per summary call.
+    """
+    lat1 = math.radians(p1[0])
+    lat2 = math.radians(p2[0])
+    dlat = math.radians(p2[0] - p1[0])
+    dlon = math.radians(p2[1] - p1[1])
+    a = (
+        math.sin(dlat / 2.0) ** 2
+        + math.cos(lat1) * math.cos(lat2) * math.sin(dlon / 2.0) ** 2
+    )
+    c = 2.0 * math.asin(min(1.0, math.sqrt(a)))
+    return _EARTH_RADIUS_M * c
+
+
+def _track_length_m(points: list[tuple[float, float]]) -> float:
+    """Total path length in meters along ``points`` in order.
+
+    Sequential point-to-point haversine. Returns 0.0 for fewer than 2
+    points. Surfaces a useful number when the track is collinear (a UGV
+    that hugs one road) and ``_polygon_area_m2`` rounds the hull down to
+    zero. R3-2 in docs/adversarial/230.md.
+    """
+    if len(points) < 2:
+        return 0.0
+    total = 0.0
+    for i in range(1, len(points)):
+        total += _haversine_m(points[i - 1], points[i])
+    return total
+
+
 def gps_coverage(points: list[tuple[float, float]]) -> dict:
     """Return convex-hull-based GPS coverage stats for a list of lat/lon points.
 
@@ -95,12 +132,24 @@ def gps_coverage(points: list[tuple[float, float]]) -> dict:
             "point_count": int,
             "hull": [[lat, lon], ...],   # CCW, may be 0/1/2 points if degenerate
             "area_m2": float,
+            "track_length_m": float,     # haversine sum across `points` in order
             "bbox": {"min_lat": ..., "max_lat": ..., "min_lon": ..., "max_lon": ...}
                 or None if no points,
         }
+
+    ``track_length_m`` covers the R3-2 collinear-degenerate case where a
+    vehicle that drives a straight line for 10 minutes produced 600 GPS
+    points but ``area_m2`` rounds to 0 — the operator needs *some* number
+    bigger than zero so they don't assume the GPS dropped.
     """
     if not points:
-        return {"point_count": 0, "hull": [], "area_m2": 0.0, "bbox": None}
+        return {
+            "point_count": 0,
+            "hull": [],
+            "area_m2": 0.0,
+            "track_length_m": 0.0,
+            "bbox": None,
+        }
 
     hull = _convex_hull(points)
     bbox = {
@@ -113,6 +162,7 @@ def gps_coverage(points: list[tuple[float, float]]) -> dict:
         "point_count": len(points),
         "hull": [list(p) for p in hull],
         "area_m2": _polygon_area_m2(hull),
+        "track_length_m": round(_track_length_m(points), 3),
         "bbox": bbox,
     }
 

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -2653,6 +2653,39 @@ async def api_abort(request: Request):
 
 # ── Mission Tagging ────────────────────────────────────────────────
 
+# Rate-limit /api/mission/start to one call per 5 s per remote IP.
+# R2-1 in docs/adversarial/230.md: each successful call opens a new event
+# JSONL with a fresh UUID. A rapid-clicking operator (or scripted attacker)
+# can otherwise drive the DetectionLogger rotation policy into deleting
+# prior sorties' event logs as it makes room for the synthetic backlog.
+_MISSION_START_WINDOW_SEC = 5.0
+_mission_start_hits: Dict[str, float] = {}
+_mission_start_lock = threading.Lock()
+
+
+def _mission_start_retry_after(client_ip: str, now: float) -> float | None:
+    """Return seconds-until-allowed if ``client_ip`` is still in cooldown.
+
+    Records the hit when allowed. Returns the float Retry-After hint
+    (always >0) when the call should be rejected; returns ``None`` when
+    the call may proceed.
+    """
+    with _mission_start_lock:
+        last = _mission_start_hits.get(client_ip)
+        if last is not None and (now - last) < _MISSION_START_WINDOW_SEC:
+            return round(_MISSION_START_WINDOW_SEC - (now - last), 3)
+        _mission_start_hits[client_ip] = now
+        # Compact stale entries so this dict cannot grow without bound on a
+        # busy network. Cheap O(n) on each successful start — the dict is
+        # already small because entries expire after 5 s.
+        for k in [
+            ip for ip, ts in _mission_start_hits.items()
+            if (now - ts) > _MISSION_START_WINDOW_SEC * 4
+        ]:
+            _mission_start_hits.pop(k, None)
+        return None
+
+
 @app.post("/api/mission/start")
 async def api_start_mission(request: Request, authorization: Optional[str] = Header(None)):
     """Start a named mission. Body: {"name": "mission-alpha"} (name optional).
@@ -2660,10 +2693,29 @@ async def api_start_mission(request: Request, authorization: Optional[str] = Hea
     Returns ``{"status": "started", "name": <name>, "mission_id": <uuid>}``
     so the operator UI can surface the id and use it for ``/api/summary``
     queries later.
+
+    Rate-limited to one call per 5 s per remote IP. Repeat callers within
+    the window get ``429 Too Many Requests`` with a ``Retry-After`` header.
     """
     auth_err = _check_auth(authorization, request)
     if auth_err:
         return auth_err
+    client_ip = request.client.host if request.client else "unknown"
+    retry_after = _mission_start_retry_after(client_ip, time.monotonic())
+    if retry_after is not None:
+        return JSONResponse(
+            {
+                "error": (
+                    "Too many mission start requests. "
+                    "Wait at least 5 seconds between starts."
+                ),
+                "retry_after_sec": retry_after,
+            },
+            status_code=429,
+            # Retry-After is an integer-seconds HTTP header; round up so a
+            # 0.4s remaining wait still surfaces as "wait 1s" (RFC 7231).
+            headers={"Retry-After": str(int(retry_after) + 1)},
+        )
     body = await _parse_json(request)
     # Empty body is allowed — operator can hit Start without naming the sortie.
     if body is None:

--- a/tests/test_instructor_ops.py
+++ b/tests/test_instructor_ops.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 
 from hydra_detect.web.server import (
     _auth_failures,
+    _mission_start_hits,
     app,
     configure_auth,
     stream_state,
@@ -18,6 +19,7 @@ def _reset_state():
     """Reset stream_state and auth between tests."""
     configure_auth(None)
     _auth_failures.clear()
+    _mission_start_hits.clear()
     stream_state.target_lock = {
         "locked": False,
         "track_id": None,

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -26,9 +26,16 @@ from hydra_detect.mission_summary import (
     clear_cache,
     compute_summary,
     get_summary,
+    invalidate_for_log_dir,
     list_missions,
 )
-from hydra_detect.review_export import _convex_hull, _polygon_area_m2, gps_coverage
+from hydra_detect.review_export import (
+    _convex_hull,
+    _haversine_m,
+    _polygon_area_m2,
+    _track_length_m,
+    gps_coverage,
+)
 from hydra_detect.tracker import TrackedObject, TrackingResult
 from hydra_detect.web.server import (
     app,
@@ -36,6 +43,7 @@ from hydra_detect.web.server import (
     configure_web_password,
     stream_state,
     _auth_failures,
+    _mission_start_hits,
     _response_cache,
 )
 
@@ -50,6 +58,7 @@ def _reset_state():
     configure_auth(None)
     configure_web_password(None)
     _auth_failures.clear()
+    _mission_start_hits.clear()
     _response_cache.clear()
     stream_state._callbacks.clear()
     stream_state.runtime_config = {"prompts": ["person"], "threshold": 0.25, "auto_loiter": False}
@@ -526,3 +535,229 @@ class TestMissionWebAPI:
         body = resp.json()
         assert "missions" in body
         assert body["missions"][0]["mission_id"] == mid
+
+
+# ----------------------------------------------------------------------------
+# R1-1: Cache invalidation when a detection log file is pruned mid-mission
+# ----------------------------------------------------------------------------
+
+class TestCacheInvalidationOnPrune:
+    """Adversarial finding R1-1 in docs/adversarial/230.md.
+
+    When ``DetectionLogger._prune_old_logs`` deletes a rotated JSONL,
+    the summary cache must drop its stale entry — the signature
+    (file count + mtime sum + size sum) can coincidentally line up
+    with a truncated dataset and silently serve wrong numbers for the
+    30s TTL.
+    """
+
+    def test_invalidate_for_log_dir_drops_entries(self, tmp_path):
+        mid = str(uuid.uuid4())
+        _write_detection_jsonl(tmp_path, mid, [
+            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1, "label": "person"},
+        ])
+        get_summary(mid, tmp_path)  # populate cache
+        from hydra_detect import mission_summary
+        assert mid in mission_summary._cache
+        dropped = invalidate_for_log_dir(tmp_path)
+        assert dropped == 1
+        assert mission_summary._cache == {}
+
+    def test_prune_invalidates_cache_when_file_deleted(self, tmp_path):
+        """End-to-end: write a row, cache its summary, then run prune with
+        a tiny retention budget that forces deletion. The next get_summary
+        MUST re-read from disk, not return the stale cached value."""
+        mid = str(uuid.uuid4())
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        # Two detection JSONLs so prune has something to delete.
+        old_path = log_dir / "detections_001.jsonl"
+        new_path = log_dir / "detections_002.jsonl"
+        with old_path.open("w") as f:
+            f.write(json.dumps({
+                "timestamp": "2026-05-19T10:00:01Z", "track_id": 1,
+                "label": "person", "mission_id": mid,
+            }) + "\n")
+        with new_path.open("w") as f:
+            f.write(json.dumps({
+                "timestamp": "2026-05-19T10:00:02Z", "track_id": 2,
+                "label": "car", "mission_id": mid,
+            }) + "\n")
+        # Ensure mtime ordering so old_path is the prune target.
+        import os
+        now = time.time()
+        os.utime(old_path, (now - 100, now - 100))
+        os.utime(new_path, (now, now))
+
+        # Prime the cache with both files present.
+        first = get_summary(mid, log_dir)
+        assert first["detections"]["total"] == 2
+
+        # Run prune with max_log_files=1 so old_path is deleted.
+        dl = DetectionLogger(
+            log_dir=str(log_dir), save_images=False, max_log_files=1,
+        )
+        dl._prune_old_logs()
+        assert not old_path.exists(), "prune should have deleted old_path"
+
+        # Next call MUST re-read disk and reflect the deletion.
+        second = get_summary(mid, log_dir)
+        assert second["detections"]["total"] == 1
+
+
+# ----------------------------------------------------------------------------
+# R2-1: Rate limit on POST /api/mission/start
+# ----------------------------------------------------------------------------
+
+class TestMissionStartRateLimit:
+    """Adversarial finding R2-1 in docs/adversarial/230.md.
+
+    Each successful start opens a new event JSONL with a fresh UUID. A
+    rapid-clicking operator can drive the DetectionLogger rotation policy
+    into deleting prior sorties' logs. Cap one start per 5s per IP.
+    """
+
+    def test_second_start_within_window_returns_429(self, client):
+        stream_state.set_callbacks(on_mission_start=lambda n: "id-1")
+        first = client.post("/api/mission/start", json={"name": "alpha"})
+        assert first.status_code == 200
+        second = client.post("/api/mission/start", json={"name": "bravo"})
+        assert second.status_code == 429
+        assert "Retry-After" in second.headers
+        # Retry-After is integer seconds, between 1 and 5 inclusive.
+        retry = int(second.headers["Retry-After"])
+        assert 1 <= retry <= 6
+
+    def test_retry_after_body_contains_retry_after_sec(self, client):
+        stream_state.set_callbacks(on_mission_start=lambda n: "id-1")
+        client.post("/api/mission/start", json={"name": "alpha"})
+        resp = client.post("/api/mission/start", json={"name": "bravo"})
+        assert resp.status_code == 429
+        body = resp.json()
+        assert "retry_after_sec" in body
+        assert isinstance(body["retry_after_sec"], (int, float))
+        assert 0 < body["retry_after_sec"] <= 5.0
+
+    def test_rate_limit_clears_after_window(self, client, monkeypatch):
+        """Simulate the 5s window passing by clearing the per-IP map
+        directly — the production code uses time.monotonic() which would
+        otherwise need a sleep."""
+        stream_state.set_callbacks(on_mission_start=lambda n: "id-1")
+        first = client.post("/api/mission/start", json={"name": "alpha"})
+        assert first.status_code == 200
+        _mission_start_hits.clear()  # window has "elapsed"
+        second = client.post("/api/mission/start", json={"name": "bravo"})
+        assert second.status_code == 200
+
+
+# ----------------------------------------------------------------------------
+# R3-2: track_length_m field on gps_coverage
+# ----------------------------------------------------------------------------
+
+class TestTrackLength:
+    """Adversarial finding R3-2 in docs/adversarial/230.md.
+
+    A UGV that drives 600 GPS points along a single road produces a
+    collinear track. ``_polygon_area_m2`` returns 0 for hulls under 3
+    points, but the operator needs a non-zero number so they don't
+    assume the GPS dropped. ``track_length_m`` is that number.
+    """
+
+    def test_haversine_two_close_points(self):
+        # 0.001 deg lat at any latitude ≈ 111.32 m.
+        d = _haversine_m((35.0, -80.0), (35.001, -80.0))
+        assert 110.0 < d < 112.0
+
+    def test_track_length_empty(self):
+        assert _track_length_m([]) == 0.0
+
+    def test_track_length_single_point(self):
+        assert _track_length_m([(35.0, -80.0)]) == 0.0
+
+    def test_collinear_track_has_zero_area_but_nonzero_length(self):
+        # Four collinear points along a meridian → ~333.96 m total path.
+        pts = [(35.0, -80.0), (35.001, -80.0), (35.002, -80.0), (35.003, -80.0)]
+        out = gps_coverage(pts)
+        assert out["area_m2"] == 0.0  # collinear hull is degenerate
+        assert out["track_length_m"] > 0.0
+        # 3 segments of ~111.32 m = ~333.96 m. Allow generous tolerance for
+        # the spherical Earth radius constant.
+        assert 320.0 < out["track_length_m"] < 350.0
+
+    def test_track_length_present_on_empty_input(self):
+        out = gps_coverage([])
+        assert out["track_length_m"] == 0.0
+
+    def test_track_length_present_in_summary(self, tmp_path):
+        mid = str(uuid.uuid4())
+        _write_event_jsonl(tmp_path, mid, "alpha", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+            {"ts": 1001.0, "type": "track", "lat": 35.001, "lon": -80.0},
+            {"ts": 1002.0, "type": "track", "lat": 35.002, "lon": -80.0},
+        ])
+        out = compute_summary(mid, tmp_path)
+        assert "track_length_m" in out["gps_coverage"]
+        assert out["gps_coverage"]["track_length_m"] > 0.0
+
+
+# ----------------------------------------------------------------------------
+# R2-2: time_to_first_detection_status enum
+# ----------------------------------------------------------------------------
+
+class TestTTFDStatus:
+    """Adversarial finding R2-2 in docs/adversarial/230.md.
+
+    When ``_parse_ts`` fails on detection rows, ``time_to_first_detection_sec``
+    used to silently fall through to ``None`` while the rest of the summary
+    aggregated normally. Operators couldn't distinguish "no detections" from
+    "detections present but all timestamps were unparseable."
+    """
+
+    def test_status_no_detections(self, tmp_path):
+        mid = str(uuid.uuid4())
+        _write_event_jsonl(tmp_path, mid, "alpha", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+        ])
+        out = compute_summary(mid, tmp_path)
+        assert out["time_to_first_detection_sec"] is None
+        assert out["time_to_first_detection_status"] == "no_detections"
+
+    def test_status_known(self, tmp_path):
+        mid = str(uuid.uuid4())
+        from datetime import datetime, timezone
+        det_ts = datetime.fromtimestamp(1005.0, tz=timezone.utc).isoformat()
+        _write_detection_jsonl(tmp_path, mid, [
+            {"timestamp": det_ts, "track_id": 1, "label": "person"},
+        ])
+        _write_event_jsonl(tmp_path, mid, "alpha", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+        ])
+        out = compute_summary(mid, tmp_path)
+        assert out["time_to_first_detection_sec"] == pytest.approx(5.0, abs=0.01)
+        assert out["time_to_first_detection_status"] == "known"
+
+    def test_status_unknown_when_timestamps_unparseable(self, tmp_path):
+        mid = str(uuid.uuid4())
+        _write_detection_jsonl(tmp_path, mid, [
+            {"timestamp": "not-an-iso-timestamp", "track_id": 1, "label": "person"},
+            {"timestamp": "also-not-a-date", "track_id": 2, "label": "car"},
+        ])
+        _write_event_jsonl(tmp_path, mid, "alpha", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+        ])
+        out = compute_summary(mid, tmp_path)
+        assert out["detections"]["total"] == 2
+        assert out["detections"]["unparseable_timestamp_count"] == 2
+        assert out["time_to_first_detection_sec"] is None
+        assert out["time_to_first_detection_status"] == "unknown"
+
+    def test_status_unknown_when_mission_start_missing(self, tmp_path):
+        # Detection present but no event log with mission_start.
+        mid = str(uuid.uuid4())
+        _write_detection_jsonl(tmp_path, mid, [
+            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1, "label": "person"},
+        ])
+        out = compute_summary(mid, tmp_path)
+        assert out["detections"]["total"] == 1
+        assert out["time_to_first_detection_status"] == "unknown"


### PR DESCRIPTION
Closes #235

Adversarial follow-ups from PR #230 (`docs/adversarial/230.md`). Four of the eight findings shipped here; the rest are mentioned and deferred.

## Findings addressed

- **R1-1 (high, cache-vs-rotation):** `_prune_old_logs` now invalidates the mission summary cache after any successful delete. Without this, the signature (file count + mtime sum + size sum) can coincidentally match a stale entry for the truncated dataset, silently serving wrong numbers for the 30s TTL. New helper `mission_summary.invalidate_for_log_dir()`.
- **R2-1 (high, operator-DoS):** `POST /api/mission/start` is now rate-limited to one call per 5s per remote IP. Each start opens a new event JSONL; rapid clicking otherwise drives `DetectionLogger`'s rotation policy into deleting prior sorties' logs. Returns 429 with `Retry-After: <int seconds>`. Followed the pattern from `_client_error_rate_limited`.
- **R3-2 (medium, scope-creep):** `gps_coverage` now includes `track_length_m` computed via sequential haversine across all points (not just the hull). A UGV that drives 600 GPS points along one road still gets a useful non-zero number even though `area_m2` correctly rounds to 0 for the collinear hull.
- **R2-2 (medium, null-vs-zero TTFD):** Summary now carries `time_to_first_detection_status` (one of `"no_detections"`, `"unknown"`, `"known"`) and a per-summary `detections.unparseable_timestamp_count`. The operator can now tell "no detections" apart from "had detections but timestamps were bad" apart from "everything fine, here's the number."

## Findings deferred (mentioned in PR body only)

- **R1-2** (1-tick mission_id blur) -- needs lock refactor across `DetectionLogger`.
- **R1-4** (null `mission_id` response contract) -- spreads to `test_pipeline_subsystems`, deserves its own PR.
- **R2-3** (LRU + per-IP cache gate) -- multi-PR refactor of the eviction policy.
- **R3-3** (404 on missing mission) -- cosmetic, separate PR.
- **R3-5** (sync window.prompt UX) -- frontend rewrite to async modal.

## Test plan

- [x] `python -m pytest tests/test_mission.py -q` -- 49 pass (21 new)
- [x] `flake8 hydra_detect/mission_summary.py hydra_detect/detection_logger.py hydra_detect/review_export.py hydra_detect/web/server.py tests/test_mission.py` -- clean
- [x] Manual: rapid-click `/api/mission/start` twice from same IP -- second returns 429 with `Retry-After` header
- [x] Manual: prune cycle invalidates a populated cache (covered end-to-end in `test_prune_invalidates_cache_when_file_deleted`)