### PR TITLE
feat(config): adversarial follow-ups for #228 (R1-1, R2-1, R2-2, R3-3) (#233)

### DIFF
--- a/docs/adversarial/239.md
+++ b/docs/adversarial/239.md
@@ -1,0 +1,81 @@
+# Adversarial Analysis — PR #239 (claude/wave3-233-config-diff-polish)
+
+**Generated:** 2026-05-19T17:30:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/239
+**PR head:** e612043 (claude/wave3-233-config-diff-polish)
+**Base:** main at 137161a
+**Diff size:** +367 / -23 across 3 files (pipeline/control.py, web/server.py, tests/test_config_api.py)
+**Touches adversarial-required:** yes (`hydra_detect/pipeline/`, `hydra_detect/web/server.py`)
+
+## Summary
+
+- **Round 1:** 4 findings (0 high - 3 medium - 1 low). Pattern-match on the deepcopy contract, the new tri-tuple in `_maybe_auto_restart`, the audit-format change, and the deprecated `restart_triggered` alias.
+- **Round 2:** 3 second-order findings. Counter-critique re-examined R1-1's deepcopy cost on the diff endpoint poll cadence (cheap, confirmed), R1-3 the alias deprecation timeline (formalize via comment, downgraded), and surfaced two new gaps: caplog plumbing assumption for audit assertions, and the import-path bare-dict envelope edge where `auto_restart` is stripped before validation but the audit row could double-count.
+- **Round 3:** 3 findings. Framing identified: R1 + R2 audited the new code surface in isolation but did not ask (a) whether the deepcopy in the pipeline callback widens the surface for a slow-callback DoS on the diff poll loop, (b) whether the audit-row format change `target=<path> auto_restart=<bool>` collides with any downstream parser that splits on whitespace, or (c) whether the `restart_triggered` alias being kept while the message text shifts to "requested" creates a contradictory operator-facing signal during the deprecation window. None high.
+- **Consolidated:** 0 gates - 4 follow-ups - 2 dropped (deepcopy DoS, message-vs-alias contradiction).
+
+## Round 1 — Pattern Match
+
+4 findings. Dominant pattern: the PR extends two already-load-bearing endpoints (factory-reset, import) with a new three-axis return signal (requested / suppressed / failed) and a deprecated-alias response key. Failure modes cluster around (a) the audit-row format change, (b) the deepcopy invariant in the pipeline callback, and (c) the operator-visible deprecation window.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | callback-contract | pipeline/control.py:64-72 | Switching from `lambda: p._cfg` to `lambda: copy.deepcopy(p._cfg)` is correct for the diff endpoint, but the lambda runs on every poll. If the dashboard polls /api/config/diff at 1 Hz and the ConfigParser grows (currently ~5 KB), deepcopy cost scales linearly. Acceptable today; flag for review if config.ini ever crosses 50 KB. |
+| R1-2 | medium | audit-format | server.py:3497-3501 (factory-reset audit_target) | Audit target shifts from `<backup_path>` to `<backup_path> auto_restart=<bool>` — a space-separated multi-token format. The audit log format string is `target=%s` so downstream parsers that split on whitespace see `target=<path>` and lose the `auto_restart=<bool>` token. Internal log scraping tools may break silently. Mitigated by R2-2's intent (post-incident replay reads the full line, not just the target token). |
+| R1-3 | low | api-deprecation | server.py:3543 (restart_triggered alias) | `restart_triggered` is kept as a deprecated alias for one release, but there is no machine-readable signal (no deprecation header, no warning log on first use). External consumers reading `restart_triggered` get the right value but no nudge to migrate. |
+| R1-4 | medium | three-tuple-overload | server.py:_maybe_auto_restart | The function now returns three orthogonal signals but only one can be non-False/None at a time (mutual exclusion is implicit, not enforced). A future contributor extending the function could accidentally return both `suppression_reason` and `failure_reason` set — the caller's elif chain handles failure first, so the suppression reason silently disappears from the response. |
+
+## Round 2 — Counter-Critique
+
+**Challenged:** R1-1 (deepcopy DoS). Re-read the callback context: the dashboard polls /api/config/diff via `refreshRuntimeDiffBanner` on settings-tab enter only (not on a setInterval — that was the R1-3 nit in 228.md that downgraded to nit). Polling cadence is operator-event-driven, not loop-driven. Diff endpoint also short-circuits on `if cb is None` (test harness). **Downgrade to nit.** The deepcopy is cheap and runs only when the operator clicks Settings.
+
+**Challenged:** R1-3 (deprecation visibility). Adding a `Warning:` header or `logger.warning` on first read of `restart_triggered` requires intercepting the response builder, which is a structural change for one line of API hygiene. The PR body already documents the deprecation timeline. **Downgrade to nit** — file as a doc-side improvement, not a code change.
+
+**Confirmed:** R1-2 (audit-format) and R1-4 (three-tuple mutual-exclusion) hold. R1-2 is medium because downstream tooling is out of tree and not testable from this PR; the format change is observable. R1-4 is medium because the implicit invariant is the kind of gap that bites three releases from now.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | test-plumbing | tests/test_config_api.py:audit-asserting tests | `caplog.set_level(logging.INFO, logger="hydra.audit")` is correct, but the audit logger has its own `_AuditRingHandler` + `_MetricsAuditHandler` attached at module import. `propagate=True` was verified empirically, but a future contributor adding `logger.propagate = False` to harden the audit sink would silently break the new tests. Tests should be more defensive: assert via the ring sink, not via caplog. |
+| R2-2 | low | api-shape-bloat | server.py:3535-3549 (factory-reset response) | The response gained four new fields (`restart_requested`, `restart_note`, `restart_failed_reason`, plus the existing `restart_triggered` alias). That's six total restart-related keys on a single response. The keyspace is now wide enough that an operator reading the JSON has to consult docs to know which key is canonical. Documented in the PR body but not in the endpoint docstring. |
+| R2-3 | nit | import-envelope | server.py:3622-3624 (import bare-dict strip) | The bare-dict envelope strips `auto_restart` before validation. The new `auto_restart_requested` audit-target computation runs AFTER the strip on the bare-dict path, so the audit row correctly reads true for the bare-dict path. Confirmed by inspection; no test pins it. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds focused on the explicit surface (new keys, new tuple shape, audit format). Neither asked: (a) does the deepcopy widen the diff-endpoint surface for a SIGTERM-during-deepcopy race that leaves the pipeline holding a partially-copied ConfigParser, (b) when `restart_failed_reason` carries operator-supplied input (e.g. an exception message that itself contains `auto_restart=true`), can it confuse a downstream log parser, or (c) does the deprecation alias survive a partial-merge scenario where one caller has migrated and another hasn't?*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R3-1 | low | exception-message-injection | server.py:3444 (failure_reason from str(e)) | The exception message is passed verbatim to the response body AND to the audit-row target field. A malicious or noisy callback could raise `RuntimeError("auto_restart=false outcome=failed")` and that string lands inside `target=%s` in the audit log. Audit parser running on whitespace would now see `outcome=failed` from the exception message, not the actual outcome. Mitigated by: callback is internal (`p._handle_restart_command`), not operator-supplied. **Defer.** |
+| R3-2 | nit | deepcopy-signal-window | pipeline/control.py + control.py:75 | The lambda captures `p` by reference. If the pipeline is torn down between callback registration and callback invocation, `p._cfg` is gone and deepcopy raises AttributeError. The diff endpoint already wraps the call in try/except, so the symptom is "diff endpoint logs warning, returns empty runtime." Acceptable. |
+| R3-3 | low | mutual-exclusion-on-three-tuple | server.py:_maybe_auto_restart:return paths | The three return paths (suppressed, failed, requested) are mutually exclusive by control flow, but a future contributor adding a fourth state (e.g., "throttled — too many restart attempts in 60s") would have to extend both the tuple and every caller's elif chain. The shape is correct for today; the extensibility cost is real. Document the contract in the docstring. |
+
+### Consistency-bias callouts
+
+- **R1 and R2 both rated audit-format change medium** (R1-2). R3 confirmed the medium severity but identified that the actual exposure is limited to out-of-tree log scrapers, not Hydra itself. No internal code splits the audit target on whitespace.
+- **R1-3 (deprecation visibility) was downgraded to nit in R2** without R3 surfacing a higher-severity finding in the same area. The alias-vs-message-text contradiction R3 considered (alias says "triggered", message says "requested") was real but operationally inert: an operator reading the message gets the correct mental model, and a programmatic consumer reads keys not prose.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | audit-format | R1-2 | `target=<path> auto_restart=<bool>` is a multi-token format. Downstream parsers that split on whitespace will need updating. Internal tools are fine; out-of-tree scrapers may break silently. | R1-2 | document the format change in the endpoint docstring; track downstream tooling impact in a follow-up issue |
+| medium | three-tuple-overload | R1-4 | `_maybe_auto_restart` now returns three orthogonal signals with implicit mutual exclusion. Future extension (fourth state) requires updating both producer and all consumers. Add a docstring assertion that exactly one of the three values is non-falsy. | R1-4 | follow-up: tighten via NamedTuple or dataclass |
+| medium | test-plumbing | R2-1 | New audit tests rely on caplog propagation from `hydra.audit`. A future hardening that disables propagation would silently break the tests. Assert via the ring sink for defense in depth. | R2-1 | follow-up: refactor audit tests to inspect `_get_audit_sink()` |
+| low | api-shape-bloat | R2-2 | Six restart-related keys on the response — operator needs docs to know which is canonical. | R2-2 | doc-side fix in endpoint docstring |
+| low | exception-injection | R3-1 | Callback exception message lands in `target=%s` audit field verbatim. Not exploitable today (callback is internal). Document the threat in the audit-format spec when it's written. | R3-1 | follow-up |
+| nit | extensibility | R3-3 | Three-tuple is extensible but expensive to extend. NamedTuple would document the contract. | R3-3 | nit |
+| dropped | deepcopy-DoS | R1-1 | Polling cadence is event-driven, not loop-driven. Cost is noise. | R1-1 | dropped |
+| dropped | message-vs-alias-contradiction | (R3 considered) | `restart_triggered=true` + message="restart requested" — different words, same semantics. Operator gets the right mental model from the message; programmatic consumers read the keys. | R3 | dropped |
+
+## Recommendation
+
+**No gate before merge.** The four medium follow-ups are formatting / documentation / test-hardening concerns. None of them describe a real-world failure that would be triggered by merging this PR.
+
+The two highest-value follow-ups are (a) R1-4 — tighten `_maybe_auto_restart` to a NamedTuple to document the three-axis contract for future contributors, and (b) R2-1 — refactor the new audit-assertion tests to inspect the ring sink directly. Both are next-iteration polish, not blockers.
+
+The PR's core surface (deepcopy contract, three-state restart return, audit granularity, response-shape additive evolution) is sound; the new findings cluster in the seams between the explicit API surface and the broader logging / extensibility surface.

--- a/hydra_detect/pipeline/control.py
+++ b/hydra_detect/pipeline/control.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 from dataclasses import dataclass
 
 
@@ -61,7 +62,14 @@ class PipelineControlAdapter:
             # Issue #224 — expose the boot-time ConfigParser so the web
             # diff endpoint can compare it against the on-disk file and
             # surface drift after factory-reset / import.
-            "get_in_memory_config": lambda: p._cfg,
+            #
+            # Issue #233 (R1-1) — deepcopy so a future contributor cannot
+            # accidentally mutate `p._cfg` through the diff endpoint and
+            # silently invalidate drift detection. The pipeline never
+            # mutates `_cfg` post-boot today; the copy guards the contract
+            # against drift in that invariant. ConfigParser of a typical
+            # config.ini is well under 5 KB so the per-call cost is noise.
+            "get_in_memory_config": lambda: copy.deepcopy(p._cfg),
             "on_drop_command": p._handle_drop_command,
             "on_follow_command": p._handle_follow_command,
             "on_approach_strike_command": p._handle_approach_strike_command,

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -3375,13 +3375,35 @@ async def api_config_diff():
     return {"disk": disk, "runtime": runtime, "diff": diff}
 
 
-def _maybe_auto_restart(body: dict | None) -> tuple[bool, str | None]:
+# Issue #233 (R3-3) — operator-facing note on the trigger-vs-apply
+# contract. The restart callback flips a flag the pipeline reads on
+# its next main-loop iteration (~200 ms on a 5 Hz pipeline). The
+# response returns BEFORE that iteration completes, so a brief window
+# exists where the API says "restart requested" while the pipeline is
+# still running the stale `_cfg`. Bounded but not zero.
+_AUTO_RESTART_NOTE = (
+    "Pipeline will pick up the new config on its next main-loop "
+    "iteration (~200ms)."
+)
+
+
+def _maybe_auto_restart(body: dict | None) -> tuple[bool, str | None, str | None]:
     """Pop auto_restart from a request body and fire the restart callback.
 
-    Returns ``(restart_triggered, suppression_reason)``. ``restart_triggered``
-    is True only when the restart callback actually fired. When suppressed
-    by the engagement-active safety gate (PR #228 review-pass), the second
-    tuple element is a short human-readable reason; otherwise None.
+    Returns ``(restart_requested, suppression_reason, failure_reason)``.
+
+    - ``restart_requested`` is True only when the restart callback was
+      invoked without raising. Note: this is "requested," not "applied" —
+      the pipeline applies the new config on its next main-loop iteration.
+      The response payload returns this value under both ``restart_requested``
+      (the canonical key) and ``restart_triggered`` (deprecated alias kept
+      for one release for backward compat).
+    - ``suppression_reason`` is a short human-readable string when the
+      engagement-active safety gate refused the restart; otherwise None.
+    - ``failure_reason`` is a short error string when the callback raised;
+      otherwise None. Callers MUST write a `*_restart_failed` audit row
+      when this is non-None (the disk write already succeeded, so the
+      failure is operator-actionable: re-run or restart manually).
 
     Used by factory-reset and import to opt into the same
     on_restart_command surface /api/restart uses (server.py:2344, :3532
@@ -3394,27 +3416,33 @@ def _maybe_auto_restart(body: dict | None) -> tuple[bool, str | None]:
     gate. The disk reset itself still goes through (callers do that
     before invoking this helper); only the auto-restart is suppressed.
     (Adversarial finding R3-1 in docs/adversarial/228.md.)
+
+    Issue #233 (R2-1) — when the callback raises, the original return
+    `(False, None)` masked the failure as "no restart requested." That
+    silently dropped the audit trail. Now we surface a third value so
+    callers can write a `_restart_failed` audit row and the response
+    payload can carry `restart_failed_reason` for the operator.
     """
     if not isinstance(body, dict):
-        return False, None
+        return False, None, None
     auto = body.get("auto_restart")
     if not bool(auto):
-        return False, None
+        return False, None, None
     engagement_active_cb = _engagement_active_cb_or_none()
     if engagement_active_cb is not None and engagement_active_cb():
         return False, (
             "Autonomous engagement active — auto-restart suppressed. "
             "Disengage and restart manually."
-        )
+        ), None
     cb = stream_state.get_callback("on_restart_command")
     if cb is None:
-        return False, None
+        return False, None, None
     try:
         cb()
     except Exception as e:
         logger.error("auto_restart callback raised: %s", e)
-        return False, None
-    return True, None
+        return False, None, str(e) or e.__class__.__name__
+    return True, None, None
 
 
 def _engagement_active_cb_or_none():
@@ -3460,12 +3488,35 @@ async def api_factory_reset(request: Request, authorization: str | None = Header
             return JSONResponse({"error": "Invalid JSON"}, status_code=400)
     try:
         result = factory_reset_with_backup()
-        _audit(request, "config_factory_reset", target=result.get("backup_path", ""))
+        # Issue #233 (R2-2) — include auto_restart flag in audit target so
+        # post-incident replay can distinguish operator-initiated restart
+        # from auto_restart firing. Format: "<backup_path> auto_restart=<bool>".
+        auto_restart_requested = bool(
+            isinstance(body, dict) and body.get("auto_restart")
+        )
+        audit_target = (
+            f"{result.get('backup_path', '')} "
+            f"auto_restart={str(auto_restart_requested).lower()}"
+        )
+        _audit(request, "config_factory_reset", target=audit_target)
         identity_preserved = bool(result.get("identity_preserved", False))
-        restart_triggered, restart_suppressed_reason = _maybe_auto_restart(body)
-        if restart_triggered:
+        restart_requested, restart_suppressed_reason, restart_failed_reason = (
+            _maybe_auto_restart(body)
+        )
+        if restart_requested:
             _audit(request, "config_factory_reset_restart")
-            message_suffix = " Pipeline restart triggered."
+            message_suffix = " Pipeline restart requested."
+        elif restart_failed_reason is not None:
+            # Issue #233 (R2-1) — disk reset succeeded but the restart
+            # callback raised. Operator needs a replayable trail.
+            _audit(
+                request, "config_factory_reset_restart_failed",
+                target=restart_failed_reason,
+            )
+            message_suffix = (
+                " Restart did not fire (callback error). "
+                "Restart manually to apply."
+            )
         elif restart_suppressed_reason is not None:
             _audit(
                 request, "config_factory_reset_restart_suppressed",
@@ -3485,8 +3536,14 @@ async def api_factory_reset(request: Request, authorization: str | None = Header
             "status": "ok",
             "backup_path": result["backup_path"],
             "restart_required": result["restart_required"],
-            "restart_triggered": restart_triggered,
+            # Issue #233 (R3-3) — `restart_requested` is the canonical
+            # key. `restart_triggered` is a deprecated alias kept for one
+            # release; remove after dashboard JS has been updated.
+            "restart_requested": restart_requested,
+            "restart_triggered": restart_requested,
+            "restart_note": _AUTO_RESTART_NOTE if restart_requested else None,
             "restart_suppressed_reason": restart_suppressed_reason,
+            "restart_failed_reason": restart_failed_reason,
             "identity_preserved": identity_preserved,
             "message": message,
         }
@@ -3584,13 +3641,30 @@ async def api_config_import(request: Request, authorization: str | None = Header
 
     try:
         result = write_config(validation["updates"])
-        _audit(request, "config_import", target=str(len(validation["updates"])))
-        restart_fields = result.get("restart_required", [])
-        restart_triggered, restart_suppressed_reason = _maybe_auto_restart(
-            {"auto_restart": auto_restart_flag} if auto_restart_flag is not None else None
+        # Issue #233 (R2-2) — include auto_restart in audit target.
+        auto_restart_requested = bool(auto_restart_flag)
+        _audit(
+            request, "config_import",
+            target=(
+                f"{len(validation['updates'])} "
+                f"auto_restart={str(auto_restart_requested).lower()}"
+            ),
         )
-        if restart_triggered:
+        restart_fields = result.get("restart_required", [])
+        restart_requested, restart_suppressed_reason, restart_failed_reason = (
+            _maybe_auto_restart(
+                {"auto_restart": auto_restart_flag}
+                if auto_restart_flag is not None else None
+            )
+        )
+        if restart_requested:
             _audit(request, "config_import_restart")
+        elif restart_failed_reason is not None:
+            # Issue #233 (R2-1) — disk write succeeded but restart callback raised.
+            _audit(
+                request, "config_import_restart_failed",
+                target=restart_failed_reason,
+            )
         elif restart_suppressed_reason is not None:
             _audit(
                 request, "config_import_restart_suppressed",
@@ -3599,8 +3673,12 @@ async def api_config_import(request: Request, authorization: str | None = Header
         return {
             "status": "imported",
             "restart_required_fields": restart_fields,
-            "restart_triggered": restart_triggered,
+            # Issue #233 (R3-3) — canonical key + deprecated alias.
+            "restart_requested": restart_requested,
+            "restart_triggered": restart_requested,
+            "restart_note": _AUTO_RESTART_NOTE if restart_requested else None,
             "restart_suppressed_reason": restart_suppressed_reason,
+            "restart_failed_reason": restart_failed_reason,
             **result,
         }
     except Exception as e:

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -893,8 +893,16 @@ class TestFactoryResetAutoRestart:
         assert resp.status_code == 200
         data = resp.json()
         assert data["restart_triggered"] is True
+        # Issue #233 (R3-3) — canonical `restart_requested` key + deprecated
+        # `restart_triggered` alias must agree.
+        assert data["restart_requested"] is True
         assert data["restart_suppressed_reason"] is None
-        assert "Pipeline restart triggered" in data["message"]
+        assert data.get("restart_failed_reason") is None
+        # Issue #233 (R3-3) — message wording shifted to "requested" to
+        # honor the trigger-vs-apply distinction. The `restart_note` field
+        # carries the load-bearing operator hint.
+        assert "Pipeline restart requested" in data["message"]
+        assert data.get("restart_note") and "200" in data["restart_note"]
         restart_cb.assert_called_once()
 
     @_skip_on_windows
@@ -1079,3 +1087,253 @@ class TestComputeConfigDiff:
         disk = {"web": {"api_token": "***"}}
         runtime = {"web": {"api_token": "***"}}
         assert compute_config_diff(disk, runtime) == {}
+
+
+# ── Issue #233 — Adversarial follow-ups for PR #228 ───────────────────────
+
+
+class TestGetInMemoryConfigDeepcopy:
+    """Issue #233 (R1-1) — pipeline callback returns an isolated copy.
+
+    The diff endpoint compares disk vs in-memory cfg. If the callback
+    returns `p._cfg` by reference, a future contributor mutating the
+    returned ConfigParser would silently invalidate drift detection on
+    that field. The contract is now: get_in_memory_config returns a
+    deepcopy so callers cannot reach back into the pipeline state.
+    """
+
+    def test_callback_returns_independent_copy(self):
+        # Build a stand-in pipeline carrying a ConfigParser and exercise
+        # the adapter the way the web layer does.
+        import configparser
+
+        from hydra_detect.pipeline.control import PipelineControlAdapter
+
+        class _Stub:
+            def __init__(self, cfg):
+                self._cfg = cfg
+
+            # PipelineControlAdapter.callbacks() iterates a wide surface of
+            # pipeline attributes; stub the unused ones to None so dict
+            # construction succeeds. Only get_in_memory_config matters here.
+            def __getattr__(self, name):
+                return None
+
+            class _DetLogger:
+                get_recent = None
+
+            class _EventLogger:
+                get_status = None
+
+            class _Detector:
+                get_class_names = None
+
+            _det_logger = _DetLogger()
+            _event_logger = _EventLogger()
+            _detector = _Detector()
+
+        cfg = configparser.ConfigParser()
+        cfg["camera"] = {"fps": "30"}
+        stub = _Stub(cfg)
+        adapter = PipelineControlAdapter(pipeline=stub)
+        cb = adapter.callbacks()["get_in_memory_config"]
+
+        snap1 = cb()
+        assert snap1.get("camera", "fps") == "30"
+        # Mutating the returned copy must NOT affect the pipeline state.
+        snap1.set("camera", "fps", "999")
+        assert stub._cfg.get("camera", "fps") == "30"
+        # And a subsequent call must reflect the pipeline state, not the
+        # mutated snapshot from the prior call.
+        snap2 = cb()
+        assert snap2.get("camera", "fps") == "30"
+
+
+class TestFactoryResetAutoRestartFollowups:
+    """Issue #233 — restart-ordering wording, audit granularity, failure audit."""
+
+    @_skip_on_windows
+    def test_factory_reset_response_carries_restart_requested_alias(
+        self, client, tmp_config_with_factory,
+    ):
+        """R3-3: response shape adds `restart_requested` (canonical) and
+        `restart_note` (trigger-vs-apply hint). `restart_triggered` stays
+        as a deprecated alias for one release."""
+        from unittest.mock import MagicMock
+        restart_cb = MagicMock()
+        stream_state.set_callbacks(on_restart_command=restart_cb)
+        with patch(
+            "hydra_detect.web.config_api.get_config_path",
+            return_value=tmp_config_with_factory,
+        ):
+            resp = client.post(
+                "/api/config/factory-reset", json={"auto_restart": True},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        # Both keys present and equal — alias contract.
+        assert data["restart_requested"] is True
+        assert data["restart_triggered"] is True
+        assert data["restart_requested"] == data["restart_triggered"]
+        # Note field documents the apply window for the operator.
+        assert isinstance(data.get("restart_note"), str)
+        assert "main-loop" in data["restart_note"]
+
+    @_skip_on_windows
+    def test_factory_reset_audit_target_carries_auto_restart_flag(
+        self, client, tmp_config_with_factory, caplog,
+    ):
+        """R2-2: audit row must record auto_restart=true|false so replay
+        can distinguish operator-initiated from auto restart."""
+        import logging as _logging
+        from unittest.mock import MagicMock
+        restart_cb = MagicMock()
+        stream_state.set_callbacks(on_restart_command=restart_cb)
+        caplog.set_level(_logging.INFO, logger="hydra.audit")
+        with patch(
+            "hydra_detect.web.config_api.get_config_path",
+            return_value=tmp_config_with_factory,
+        ):
+            resp = client.post(
+                "/api/config/factory-reset", json={"auto_restart": True},
+            )
+        assert resp.status_code == 200
+        # The "config_factory_reset" audit row's target field must include
+        # auto_restart=true.
+        msgs = [
+            r.getMessage() for r in caplog.records
+            if "config_factory_reset" in r.getMessage()
+        ]
+        reset_rows = [m for m in msgs if "action=config_factory_reset " in m]
+        assert reset_rows, f"expected config_factory_reset audit row, got: {msgs}"
+        assert any("auto_restart=true" in m for m in reset_rows), reset_rows
+
+    @_skip_on_windows
+    def test_factory_reset_audit_target_records_auto_restart_false(
+        self, client, tmp_config_with_factory, caplog,
+    ):
+        """R2-2: even when auto_restart is absent or false, the audit row
+        records auto_restart=false so replay never has to infer it."""
+        import logging as _logging
+        caplog.set_level(_logging.INFO, logger="hydra.audit")
+        with patch(
+            "hydra_detect.web.config_api.get_config_path",
+            return_value=tmp_config_with_factory,
+        ):
+            resp = client.post("/api/config/factory-reset")
+        # Status check is OS-dependent; the audit row is the contract.
+        msgs = [
+            r.getMessage() for r in caplog.records
+            if "config_factory_reset" in r.getMessage()
+        ]
+        reset_rows = [m for m in msgs if "action=config_factory_reset " in m]
+        if resp.status_code == 200:
+            assert reset_rows, f"expected audit row, got: {msgs}"
+            assert any("auto_restart=false" in m for m in reset_rows), reset_rows
+
+    @_skip_on_windows
+    def test_factory_reset_restart_callback_raise_writes_failed_audit(
+        self, client, tmp_config_with_factory, caplog,
+    ):
+        """R2-1: callback raise -> response succeeds with restart_requested
+        false AND a `config_factory_reset_restart_failed` audit row is
+        written so the operator has a replayable trail."""
+        import logging as _logging
+        from unittest.mock import MagicMock
+
+        def _raises():
+            raise RuntimeError("simulated callback failure")
+
+        restart_cb = MagicMock(side_effect=_raises)
+        stream_state.set_callbacks(on_restart_command=restart_cb)
+        caplog.set_level(_logging.INFO, logger="hydra.audit")
+        with patch(
+            "hydra_detect.web.config_api.get_config_path",
+            return_value=tmp_config_with_factory,
+        ):
+            resp = client.post(
+                "/api/config/factory-reset", json={"auto_restart": True},
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        # Disk reset still went through.
+        assert data["status"] == "ok"
+        # Callback raised — restart_requested must be False, failure
+        # reason surfaced to the operator.
+        assert data["restart_requested"] is False
+        assert data["restart_triggered"] is False
+        assert data.get("restart_failed_reason"), data
+        assert "simulated callback failure" in data["restart_failed_reason"]
+        # The _failed audit row was written.
+        msgs = [
+            r.getMessage() for r in caplog.records
+            if "config_factory_reset" in r.getMessage()
+        ]
+        failed_rows = [m for m in msgs if "config_factory_reset_restart_failed" in m]
+        assert failed_rows, f"expected restart_failed audit, got: {msgs}"
+        assert any("simulated callback failure" in m for m in failed_rows), failed_rows
+        # Sanity: the success-path audit row was NOT written.
+        assert not any(
+            "action=config_factory_reset_restart " in m for m in msgs
+        ), msgs
+
+
+class TestImportAutoRestartFollowups:
+    """Issue #233 — same restart-ordering + failure-audit contract on /import."""
+
+    @_skip_on_windows
+    def test_import_response_carries_restart_requested_alias(
+        self, client, tmp_config,
+    ):
+        from unittest.mock import MagicMock
+        restart_cb = MagicMock()
+        stream_state.set_callbacks(on_restart_command=restart_cb)
+        with patch(
+            "hydra_detect.web.config_api.get_config_path", return_value=tmp_config,
+        ):
+            resp = client.post(
+                "/api/config/import",
+                json={"auto_restart": True, "sections": {"camera": {"fps": "20"}}},
+            )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["restart_requested"] is True
+        assert data["restart_triggered"] is True
+        assert isinstance(data.get("restart_note"), str)
+        assert "main-loop" in data["restart_note"]
+
+    @_skip_on_windows
+    def test_import_restart_callback_raise_writes_failed_audit(
+        self, client, tmp_config, caplog,
+    ):
+        import logging as _logging
+        from unittest.mock import MagicMock
+
+        def _raises():
+            raise RuntimeError("import restart boom")
+
+        restart_cb = MagicMock(side_effect=_raises)
+        stream_state.set_callbacks(on_restart_command=restart_cb)
+        caplog.set_level(_logging.INFO, logger="hydra.audit")
+        with patch(
+            "hydra_detect.web.config_api.get_config_path", return_value=tmp_config,
+        ):
+            resp = client.post(
+                "/api/config/import",
+                json={"auto_restart": True, "sections": {"camera": {"fps": "20"}}},
+            )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["restart_requested"] is False
+        assert data.get("restart_failed_reason"), data
+        assert "import restart boom" in data["restart_failed_reason"]
+        msgs = [
+            r.getMessage() for r in caplog.records
+            if "config_import" in r.getMessage()
+        ]
+        failed_rows = [m for m in msgs if "config_import_restart_failed" in m]
+        assert failed_rows, f"expected import restart_failed audit, got: {msgs}"
+        assert any("import restart boom" in m for m in failed_rows), failed_rows
+        assert not any(
+            "action=config_import_restart " in m for m in msgs
+        ), msgs


### PR DESCRIPTION
## Summary

Close four medium adversarial follow-ups from PR #228 (config diff + auto_restart). The HIGH-severity R3-1 was gated before merge; this PR closes the medium register.

- **R1-1 (callback-contract):** `pipeline/control.py:get_in_memory_config` now returns `copy.deepcopy(p._cfg)` so the diff endpoint cannot be silently invalidated by future mutation of `_cfg` post-boot. Test pins the contract.
- **R2-1 (audit-on-failure):** `_maybe_auto_restart` now returns `(requested, suppressed, failed)`. When the restart callback raises, `restart_failed_reason` surfaces in the response and a `config_factory_reset_restart_failed` / `config_import_restart_failed` audit row is written so post-incident replay can tell "operator did not opt in" apart from "callback blew up."
- **R2-2 (audit-granularity):** `config_factory_reset` and `config_import` audit rows now record `auto_restart=true|false` in the target field.
- **R3-3 (restart-ordering):** Response adds `restart_requested` (canonical key, honest about trigger-vs-apply) and `restart_note` (operator hint about the ~200ms main-loop pickup window). `restart_triggered` is kept as a deprecated alias for one release. Message wording shifts to "Pipeline restart requested."

## Backward-compatibility decision (R3-3)

Chose **additive key + deprecated alias** over rename: the response now carries both `restart_requested` (canonical) and `restart_triggered` (deprecated alias, same value). External callers that read `restart_triggered` keep working. The dashboard JS does not read either key today, so no UI update is required. Plan: remove `restart_triggered` next release once any out-of-tree consumers have migrated.

The operator-facing `message` text changes from "Pipeline restart triggered." to "Pipeline restart requested." -- message text is not a stable API surface (it carries operator-friendly prose, not a structured key), so this is treated as honesty-over-stability.

## Deferred (separate issues)

- **R1-2** redaction tightening (either-side redacted -> skip): needs careful thinking about the partial-redaction case + tests.
- **R3-2** flock around diff-endpoint disk+runtime snapshot: needs more design.

## Adversarial review

`docs/adversarial/239.md` -- three-round review captured. The adversarial-required CI gate detected the touches to `hydra_detect/web/server.py` and `pipeline/` and PASSED.

## Acceptance criteria

- [x] R1-1: deepcopy in get_in_memory_config + test asserts mutation isolation.
- [x] R2-1: restart_failed_reason + config_factory_reset_restart_failed / config_import_restart_failed audit rows + tests.
- [x] R2-2: auto_restart=<bool> in audit target for both factory-reset and import + tests.
- [x] R3-3: restart_requested canonical key + restart_note + deprecated restart_triggered alias + tests.
- [x] flake8 clean on changed files.
- [x] Source-only diff: ~108 insertions / 22 deletions -- well under 200 LOC cap.
- [x] Adversarial doc >500 bytes with `## Round 3`.

## Test plan

- [x] `python -m pytest tests/test_config_api.py -k "Followups or Deepcopy or RuntimeConfigDiff or FactoryResetAutoRestart or ImportAutoRestart or ComputeConfigDiff"` -> 12 passed, 12 skipped (Windows os.replace flake markers, pre-existing).

Closes #233