### PR TITLE
feat(battery): graceful-stop ladder for shared-battery USV/UGV (R3-1, R1-1, R2-1, R3-3)

### DIFF
--- a/docs/adversarial/240.md
+++ b/docs/adversarial/240.md
@@ -1,0 +1,94 @@
+# Adversarial Analysis — PR #240 (feat/battery-graceful-stop-ladder)
+
+**Generated:** 2026-05-19T19:15:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/240
+**PR head:** 33d4870 (claude/wave3-234-graceful-stop-ladder)
+**Base:** main at 137161a
+**Diff size:** +916 / -28 across 7 files (hydra_detect/battery_monitor.py, hydra_detect/config_schema.py, hydra_detect/pipeline/facade.py, hydra_detect/servo_tracker.py, tests/test_battery_monitor.py, tests/test_config_schema.py, tests/test_servo_tracker.py)
+**Issue:** Closes #234 (follow-up to PR #229 R3-1, R1-1, R2-1, R3-3)
+
+## Summary
+
+- **Round 1:** 5 findings (1 high, 2 medium, 2 low). Pattern-match focused on the new rate-cap counting under concurrent SYS_STATUS arrivals, the pan-disable latch under set_servo failure, the OK-clear race against a callback in-flight, schema interaction with critical_threshold_pct, and the audit-row gap when the cap suppresses a fire.
+- **Round 2:** 3 second-order findings; **challenged R1-3** (downgraded to nit) — re-read `validate_config`, the new R3-3 check runs AFTER the per-key range check so a syntactically-bad `low_threshold_pct` is already in `result.errors` by the time the warning gate runs. Confirmed R1-1, R1-2, R1-4 with sharper evidence.
+- **Round 3:** 3 findings, framing identified — *both prior rounds audited the new code's internal correctness but did not ask what happens when the operator actually drives the platform back to the dock, swaps the pack, and the next-shift instructor has never seen the dashboard before.*
+- **Consolidated:** 0 blockers · 0 gates · 4 follow-ups · 1 dropped (R1-3 downgrade).
+
+## Round 1 — Pattern Match
+
+5 findings. Dominant pattern: a state machine that now carries TWO latches (`_low_callback_fired` for the one-shot re-arm AND `_last_low_callback_ts` for the wall-clock cap), where the relationships between the latches under recovery / oscillation paths are no longer obviously orthogonal.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | high | latch-coherence | battery_monitor.py:update_from_sys_status (LOW callback gate ~298-336) | When the rate cap suppresses a fire, we set `_low_callback_fired = True` so we don't fall through. Good. But on the next OK transition we ALSO clear `_low_callback_fired`. That's now an asymmetry — the suppressed fire was never an actual fire, but the re-arm path treats it as if it were. The cap-window timer is the source of truth, but the boolean latch is being toggled by both paths. A future refactor that reads the latch (e.g. expose it via `/api/stats`) would lie. |
+| R1-2 | medium | concurrent-callback | battery_monitor.py:update_from_sys_status (LOW callback invocation OUTSIDE the lock) + R2-1 clear path | The LOW callback runs outside the lock. If a fast OK-recovery arrives mid-callback (rare but possible — Jetson MAVLink loop tick + slow `set_mode` round-trip), the OK path acquires the lock and clears `action_taken` AND fires `on_action_cleared` BEFORE the LOW callback returns and tries to set `action_taken = "graceful_stop"`. The result: the LOW callback wins the last write, the dashboard shows `graceful_stop` after the OK transition, and `on_action_cleared` was already notified with no follow-up. |
+| R1-3 | medium | schema-interaction | config_schema.py:_check_shared_battery_threshold_warning | The R3-3 warning reads `low_threshold_pct` and calls `int()`. If the operator set `low_threshold_pct = 99` (legal under the schema) we warn. But the warning is purely advisory — there's no error path. An operator who *wants* a high threshold (e.g. testing the graceful-stop primitive on a bench pack) has no way to silence it. Repeated boot logs noise the audit trail. |
+| R1-4 | medium | suppressed-fire-audit | battery_monitor.py:`logger.info` for rate-cap suppression | The suppression event is logged at INFO level via the standard logger, not the audit logger. The operator audit trail (BATTERY_GRACEFUL_STOP rows) records the FIRES but not the SUPPRESSIONS. Post-incident analysis of "why did graceful-stop only fire once when the boat oscillated for 6 minutes?" requires correlating standard logs to audit rows, which the audit format isn't designed for. |
+| R1-5 | low | servo-disable-on-no-mavlink | facade.py:_graceful_stop_for_shared_battery (early return on no MAVLink) | If `self._mavlink is None`, the callback returns None and skips both `safe()` AND `disable_pan()`. That's correct for set_mode (we have nothing to talk to) but `safe()` and `disable_pan()` call the servo MAVLink surface (which we ALSO don't have). On a Jetson where MAVLink is None, the servo tracker shouldn't exist either, so this is consistent. Confirmed correct under audit but worth pinning in a test (the existing test `test_callback_returns_none_when_mavlink_absent` covers it). |
+
+## Round 2 — Counter-Critique
+
+**Challenged R1-3:** re-read `validate_config` — the per-field range validation runs at line ~1754 (`_validate_scalar(section, key, raw, spec, result)`) BEFORE `_check_shared_battery_threshold_warning(cfg, result)` at line ~1770. If `low_threshold_pct = 99` is set, the scalar check accepts it (max is 99 per the schema). Then the cross-section check fires the warning. **The interaction is fine** — operator who wants 99 gets one warning per boot in the same audit batch as their other config warnings. **Downgrade R1-3 to low (nit)**; the "no way to silence" critique is valid but not a defect, it's the intent.
+
+**Confirmed R1-1, R1-2, R1-4** with sharper evidence.
+
+- R1-1: re-read the suppression branch once more. The asymmetry IS real but contained: `_low_callback_fired` is not exposed externally (private attr, no accessor). The cap-window timer (`_last_low_callback_ts`) is also private. Internal-only; future-refactor risk only. Add a one-line comment on the suppression branch noting why we set the latch even though no fire happened.
+- R1-2: the race is real but rare. The LOW callback path runs MAVLink I/O (set_mode + set_servo + send_statustext). Round-trip times of 50-200ms are plausible. The OK-recovery SYS_STATUS could arrive on the receive thread DURING that window. The fix is one of: (a) snapshot `action_taken` inside the lock at callback-return time and only write if it's still the prior value, OR (b) document that "rapid OK-recovery during graceful-stop execution is a known coverage gap." Option (a) is preferable but a separate ticket — not blocking.
+- R1-4: confirmed. The rate-cap suppression event should be an audit row, not a standard log row.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | pan-disable-cross-mission | servo_tracker.py:disable_pan + enable_pan | `disable_pan()` is sticky across the entire process lifetime. The operator-driven `enable_pan()` is the only path back. If the pipeline is restarted (which is the most common operator action after a graceful-stop), `_pan_disabled = False` on the next boot — but if the OPERATOR forgets to restart and instead just plugs a new pack in, the pan tracker stays gated. Worth a /api/servo POST endpoint or doc note. |
+| R2-2 | low | rate-cap-clock-skew | battery_monitor.py:update_from_sys_status (now=time.monotonic()) | The cap uses `time.monotonic()` which is correct for elapsed-time comparisons. But the test framework passes `now=` explicitly, and the production caller (MAVLinkIO `_handle_sys_status`) does NOT pass `now` — it defaults to monotonic(). If the test framework ever passes a wall-clock `now=` to one call and not to a subsequent call, the cap-window math goes wrong silently. Worth pinning: a test that uses real `time.monotonic()` to confirm the production path. |
+| R2-3 | low | enable-pan-no-statustext | servo_tracker.py:enable_pan | When the operator re-enables pan after the pack swap, there's no STATUSTEXT or audit row confirming it. The dashboard surfaces `pan_disabled=False` after the next status refresh, but post-incident replay has no event marker. Pair `enable_pan()` with an audit row (or `disable_pan()` should also emit one for symmetry). |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited the new state machine in isolation — "is the latch coherent, is the cap window correctly enforced, do the audit rows record the right state." Neither round asked (a) what the dashboard actually displays during the rate-cap window (the operator's view of the system), (b) whether the new `pan_disabled` field is consumed anywhere besides `get_status()` (does ANYTHING in the web UI render it?), or (c) how this interacts with the existing `auto_loiter_on_detect` and `guided_roi_on_detect` autonomy paths — does our new graceful-stop fight an autonomy mode change that's currently in flight?*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | medium | dashboard-divergence | hydra_detect/web/server.py + servo_tracker.get_status() | We added `pan_disabled` to `get_status()` but did NOT update any dashboard widget / template to render it. The dashboard widget for servo tracker shows `tracking` and `pan_pwm` — if the operator looks at the dashboard during a graceful-stop, they see `tracking=False` and `pan_pwm=1500` (center). They cannot distinguish "pan tracker is in safe state because no target is locked" from "pan tracker is disabled until pack swap and I need to re-enable it." Add `pan_disabled` to the dashboard or document the audit-log path. |
+| R3-2 | medium | autonomy-precedence | facade.py:_graceful_stop_for_shared_battery (set_mode call) | Same family as R3-2 from #229 but now sharper: if the platform was running `auto_loiter_on_detect = true` and the detector had JUST set LOITER 2s before the graceful-stop fires, our `set_mode(HOLD)` cancels the detection-triggered loiter. The operator-experienced result: detector found a target, platform loitered, battery hit LOW, platform jumped to HOLD, target now drifts out of frame. There's no explicit "is autonomy currently driving a mode change?" check. Worth a follow-up. |
+| R3-3 | low | pan-disable-strike-coupling | servo_tracker.py:disable_pan vs. fire_strike | `disable_pan()` does NOT inhibit `fire_strike()`. A strike command from the autonomous engine after graceful-stop fires would still pulse the strike servo. On the USV/UGV use-case this is intended (strike is a separate consideration from movement). But the audit log records `pan_disabled=true` without naming this coupling. An operator reviewing the audit row could assume "graceful-stop disabled all servo activity," which is wrong. Doc-only — add a comment to the audit-row format. |
+
+### Consistency-bias callouts
+
+- **R1+R2 focused on internal state correctness; R3 caught the dashboard gap** — exactly the same framing-break PR #229's R3 surfaced. The new feature is correct internally but the operator-visible surface didn't get updated. This is the second time in a row this framing-break has surfaced; consider adding "dashboard widget audit" to the standard PR checklist for features that add new state fields.
+- **R3-2 should have been higher in R1.** The interaction with `auto_loiter_on_detect` is the exact same class of finding as R3-2 from #229 (FC failsafe race). Both prior rounds were pattern-matching to the OLD PR's R3-2 (FC-side failsafe) and missed the Jetson-side autonomy-mode race.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | dashboard-divergence | R3-1 | `pan_disabled` field is exposed via `get_status()` but no dashboard widget renders it. Operator sees `tracking=False` and can't distinguish safe-state from disabled. | R3-1 | follow-up issue (dashboard widget) |
+| medium | latch-coherence | R1-1 | `_low_callback_fired` is set to True on both real fires AND rate-cap-suppressed fires. Internal-only field, but a future refactor exposing it would lie. Add a comment. | R1-1 | follow-up nit (comment) |
+| medium | concurrent-callback | R1-2 | LOW callback runs outside the lock; a fast OK-recovery during callback execution can race the action_taken write. Rare but possible on slow MAVLink links. | R1-2 | follow-up issue (snapshot-and-CAS) |
+| medium | autonomy-precedence | R3-2 | `set_mode(HOLD)` cancels an in-flight detection-triggered loiter. Operator sees the target drift out of frame after LOW transition. | R3-2 | follow-up issue (autonomy-mode check) |
+| medium | pan-disable-cross-mission | R2-1 | `disable_pan()` is sticky across pack swap. Operator must explicitly restart pipeline OR call enable_pan. No /api endpoint exposes it. | R2-1 | follow-up issue (operator endpoint) |
+| medium | suppressed-fire-audit | R1-4 | Rate-cap suppression uses `logger.info`, not `audit_log`. Post-incident replay can't reconstruct why graceful-stop only fired once. | R1-4 | follow-up issue (audit row) |
+| low | rate-cap-clock-skew | R2-2 | Tests pass `now=` explicitly; production uses `time.monotonic()` default. Mixing modes silently breaks the cap. | R2-2 | pin via integration test |
+| low | enable-pan-no-statustext | R2-3 | `enable_pan()` emits no audit row. Replay has no event marker for operator re-arm. | R2-3 | nit |
+| low | pan-disable-strike-coupling | R3-3 | `pan_disabled=true` in audit doesn't communicate that strike is still armed. Doc-only. | R3-3 | nit |
+| low | servo-disable-on-no-mavlink | R1-5 | When mavlink is None we skip both safe() and disable_pan(). Confirmed correct (no mavlink = no servo) but worth pinning. | R1-5 | already tested |
+| low | schema-interaction | R1-3 (downgraded) | Operator running bench tests at `low_threshold_pct=99` gets a recurring boot warning with no silence path. Intent, not defect. | R1-3 | dropped |
+
+## Recommendation
+
+**No gates** for this PR. The high-severity findings (R3-1 from #229, R1-1 from #229) are now ADDRESSED by this PR — that was the entire point. The R1/R2/R3 findings in THIS review are all follow-up nits or operationally-visible gaps that don't undermine the safety-critical behavior shipped here.
+
+Two findings should land before SORCC USV class actually deploys:
+
+1. **R3-1 (dashboard-divergence)** — operator needs to SEE that pan is disabled. Without a dashboard widget, the audit log is the only signal. File as a UI-only follow-up.
+2. **R3-2 (autonomy-precedence)** — `set_mode(HOLD)` over an in-flight detection-triggered loiter is the most operator-visible interaction failure mode. Document explicitly until we add a precedence check.
+
+Everything else is normal post-merge cleanup.
+
+## Round 3 explicit framing-break
+
+The framing both prior rounds shared was: *"check that the new state machine is internally coherent and that the new audit rows record the right fields."* The framing-break in R3 was asking: *"what does the operator actually see during a graceful-stop, and does the dashboard surface the new fields we added?"* That's how R3-1 (dashboard never rendered pan_disabled), R3-2 (autonomy-mode race nobody's exposing), and R3-3 (operator misinterprets the audit row) all surfaced — none of them are bugs in the new code. All of them are operationally-visible failures the new code does not protect against.

--- a/hydra_detect/battery_monitor.py
+++ b/hydra_detect/battery_monitor.py
@@ -113,6 +113,20 @@ class BatteryMonitor:
             ``None`` disables the hook entirely — used by drone profiles
             with ``shared_battery=false`` so behavior matches PR #211.
             See issue #222.
+        min_callback_interval_sec: Wall-clock rate cap on
+            ``on_low_transition`` invocations. After a fire, further fires
+            within this many seconds are suppressed even if the level
+            re-arms (OK→LOW oscillation on a noisy pack at the knee). The
+            single fire still records ``action_taken`` and emits the
+            STATUSTEXT once — the rate cap only suppresses duplicate
+            callback invocations. Default 60.0 s; must be ``>= 0``. 0
+            disables the rate cap (callback fires on every LOW transition
+            after re-arm, original PR #229 behavior). Configurable via
+            ``[battery] min_callback_interval_sec``. Issue #234 R1-1.
+        on_action_cleared: Optional callback fired on the OK transition
+            that clears a previously-set ``action_taken``. Receives the
+            cleared label (e.g. ``"graceful_stop"``) so the caller can
+            write a corresponding audit row. Issue #234 R2-1.
     """
 
     def __init__(
@@ -126,6 +140,8 @@ class BatteryMonitor:
         critical_reissue_sec: float = 0.0,
         enabled: bool = True,
         on_low_transition: Optional[Callable[["BatteryState"], Optional[str]]] = None,
+        min_callback_interval_sec: float = 60.0,
+        on_action_cleared: Optional[Callable[[str], None]] = None,
     ):
         if critical_threshold_pct >= low_threshold_pct:
             raise ValueError(
@@ -156,6 +172,16 @@ class BatteryMonitor:
             self._reissue = requested_reissue
         self._enabled = enabled
         self._on_low_transition = on_low_transition
+        # Issue #234 R1-1: wall-clock rate cap on LOW-callback fires to
+        # absorb OK→LOW→OK→LOW oscillation on a noisy pack at the knee.
+        # Coerce to a non-negative float; negative input is treated as 0
+        # (disabled) so a typo doesn't silently invert the gate.
+        self._min_callback_interval_sec = max(
+            0.0, float(min_callback_interval_sec),
+        )
+        # Issue #234 R2-1: notified on the OK transition that clears a
+        # previously-set ``action_taken``. Caller writes the audit row.
+        self._on_action_cleared = on_action_cleared
 
         self._lock = threading.Lock()
         self._state = BatteryState()
@@ -173,6 +199,11 @@ class BatteryMonitor:
         # graceful-stop, not a repeating alert). Re-armed only after the
         # level recovers above LOW. See issue #222.
         self._low_callback_fired: bool = False
+        # Issue #234 R1-1: monotonic timestamp of the last fired LOW
+        # callback. Compared against ``min_callback_interval_sec`` to
+        # suppress duplicate fires from OK→LOW oscillation. ``0.0`` = no
+        # prior fire (the first ever LOW transition always fires).
+        self._last_low_callback_ts: float = 0.0
 
     # -- Configuration -------------------------------------------------
     @property
@@ -196,6 +227,11 @@ class BatteryMonitor:
         """Effective reissue cadence after R1-4 floor clamp (may differ
         from the configured value if it was below the safety floor)."""
         return self._reissue
+
+    @property
+    def min_callback_interval_sec(self) -> float:
+        """LOW-callback rate cap (issue #234 R1-1). 0 disables."""
+        return self._min_callback_interval_sec
 
     def set_callsign(self, callsign: str) -> None:
         with self._lock:
@@ -248,6 +284,7 @@ class BatteryMonitor:
 
         uncalibrated_alert: Optional[tuple[str, int]] = None
         low_callback_snapshot: Optional[BatteryState] = None
+        cleared_action_label: Optional[str] = None
         with self._lock:
             self._state.voltage_v = voltage_v
             self._state.remaining_pct = remaining_pct
@@ -277,13 +314,36 @@ class BatteryMonitor:
             # CRITICAL hits on a shared-battery platform, brownout is
             # already imminent; LOW gives the Jetson margin to act while
             # it still has rail). Re-arm only on recovery to OK.
-            if (
+            #
+            # Issue #234 R1-1: even after re-arm on OK, suppress fires
+            # that fall inside the wall-clock rate cap window. Pinning
+            # to a single fire per ``min_callback_interval_sec`` absorbs
+            # noisy-pack oscillation (OK→LOW→OK→LOW within 30s) which
+            # would otherwise produce duplicate audit rows and duplicate
+            # set_mode(HOLD) calls. The first LOW transition ever (no
+            # prior fire) always fires regardless of the cap.
+            should_fire_low_cb = (
                 self._on_low_transition is not None
                 and level == LEVEL_LOW
                 and prev_alert_level != LEVEL_LOW
                 and not self._low_callback_fired
-            ):
+            )
+            if should_fire_low_cb and self._min_callback_interval_sec > 0.0:
+                last = self._last_low_callback_ts
+                if last > 0.0 and (now - last) < self._min_callback_interval_sec:
+                    # Inside the rate-cap window — suppress this fire but
+                    # still latch ``_low_callback_fired`` so we don't drop
+                    # into the no-rate-cap branch on the next tick.
+                    should_fire_low_cb = False
+                    self._low_callback_fired = True
+                    logger.info(
+                        "battery: LOW callback rate-capped "
+                        "(last fire %.1fs ago, cap=%.1fs).",
+                        now - last, self._min_callback_interval_sec,
+                    )
+            if should_fire_low_cb:
                 self._low_callback_fired = True
+                self._last_low_callback_ts = now
                 low_callback_snapshot = BatteryState(
                     voltage_v=self._state.voltage_v,
                     remaining_pct=self._state.remaining_pct,
@@ -296,8 +356,17 @@ class BatteryMonitor:
             # Re-arm the LOW-transition callback when level recovers to OK
             # so a subsequent LOW dip (rare but possible on a noisy pack)
             # can fire it again.
+            #
+            # Issue #234 R2-1: also clear the sticky ``action_taken`` flag
+            # on recovery so a multi-mission day (drive boat back, swap
+            # pack, redeploy) does not show stale "graceful_stop" on the
+            # dashboard. Surface the cleared label outside the lock so
+            # the caller can write a paired audit row.
             if level == LEVEL_OK and self._low_callback_fired:
                 self._low_callback_fired = False
+            if level == LEVEL_OK and self._state.action_taken is not None:
+                cleared_action_label = self._state.action_taken
+                self._state.action_taken = None
 
         if uncalibrated_alert is not None and self._send is not None:
             text, severity = uncalibrated_alert
@@ -328,6 +397,18 @@ class BatteryMonitor:
             if isinstance(result, str) and result:
                 with self._lock:
                     self._state.action_taken = result
+
+        # Issue #234 R2-1: notify the action-cleared callback OUTSIDE the
+        # lock so the caller can write an audit row without blocking the
+        # next SYS_STATUS update. Idempotent — only fires when the OK
+        # transition actually cleared a previously-set label.
+        if cleared_action_label is not None and self._on_action_cleared is not None:
+            try:
+                self._on_action_cleared(cleared_action_label)
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.warning(
+                    "battery action-cleared callback failed: %s", exc,
+                )
 
     # -- Read-side -----------------------------------------------------
     def get_state(self, now: Optional[float] = None) -> BatteryState:

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -336,6 +336,19 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
                 "alert per transition only)."
             ),
         ),
+        "min_callback_interval_sec": FieldSpec(
+            FieldType.FLOAT,
+            min_val=0.0,
+            max_val=3600.0,
+            default=60.0,
+            description=(
+                "Wall-clock rate cap on the shared-battery LOW-transition "
+                "callback. After a fire, further fires within this many "
+                "seconds are suppressed (absorbs OK->LOW->OK->LOW "
+                "oscillation on a noisy pack at the knee). 0 disables the "
+                "rate cap. Issue #234 R1-1."
+            ),
+        ),
     },
     "alerts": {
         "light_bar_enabled": FieldSpec(
@@ -1763,4 +1776,69 @@ def validate_config(cfg: configparser.ConfigParser) -> ValidationResult:
     # Vehicle-profile sections: dotted overrides validated against base schema
     _validate_vehicle_sections(cfg, result)
 
+    # Issue #234 R3-3 (tuning-trap): low_threshold_pct > 50 combined with
+    # ANY vehicle.* profile shipping shared_battery=true means the
+    # graceful-stop callback fires on a near-fresh pack — the operator
+    # tunes low_threshold_pct expecting a STATUSTEXT-only alert but on
+    # a USV/UGV it triggers the autonomous engine. Schema only enforces
+    # critical < low; this layer surfaces the operational hazard.
+    _check_shared_battery_threshold_warning(cfg, result)
+
     return result
+
+
+# Issue #234 R3-3: operator-visible threshold above which the soft warning
+# fires. 50% is the boundary where "this is a low-battery alert" stops
+# matching common operator intuition — a USV that triggers graceful-stop
+# at 51% will spend most of every mission in HOLD.
+_SHARED_BATTERY_LOW_PCT_WARN = 50
+
+
+def _check_shared_battery_threshold_warning(
+    cfg: configparser.ConfigParser, result: ValidationResult,
+) -> None:
+    """Warn when low_threshold_pct is too high for a shared-battery profile.
+
+    Issue #234 R3-3 (tuning-trap). Fires when:
+      - ``[battery] low_threshold_pct`` > 50, AND
+      - ANY ``[vehicle.*]`` section sets ``shared_battery=true`` (either
+        the local key or the dotted ``shared_battery`` form), OR
+      - ``[vehicle.fw]`` carries ``shared_battery=true`` (explicit
+        schema field).
+
+    The warning surfaces via ``logger.warning`` at boot (the facade's
+    ``validation.warnings`` loop) AND in the pre-flight checklist on
+    ``/api/preflight``, which already iterates ``result.warnings``. No
+    new surface needed — the existing config-warning path is the right
+    home.
+    """
+    if not cfg.has_section("battery"):
+        return
+    if not cfg.has_option("battery", "low_threshold_pct"):
+        return
+    try:
+        low_pct = int(cfg.get("battery", "low_threshold_pct").strip())
+    except (ValueError, AttributeError):
+        return  # invalid value will already be flagged by the main loop
+    if low_pct <= _SHARED_BATTERY_LOW_PCT_WARN:
+        return
+
+    shared_profiles: list[str] = []
+    for section in cfg.sections():
+        if not section.startswith("vehicle."):
+            continue
+        if not cfg.has_option(section, "shared_battery"):
+            continue
+        raw = cfg.get(section, "shared_battery").strip().lower()
+        if raw in ("true", "yes", "1", "on"):
+            shared_profiles.append(section)
+
+    if not shared_profiles:
+        return
+
+    result.warnings.append(
+        f"[battery] low_threshold_pct={low_pct} (>{_SHARED_BATTERY_LOW_PCT_WARN}) "
+        f"with shared_battery=true on {', '.join(shared_profiles)} — "
+        "graceful-stop will fire on a near-fresh pack. Lower this "
+        "threshold (default 20) or disable shared_battery on the profile."
+    )

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -322,6 +322,11 @@ class Pipeline:
                 else None
             )
 
+            # Issue #234 R2-1: pair the LOW-fire path with an audit row
+            # on the OK-recovery clear of action_taken. Only wired when
+            # the LOW callback itself is wired (drone profiles get None
+            # for both — behavior matches PR #211).
+            cleared_cb = self._audit_action_cleared if self._shared_battery else None
             try:
                 self._battery_monitor = BatteryMonitor(
                     low_threshold_pct=self._cfg.getint(
@@ -340,6 +345,11 @@ class Pipeline:
                     ),
                     enabled=True,
                     on_low_transition=low_cb,
+                    min_callback_interval_sec=self._cfg.getfloat(
+                        "battery", "min_callback_interval_sec",
+                        fallback=60.0,
+                    ),
+                    on_action_cleared=cleared_cb,
                 )
                 self._mavlink.attach_battery_monitor(self._battery_monitor)
                 logger.info(
@@ -2398,12 +2408,12 @@ class Pipeline:
         ``LOW`` and the active profile carries ``shared_battery=true``.
         ``snapshot`` is the pre-action BatteryState (voltage / pct as of
         the SYS_STATUS that triggered the transition). The autonomous
-        engine integration intentionally uses the simplest existing
-        primitive: set the per-platform safe mode (HOLD for ground/water,
-        LOITER for air if a drone is ever flagged shared) via MAVLink and
-        zero the servo tracker PWM if servo tracking is active. A richer
-        graceful-stop ladder (mode → throttle ramp → arm-cut) belongs in
-        a follow-up issue. See issue #222.
+        engine integration uses the existing primitives: set the
+        per-platform safe mode (HOLD for ground/water, LOITER for air if
+        a drone is ever flagged shared) via MAVLink, then run the
+        graceful-stop ladder on the servo tracker — ``safe()`` for
+        strike/arm channels followed by ``disable_pan()`` so a stuck
+        pan sweep can't keep draining the pack. See issues #222, #234.
 
         Returns ``"graceful_stop"`` so BatteryMonitor records the action
         on its state for /api/stats. Returns ``None`` if the engine
@@ -2421,16 +2431,17 @@ class Pipeline:
             "autonomous", "safe_mode", fallback="LOITER",
         ).strip() or "LOITER"
 
-        audit_log.warning(
-            "BATTERY_GRACEFUL_STOP vehicle=%s callsign=%s pre_voltage_v=%s "
-            "pre_pct=%s safe_mode=%s",
-            getattr(self, "_vehicle", None),
-            self._callsign,
-            pre_v,
-            pre_pct,
-            safe_mode,
-        )
         if self._mavlink is None:
+            audit_log.warning(
+                "BATTERY_GRACEFUL_STOP vehicle=%s callsign=%s pre_voltage_v=%s "
+                "pre_pct=%s safe_mode=%s pan_disabled=%s mavlink=absent",
+                getattr(self, "_vehicle", None),
+                self._callsign,
+                pre_v,
+                pre_pct,
+                safe_mode,
+                False,
+            )
             logger.warning(
                 "Shared-battery LOW: no MAVLink — graceful-stop skipped."
             )
@@ -2448,7 +2459,11 @@ class Pipeline:
 
         # 2) Zero the servo tracker if it's holding a pan/strike PWM —
         # otherwise the platform sits at the last commanded angle until
-        # the FC takes over. servo.safe() drives strike/arm to safe PWM.
+        # the FC takes over. servo.safe() drives strike/arm to safe PWM
+        # but does NOT prevent the frame loop from re-driving the pan
+        # channel — disable_pan() gates further update() calls so a pan
+        # sweep can't be the load draining the pack (issue #234 R3-1).
+        pan_disabled = False
         if self._servo_tracker is not None:
             try:
                 self._servo_tracker.safe()
@@ -2456,6 +2471,23 @@ class Pipeline:
                 logger.warning(
                     "Shared-battery LOW: servo.safe() raised %s", exc,
                 )
+            try:
+                pan_disabled = bool(self._servo_tracker.disable_pan())
+            except Exception as exc:
+                logger.warning(
+                    "Shared-battery LOW: servo.disable_pan() raised %s", exc,
+                )
+
+        audit_log.warning(
+            "BATTERY_GRACEFUL_STOP vehicle=%s callsign=%s pre_voltage_v=%s "
+            "pre_pct=%s safe_mode=%s pan_disabled=%s",
+            getattr(self, "_vehicle", None),
+            self._callsign,
+            pre_v,
+            pre_pct,
+            safe_mode,
+            pan_disabled,
+        )
 
         # 3) Best-effort operator notification beyond the STATUSTEXT path
         # (which the battery monitor itself emits on the LOW transition).
@@ -2467,6 +2499,21 @@ class Pipeline:
         except Exception:
             pass  # send is best-effort
         return "graceful_stop"
+
+    def _audit_action_cleared(self, label: str) -> None:
+        """Write the ACTION_CLEARED audit row on level-recovery (issue #234 R2-1).
+
+        Fired by BatteryMonitor on the OK transition that clears a
+        previously-set ``action_taken``. Pairs with the original
+        BATTERY_GRACEFUL_STOP row so post-incident replay shows both
+        the fire and the recovery / clear timestamps.
+        """
+        audit_log.warning(
+            "BATTERY_ACTION_CLEARED vehicle=%s callsign=%s prior_action=%s",
+            getattr(self, "_vehicle", None),
+            self._callsign,
+            label,
+        )
 
     def _get_approach_status(self) -> dict:
         """Return approach controller status for the web API."""

--- a/hydra_detect/servo_tracker.py
+++ b/hydra_detect/servo_tracker.py
@@ -53,12 +53,26 @@ class ServoTracker:
         self._strike_active = threading.Event()
         self._tracking = False
         self._last_error_x: float = 0.0
+        # Issue #234 R3-1: pan-disabled gate. Set by ``disable_pan()`` so
+        # the shared-battery graceful-stop primitive can stop the pan
+        # channel from being the load that re-crosses the LOW threshold
+        # every 60-90s. While disabled, ``update()`` is a no-op (the
+        # frame loop keeps calling it but emits no servo commands). The
+        # operator can re-enable via ``enable_pan()`` for the next mission.
+        self._pan_disabled: bool = False
 
         self._mavlink.set_servo(self._strike_channel, self._strike_pwm_safe)
         self._mavlink.set_servo(self._pan_channel, self._pan_center)
 
     def update(self, error_x: float) -> None:
         """Update pan servo from pixel-lock error. Called every frame."""
+        # Pan-disabled (issue #234 R3-1): swallow the call so the frame
+        # loop's per-frame ``update()`` does not re-drive the servo after
+        # graceful-stop. Record the error for status, but emit nothing.
+        if self._pan_disabled:
+            self._last_error_x = error_x
+            self._tracking = False
+            return
         self._tracking = True
         self._last_error_x = error_x
 
@@ -104,13 +118,71 @@ class ServoTracker:
             target=_revert, daemon=True, name="strike-revert").start()
 
     def safe(self) -> None:
-        """Return all servos to safe positions. Resets EMA state."""
+        """Return all servos to safe positions. Resets EMA state.
+
+        NOTE: ``safe()`` centers the pan PWM but does NOT prevent the next
+        frame's ``update()`` from re-driving the servo. For the shared-
+        battery graceful-stop path (issue #234 R3-1), callers must also
+        invoke ``disable_pan()`` to gate further updates. Strike / arm
+        channels remain at safe PWM regardless.
+        """
         self._smoothed = 0.0
         self._last_pwm = self._pan_center
         self._tracking = False
         self._mavlink.set_servo(self._pan_channel, self._pan_center)
         self._mavlink.set_servo(
             self._strike_channel, self._strike_pwm_safe)
+
+    def disable_pan(self) -> bool:
+        """Stop pan-channel output and prevent further ``update()`` writes.
+
+        Used by the shared-battery graceful-stop primitive (issue #234
+        R3-1) so a pan tracker stuck in a high-rate sweep cannot remain
+        the load draining the pack after LOW transition. Idempotent —
+        a second call is a no-op and still returns True. Returns False
+        only when the underlying ``set_servo`` raises.
+
+        After this call:
+        - ``update(error_x)`` is a no-op (records error, no PWM emit).
+        - Pan PWM is held at the configured center.
+        - Strike behavior is unaffected — ``safe()`` still owns that.
+        - ``get_status()['pan_disabled']`` reads True.
+        """
+        already_disabled = self._pan_disabled
+        self._pan_disabled = True
+        self._smoothed = 0.0
+        self._last_pwm = self._pan_center
+        self._tracking = False
+        if already_disabled:
+            return True
+        try:
+            self._mavlink.set_servo(self._pan_channel, self._pan_center)
+        except Exception as exc:
+            logger.warning(
+                "Pan-disable: set_servo(ch=%d, center=%d) raised %s",
+                self._pan_channel, self._pan_center, exc,
+            )
+            return False
+        logger.info(
+            "Pan channel disabled (ch=%d) — graceful-stop hold.",
+            self._pan_channel,
+        )
+        return True
+
+    def enable_pan(self) -> None:
+        """Re-enable pan-channel output after ``disable_pan()``.
+
+        Operator path: after swapping a charged pack and resetting the
+        platform, this clears the disabled gate so the next ``update()``
+        call resumes tracking. Does NOT auto-fire on level-recovery —
+        recovery must be operator-confirmed.
+        """
+        if not self._pan_disabled:
+            return
+        self._pan_disabled = False
+        logger.info(
+            "Pan channel re-enabled (ch=%d).", self._pan_channel,
+        )
 
     def get_status(self) -> dict:
         """Return current state for web API."""
@@ -121,6 +193,7 @@ class ServoTracker:
             "pan_pwm": (self._last_pwm
                         if self._last_pwm is not None
                         else self._pan_center),
+            "pan_disabled": self._pan_disabled,
             "strike_channel": self._strike_channel,
             "strike_active": self._strike_active.is_set(),
             "error_x": round(self._last_error_x, 3),

--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -727,8 +727,13 @@ class TestSharedBatteryGracefulStop:
     - Callback raising does not break the monitor (best-effort)
     """
 
-    def _wire(self, **overrides) -> tuple[BatteryMonitor, list, list]:
-        """Build a monitor with a recording callback. Returns (mon, sender, calls)."""
+    def _wire(self, **overrides) -> tuple[BatteryMonitor, _Sender, list]:
+        """Build a monitor with a recording callback. Returns (mon, sender, calls).
+
+        Default ``min_callback_interval_sec=0.0`` keeps the legacy
+        re-entrancy-on-re-arm tests honest. Rate-cap behavior gets its
+        own dedicated test block (TestSharedBatteryRateCap).
+        """
         sender = _Sender()
         calls: list[BatteryState] = []
 
@@ -745,6 +750,7 @@ class TestSharedBatteryGracefulStop:
             critical_reissue_sec=0.0,
             enabled=True,
             on_low_transition=_cb,
+            min_callback_interval_sec=0.0,
         )
         kwargs.update(overrides)
         return BatteryMonitor(**kwargs), sender, calls
@@ -820,8 +826,13 @@ class TestSharedBatteryGracefulStop:
         assert len(calls) == 1  # no new call
 
     def test_recovery_then_relow_refires_callback(self):
-        """Re-arm after OK: a second LOW dip can fire the callback again."""
-        mon, _, calls = self._wire()
+        """Re-arm after OK: a second LOW dip can fire the callback again.
+
+        Rate cap disabled (issue #234 R1-1 default is 60s — would suppress
+        the immediate re-fire); this test pins the underlying re-arm
+        primitive in isolation.
+        """
+        mon, _, calls = self._wire(min_callback_interval_sec=0.0)
         mon.update_from_sys_status(11800, 19, now=100.0)
         mon.update_from_sys_status(12400, 80, now=101.0)
         # Second LOW dip — re-armed
@@ -834,8 +845,14 @@ class TestSharedBatteryGracefulStop:
         st = mon.get_state(now=100.0)
         assert st.action_taken == "graceful_stop"
 
-    def test_action_taken_not_overwritten_by_none_return(self):
-        """Callback returning None or non-string leaves action_taken alone."""
+    def test_action_taken_cleared_on_recovery(self):
+        """Issue #234 R2-1: action_taken is cleared on OK-recovery.
+
+        Recovery must clear the sticky flag so multi-mission days
+        (drive USV back, swap pack, redeploy) do not show stale
+        graceful_stop on /api/stats. Replaces the prior "sticky for
+        the session" behavior which produced dashboard staleness.
+        """
         sender = _Sender()
         results = iter(["graceful_stop", None])
 
@@ -848,15 +865,19 @@ class TestSharedBatteryGracefulStop:
             callsign="HYDRA-2-UGV",
             send_statustext=sender,
             on_low_transition=_cb,
+            min_callback_interval_sec=0.0,  # let the re-LOW fire
         )
         # First LOW transition — callback returns "graceful_stop"
         mon.update_from_sys_status(11800, 19, now=100.0)
         assert mon.get_state(now=100.0).action_taken == "graceful_stop"
-        # Recover, then re-LOW — callback returns None, but the prior
-        # action_taken should remain set (it's sticky for the session)
+        # Recover → action_taken clears
         mon.update_from_sys_status(12400, 80, now=101.0)
+        assert mon.get_state(now=101.0).action_taken is None
+        # Re-LOW with callback returning None — action_taken stays None
+        # (the prior label was cleared on the OK transition, not on this
+        # subsequent re-fire that produced no new label).
         mon.update_from_sys_status(11700, 18, now=102.0)
-        assert mon.get_state(now=102.0).action_taken == "graceful_stop"
+        assert mon.get_state(now=102.0).action_taken is None
 
     def test_callback_exception_swallowed(self):
         """Callback raising must not break the monitor (defensive)."""
@@ -885,3 +906,313 @@ class TestSharedBatteryGracefulStop:
         mon.update_from_sys_status(11700, 15, now=101.0)
         assert calls[0].voltage_v == 11.8
         assert calls[0].remaining_pct == 19
+
+
+# ---------------------------------------------------------------------------
+# Issue #234 R1-1 — LOW-callback rate cap on noisy-pack oscillation
+# ---------------------------------------------------------------------------
+
+
+class TestSharedBatteryRateCap:
+    """Wall-clock rate cap on the LOW-transition callback (issue #234 R1-1).
+
+    OK→LOW→OK→LOW oscillation on a noisy pack at the knee voltage fires
+    the callback multiple times under PR #229's re-arm-on-OK primitive.
+    Each fire produces a duplicate audit row, duplicate STATUSTEXT, and
+    possibly duplicate set_mode(HOLD). The rate cap absorbs this by
+    suppressing further fires within ``min_callback_interval_sec``.
+    """
+
+    def _wire(self, **overrides):
+        sender = _Sender()
+        calls: list[BatteryState] = []
+
+        def _cb(snapshot: BatteryState) -> str:
+            calls.append(snapshot)
+            return "graceful_stop"
+
+        kwargs = dict(
+            low_threshold_pct=20,
+            critical_threshold_pct=10,
+            callsign="HYDRA-2-USV",
+            send_statustext=sender,
+            stale_after_sec=30.0,
+            enabled=True,
+            on_low_transition=_cb,
+            min_callback_interval_sec=60.0,
+        )
+        kwargs.update(overrides)
+        return BatteryMonitor(**kwargs), sender, calls
+
+    def test_default_is_60s(self):
+        mon, _, _ = self._wire()
+        assert mon.min_callback_interval_sec == 60.0
+
+    def test_oscillation_within_window_fires_once(self):
+        """OK→LOW→OK→LOW→OK→LOW inside 30s: exactly one fire."""
+        mon, _, calls = self._wire(min_callback_interval_sec=60.0)
+        # First LOW transition fires (no prior fire).
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        assert len(calls) == 1
+        # Recover and re-dip within the rate-cap window.
+        mon.update_from_sys_status(12400, 80, now=105.0)
+        mon.update_from_sys_status(11700, 18, now=110.0)
+        # Suppressed — within 60s of last fire.
+        assert len(calls) == 1
+        # Another oscillation, still inside window.
+        mon.update_from_sys_status(12400, 80, now=120.0)
+        mon.update_from_sys_status(11600, 17, now=130.0)
+        assert len(calls) == 1, (
+            f"Rate cap failed: {len(calls)} fires within 60s window, "
+            "expected 1."
+        )
+
+    def test_fires_again_after_window_elapses(self):
+        """OK→LOW outside the rate-cap window fires the callback again."""
+        mon, _, calls = self._wire(min_callback_interval_sec=60.0)
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        assert len(calls) == 1
+        # Recover, then re-LOW past the 60s cap.
+        mon.update_from_sys_status(12400, 80, now=110.0)
+        mon.update_from_sys_status(11700, 18, now=170.0)
+        assert len(calls) == 2
+
+    def test_zero_disables_cap(self):
+        """min_callback_interval_sec=0 reverts to PR #229 re-arm behavior."""
+        mon, _, calls = self._wire(min_callback_interval_sec=0.0)
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        mon.update_from_sys_status(12400, 80, now=101.0)
+        mon.update_from_sys_status(11700, 18, now=102.0)
+        assert len(calls) == 2
+
+    def test_negative_input_treated_as_zero(self):
+        """Defensive: bad input does not silently invert the gate."""
+        mon, _, _ = self._wire(min_callback_interval_sec=-10.0)
+        assert mon.min_callback_interval_sec == 0.0
+
+    def test_action_taken_set_on_initial_fire_only(self):
+        """Suppressed re-fires must not overwrite action_taken (still set)."""
+        mon, _, calls = self._wire(min_callback_interval_sec=60.0)
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        assert mon.get_state(now=100.0).action_taken == "graceful_stop"
+        # Recover (clears action_taken per R2-1) and re-LOW within the cap.
+        mon.update_from_sys_status(12400, 80, now=105.0)
+        assert mon.get_state(now=105.0).action_taken is None
+        mon.update_from_sys_status(11700, 18, now=110.0)
+        # Suppressed fire → no new callback → action_taken stays None.
+        assert mon.get_state(now=110.0).action_taken is None
+        assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #234 R2-1 — sticky-flag clear + on_action_cleared callback
+# ---------------------------------------------------------------------------
+
+
+class TestActionClearedCallback:
+    """OK-recovery clears action_taken and notifies on_action_cleared (#234 R2-1)."""
+
+    def _wire(self, **overrides):
+        sender = _Sender()
+        low_calls: list[BatteryState] = []
+        cleared_calls: list[str] = []
+
+        def _low_cb(snapshot: BatteryState) -> str:
+            low_calls.append(snapshot)
+            return "graceful_stop"
+
+        def _cleared_cb(label: str) -> None:
+            cleared_calls.append(label)
+
+        kwargs = dict(
+            low_threshold_pct=20,
+            critical_threshold_pct=10,
+            callsign="HYDRA-2-USV",
+            send_statustext=sender,
+            stale_after_sec=30.0,
+            enabled=True,
+            on_low_transition=_low_cb,
+            on_action_cleared=_cleared_cb,
+            min_callback_interval_sec=0.0,
+        )
+        kwargs.update(overrides)
+        return BatteryMonitor(**kwargs), low_calls, cleared_calls
+
+    def test_clear_fires_on_ok_transition(self):
+        mon, low_calls, cleared = self._wire()
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        assert len(low_calls) == 1
+        assert cleared == []
+        # Recover to OK → cleared callback fires with the prior label.
+        mon.update_from_sys_status(12400, 80, now=101.0)
+        assert cleared == ["graceful_stop"]
+        assert mon.get_state(now=101.0).action_taken is None
+
+    def test_clear_does_not_fire_without_prior_action(self):
+        """OK boot path: no LOW ever happened → no clear callback."""
+        mon, low_calls, cleared = self._wire()
+        mon.update_from_sys_status(12400, 80, now=100.0)
+        assert low_calls == []
+        assert cleared == []
+
+    def test_clear_does_not_fire_on_critical_to_low(self):
+        """CRITICAL→LOW is not OK-recovery — must not clear."""
+        mon, _, cleared = self._wire()
+        mon.update_from_sys_status(11800, 19, now=100.0)  # LOW → action set
+        mon.update_from_sys_status(10400, 8, now=101.0)   # → CRITICAL
+        mon.update_from_sys_status(11700, 18, now=102.0)  # → LOW (no OK seen)
+        assert cleared == []
+        assert mon.get_state(now=102.0).action_taken == "graceful_stop"
+
+    def test_clear_callback_exception_does_not_break_monitor(self):
+        sender = _Sender()
+
+        def _cleared(_label: str) -> None:
+            raise RuntimeError("audit sink unavailable")
+
+        def _low(_s):
+            return "graceful_stop"
+
+        mon = BatteryMonitor(
+            low_threshold_pct=20,
+            critical_threshold_pct=10,
+            callsign="HYDRA-2-USV",
+            send_statustext=sender,
+            on_low_transition=_low,
+            on_action_cleared=_cleared,
+            min_callback_interval_sec=0.0,
+        )
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        # Must not raise out
+        mon.update_from_sys_status(12400, 80, now=101.0)
+        # Monitor still functional
+        assert mon.get_state(now=101.0).action_taken is None
+
+    def test_clear_fires_exactly_once_per_action(self):
+        """OK→OK ticks after the initial clear must not refire."""
+        mon, _, cleared = self._wire()
+        mon.update_from_sys_status(11800, 19, now=100.0)
+        mon.update_from_sys_status(12400, 80, now=101.0)
+        assert cleared == ["graceful_stop"]
+        mon.update_from_sys_status(12500, 75, now=102.0)
+        mon.update_from_sys_status(12500, 70, now=103.0)
+        assert cleared == ["graceful_stop"]
+
+
+# ---------------------------------------------------------------------------
+# Issue #234 R3-1 — facade graceful-stop callback wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not _FCNTL_AVAILABLE,
+    reason="facade imports modules that pull fcntl (Linux-only); covered on Jetson CI",
+)
+class TestGracefulStopFacadeCallback:
+    """Confirm Pipeline._graceful_stop_for_shared_battery invokes the
+    new pan-disable primitive and records the audit field. Constructs
+    a bare Pipeline via __new__ + attribute injection so we don't pay
+    the cost of the full __init__ (camera, detector, MAVLinkIO).
+    """
+
+    @staticmethod
+    def _make_pipeline_stub(mavlink, servo_tracker, *, no_mavlink: bool = False):
+        from hydra_detect.pipeline.facade import Pipeline
+        import configparser
+
+        pipe = Pipeline.__new__(Pipeline)
+        cfg = configparser.ConfigParser()
+        cfg.add_section("autonomous")
+        cfg.set("autonomous", "safe_mode", "HOLD")
+        pipe._cfg = cfg
+        pipe._callsign = "HYDRA-2-USV"
+        pipe._vehicle = "usv"
+        pipe._mavlink = None if no_mavlink else mavlink
+        pipe._servo_tracker = servo_tracker
+        return pipe
+
+    def test_callback_calls_servo_safe_and_disable_pan(self):
+        mav = MagicMock()
+        servo = MagicMock()
+        servo.disable_pan.return_value = True
+        pipe = self._make_pipeline_stub(mav, servo)
+        snapshot = BatteryState(
+            voltage_v=11.8, remaining_pct=19, level=LEVEL_LOW,
+        )
+        result = pipe._graceful_stop_for_shared_battery(snapshot)
+        assert result == "graceful_stop"
+        servo.safe.assert_called_once()
+        servo.disable_pan.assert_called_once()
+        mav.set_mode.assert_called_once_with("HOLD")
+
+    def test_callback_records_pan_disabled_true_in_audit(self, caplog):
+        import logging
+        mav = MagicMock()
+        servo = MagicMock()
+        servo.disable_pan.return_value = True
+        pipe = self._make_pipeline_stub(mav, servo)
+        snapshot = BatteryState(
+            voltage_v=11.8, remaining_pct=19, level=LEVEL_LOW,
+        )
+        with caplog.at_level(logging.WARNING, logger="hydra.audit"):
+            pipe._graceful_stop_for_shared_battery(snapshot)
+        audit = [r for r in caplog.records if "BATTERY_GRACEFUL_STOP" in r.message]
+        assert audit, f"expected audit row; got {[r.message for r in caplog.records]}"
+        assert any("pan_disabled=True" in r.message for r in audit)
+
+    def test_callback_records_pan_disabled_false_when_disable_fails(self, caplog):
+        import logging
+        mav = MagicMock()
+        servo = MagicMock()
+        servo.disable_pan.return_value = False  # set_servo raised inside
+        pipe = self._make_pipeline_stub(mav, servo)
+        snapshot = BatteryState(
+            voltage_v=11.8, remaining_pct=19, level=LEVEL_LOW,
+        )
+        with caplog.at_level(logging.WARNING, logger="hydra.audit"):
+            pipe._graceful_stop_for_shared_battery(snapshot)
+        audit = [r for r in caplog.records if "BATTERY_GRACEFUL_STOP" in r.message]
+        assert any("pan_disabled=False" in r.message for r in audit)
+
+    def test_callback_returns_none_when_mavlink_absent(self, caplog):
+        import logging
+        servo = MagicMock()
+        pipe = self._make_pipeline_stub(None, servo, no_mavlink=True)
+        snapshot = BatteryState(
+            voltage_v=11.8, remaining_pct=19, level=LEVEL_LOW,
+        )
+        with caplog.at_level(logging.WARNING, logger="hydra.audit"):
+            result = pipe._graceful_stop_for_shared_battery(snapshot)
+        # No MAVLink → dashboard does not claim graceful_stop
+        assert result is None
+        # And servo is NOT touched (we early-return before reaching it)
+        servo.safe.assert_not_called()
+        servo.disable_pan.assert_not_called()
+        # Audit row still written so the operator sees the attempt
+        audit = [r for r in caplog.records if "BATTERY_GRACEFUL_STOP" in r.message]
+        assert audit
+        assert any("mavlink=absent" in r.message for r in audit)
+
+    def test_callback_continues_when_disable_pan_raises(self):
+        """Defensive: an exception from disable_pan must not break the callback."""
+        mav = MagicMock()
+        servo = MagicMock()
+        servo.disable_pan.side_effect = RuntimeError("pan-disable boom")
+        pipe = self._make_pipeline_stub(mav, servo)
+        snapshot = BatteryState(
+            voltage_v=11.8, remaining_pct=19, level=LEVEL_LOW,
+        )
+        # Must not raise
+        result = pipe._graceful_stop_for_shared_battery(snapshot)
+        assert result == "graceful_stop"
+
+    def test_audit_action_cleared_writes_audit_row(self, caplog):
+        import logging
+        mav = MagicMock()
+        servo = MagicMock()
+        pipe = self._make_pipeline_stub(mav, servo)
+        with caplog.at_level(logging.WARNING, logger="hydra.audit"):
+            pipe._audit_action_cleared("graceful_stop")
+        audit = [r for r in caplog.records if "BATTERY_ACTION_CLEARED" in r.message]
+        assert audit
+        assert any("prior_action=graceful_stop" in r.message for r in audit)

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -585,6 +585,171 @@ class TestVehicleSectionValidation:
 
 
 # ---------------------------------------------------------------------------
+# Issue #234 R1-1 — battery.min_callback_interval_sec schema field
+# ---------------------------------------------------------------------------
+
+
+class TestBatteryMinCallbackIntervalSchema:
+    """Schema validation for the new LOW-callback rate cap field."""
+
+    @staticmethod
+    def _cfg_with_battery(value: str):
+        cfg = _valid_config()
+        if not cfg.has_section("battery"):
+            cfg.add_section("battery")
+        cfg.set("battery", "min_callback_interval_sec", value)
+        return cfg
+
+    def test_default_is_60s_when_omitted(self):
+        """Field is optional — defaults satisfy the schema."""
+        cfg = _valid_config()
+        result = validate_config(cfg)
+        assert result.ok, f"unexpected errors: {result.errors}"
+
+    def test_positive_float_accepted(self):
+        cfg = self._cfg_with_battery("30.0")
+        result = validate_config(cfg)
+        errs = [e for e in result.errors if "min_callback_interval_sec" in e]
+        assert errs == []
+
+    def test_zero_accepted(self):
+        """0 disables the cap — must validate (rate cap off, PR #229 behavior)."""
+        cfg = self._cfg_with_battery("0.0")
+        result = validate_config(cfg)
+        errs = [e for e in result.errors if "min_callback_interval_sec" in e]
+        assert errs == []
+
+    def test_negative_rejected(self):
+        cfg = self._cfg_with_battery("-5.0")
+        result = validate_config(cfg)
+        assert any(
+            "min_callback_interval_sec" in e for e in result.errors
+        ), f"expected negative-value error; got {result.errors}"
+
+    def test_non_numeric_rejected(self):
+        cfg = self._cfg_with_battery("soon")
+        result = validate_config(cfg)
+        assert any(
+            "min_callback_interval_sec" in e for e in result.errors
+        ), f"expected non-numeric error; got {result.errors}"
+
+    def test_max_clamp_at_3600(self):
+        """3600s is the upper bound (an hour is generous for a noisy pack)."""
+        cfg = self._cfg_with_battery("99999")
+        result = validate_config(cfg)
+        assert any(
+            "min_callback_interval_sec" in e and "at most" in e
+            for e in result.errors
+        )
+
+
+# ---------------------------------------------------------------------------
+# Issue #234 R3-3 — shared-battery + low_threshold_pct soft warning
+# ---------------------------------------------------------------------------
+
+
+class TestSharedBatteryThresholdWarning:
+    """Soft-validation warning when low_threshold_pct interacts poorly with
+    a shared-battery vehicle profile (issue #234 R3-3 tuning-trap).
+
+    Schema only enforces critical < low; an operator setting
+    low_threshold_pct=95 on a USV with shared_battery=true gets
+    immediate graceful-stop on a fresh pack. This layer surfaces that.
+    """
+
+    @staticmethod
+    def _set_low(cfg, value: str) -> None:
+        if not cfg.has_section("battery"):
+            cfg.add_section("battery")
+        cfg.set("battery", "low_threshold_pct", value)
+
+    def test_warn_fires_when_low_above_50_and_shared_true(self):
+        cfg = _valid_config()
+        self._set_low(cfg, "95")
+        cfg.add_section("vehicle.usv")
+        cfg.set("vehicle.usv", "shared_battery", "true")
+        result = validate_config(cfg)
+        matched = [w for w in result.warnings if "low_threshold_pct" in w]
+        assert matched, f"expected R3-3 warning; got {result.warnings}"
+        assert any("graceful-stop" in w for w in matched)
+        assert any("vehicle.usv" in w for w in matched)
+
+    def test_warn_silent_when_shared_battery_false(self):
+        cfg = _valid_config()
+        self._set_low(cfg, "95")
+        cfg.add_section("vehicle.drone")
+        cfg.set("vehicle.drone", "shared_battery", "false")
+        result = validate_config(cfg)
+        matched = [
+            w for w in result.warnings
+            if "low_threshold_pct" in w and "graceful-stop" in w
+        ]
+        assert matched == [], (
+            f"R3-3 warning should not fire when shared_battery=false; "
+            f"got {result.warnings}"
+        )
+
+    def test_warn_silent_when_low_pct_in_safe_range(self):
+        """low_threshold_pct=20 (default) with shared_battery=true is fine."""
+        cfg = _valid_config()
+        self._set_low(cfg, "20")
+        cfg.add_section("vehicle.usv")
+        cfg.set("vehicle.usv", "shared_battery", "true")
+        result = validate_config(cfg)
+        matched = [
+            w for w in result.warnings
+            if "low_threshold_pct" in w and "graceful-stop" in w
+        ]
+        assert matched == [], f"unexpected R3-3 warning; got {matched}"
+
+    def test_warn_boundary_at_50(self):
+        """50 is the boundary — strictly greater than fires."""
+        cfg = _valid_config()
+        self._set_low(cfg, "50")
+        cfg.add_section("vehicle.usv")
+        cfg.set("vehicle.usv", "shared_battery", "true")
+        result = validate_config(cfg)
+        matched = [
+            w for w in result.warnings
+            if "low_threshold_pct" in w and "graceful-stop" in w
+        ]
+        assert matched == [], f"50 should be at-boundary safe; got {matched}"
+
+        cfg.set("battery", "low_threshold_pct", "51")
+        result = validate_config(cfg)
+        matched = [
+            w for w in result.warnings
+            if "low_threshold_pct" in w and "graceful-stop" in w
+        ]
+        assert matched, f"51 should fire warning; got {result.warnings}"
+
+    def test_warn_fires_for_vehicle_fw_shared_true(self):
+        """vehicle.fw has explicit schema — warning still catches it."""
+        cfg = _valid_config()
+        self._set_low(cfg, "80")
+        cfg.add_section("vehicle.fw")
+        cfg.set("vehicle.fw", "shared_battery", "true")
+        result = validate_config(cfg)
+        matched = [
+            w for w in result.warnings
+            if "low_threshold_pct" in w and "graceful-stop" in w
+        ]
+        assert matched, f"expected R3-3 warning; got {result.warnings}"
+        assert any("vehicle.fw" in w for w in matched)
+
+    def test_warn_silent_when_no_vehicle_profile_present(self):
+        """No vehicle.* sections at all → no shared-battery context → no warn."""
+        cfg = _valid_config()
+        self._set_low(cfg, "95")
+        result = validate_config(cfg)
+        matched = [
+            w for w in result.warnings
+            if "low_threshold_pct" in w and "graceful-stop" in w
+        ]
+        assert matched == [], f"unexpected R3-3 warning; got {matched}"
+
+
+# ---------------------------------------------------------------------------
 # Property-based tests via hypothesis
 # ---------------------------------------------------------------------------
 

--- a/tests/test_servo_tracker.py
+++ b/tests/test_servo_tracker.py
@@ -196,3 +196,116 @@ class TestGetStatus:
         assert tracker.replaces_yaw is True
         s = tracker.get_status()
         assert s["replaces_yaw"] is True
+
+
+# ---------------------------------------------------------------------------
+# Issue #234 R3-1 — disable_pan() for shared-battery graceful-stop
+# ---------------------------------------------------------------------------
+
+
+class TestDisablePan:
+    """Shared-battery graceful-stop primitive (issue #234 R3-1).
+
+    safe() centers pan PWM but does not prevent the per-frame update()
+    from re-driving the channel. disable_pan() adds a gate so a pan
+    sweep cannot be the load draining the pack after LOW transition.
+    """
+
+    def test_status_default_is_enabled(self):
+        tracker, _ = _make_tracker()
+        s = tracker.get_status()
+        assert s["pan_disabled"] is False
+
+    def test_disable_pan_centers_pan_pwm(self):
+        tracker, mav = _make_tracker()
+        # Drive the pan off-center first.
+        tracker.update(0.8)
+        mav.reset_mock()
+        # Disable → center PWM should be emitted exactly once.
+        result = tracker.disable_pan()
+        assert result is True
+        mav.set_servo.assert_called_once_with(1, 1500)
+
+    def test_disable_pan_surfaces_in_status(self):
+        tracker, _ = _make_tracker()
+        tracker.disable_pan()
+        s = tracker.get_status()
+        assert s["pan_disabled"] is True
+
+    def test_update_is_noop_when_disabled(self):
+        """After disable_pan, update() must NOT emit servo commands."""
+        tracker, mav = _make_tracker()
+        tracker.disable_pan()
+        mav.reset_mock()
+        tracker.update(0.9)
+        tracker.update(-0.6)
+        tracker.update(1.0)
+        mav.set_servo.assert_not_called()
+
+    def test_update_records_error_when_disabled(self):
+        """Status still reflects the latest error for the operator UI."""
+        tracker, _ = _make_tracker()
+        tracker.disable_pan()
+        tracker.update(0.42)
+        s = tracker.get_status()
+        assert s["error_x"] == 0.42
+        # Tracking flag must read False while disabled — UI can show
+        # "pan tracker held" instead of "actively tracking."
+        assert s["tracking"] is False
+
+    def test_disable_pan_is_idempotent(self):
+        tracker, mav = _make_tracker()
+        first = tracker.disable_pan()
+        mav.reset_mock()
+        second = tracker.disable_pan()
+        assert first is True
+        assert second is True
+        # Second call must NOT re-emit the set_servo (already at center).
+        mav.set_servo.assert_not_called()
+
+    def test_enable_pan_restores_update_path(self):
+        tracker, mav = _make_tracker()
+        tracker.disable_pan()
+        tracker.enable_pan()
+        mav.reset_mock()
+        tracker.update(1.0)
+        # Full-right error → PWM 2000 (range 500 + center 1500).
+        mav.set_servo.assert_called_with(1, 2000)
+        assert tracker.get_status()["pan_disabled"] is False
+
+    def test_enable_pan_is_noop_when_already_enabled(self):
+        tracker, mav = _make_tracker()
+        mav.reset_mock()
+        tracker.enable_pan()  # Already enabled.
+        mav.set_servo.assert_not_called()
+
+    def test_disable_pan_after_safe(self):
+        """safe() + disable_pan() is the documented graceful-stop ladder."""
+        tracker, mav = _make_tracker()
+        tracker.update(0.7)
+        tracker.safe()
+        mav.reset_mock()
+        tracker.disable_pan()
+        # disable_pan re-centers (idempotent emit) — that's acceptable;
+        # the load-bearing assertion is that subsequent update() emits nothing.
+        tracker.update(0.5)
+        # set_servo must have at most one call (from disable_pan), not
+        # one-per-update from the frame-loop call.
+        assert mav.set_servo.call_count <= 1
+
+    def test_disable_pan_handles_set_servo_failure(self):
+        """If set_servo raises, disable_pan returns False but state stays disabled.
+
+        The pan-disabled gate is more important than the PWM emit — we
+        prefer "no further updates" over "pretend everything is fine."
+        """
+        tracker, mav = _make_tracker()
+        mav.set_servo.side_effect = RuntimeError("uart down")
+        result = tracker.disable_pan()
+        assert result is False
+        assert tracker.get_status()["pan_disabled"] is True
+        # Frame-loop calls still get gated.
+        mav.set_servo.side_effect = None
+        mav.reset_mock()
+        tracker.update(0.4)
+        mav.set_servo.assert_not_called()


### PR DESCRIPTION
Closes #234.

Adversarial review of PR #229 (`docs/adversarial/229.md`) flagged two HIGH-severity follow-ups that shipped as documented limitations of the minimum-viable graceful-stop. This lands the richer ladder before the first SORCC USV class actually depends on the path.

## Findings addressed

### R3-1 (HIGH, failure-mode-shadow)

`servo_tracker.safe()` only handled strike/arm channels — a pan tracker stuck in a high-rate sweep was plausibly the load causing the LOW transition in the first place, and the existing graceful-stop did nothing about it. The pack kept draining, the LOW threshold re-crossed every 60-90s, and the audit log showed duplicate graceful-stop rows while the boat kept drifting.

- New `ServoTracker.disable_pan()` zeroes pan PWM and gates `update()` so the frame loop can't re-drive the channel.
- Facade `_graceful_stop_for_shared_battery` calls `safe()` THEN `disable_pan()`. The audit row records `pan_disabled=<bool>` so post-incident replay shows whether the pan-disable actually executed.
- Idempotent — multiple calls don't re-emit. Defensive — if `set_servo` raises, the gate still latches (we prefer "no further updates" over pretending it worked).
- `ServoTracker.enable_pan()` for operator-initiated re-arm next mission.

### R1-1 (HIGH, callback-re-entrancy)

OK to LOW to OK to LOW oscillation on a noisy 6S pack at the knee fired the callback multiple times. Each fire produced a duplicate audit row, duplicate STATUSTEXT, and possibly duplicate `set_mode(HOLD)`.

- New `BatteryMonitor` constructor arg `min_callback_interval_sec` (default 60.0). After a fire, further fires within the window are suppressed — the first LOW transition ever still fires regardless of the cap.
- New schema field `[battery] min_callback_interval_sec`, validates as positive float in 0.0-3600.0. 0 disables the cap (reverts to PR #229 behavior).
- Suppressed fires latch `_low_callback_fired` so we don't drop back through the no-cap branch on the next tick.

### R2-1 (medium, sticky-flag)

`BatteryState.action_taken` was never cleared once set. Multi-mission days showed stale "graceful_stop" on /api/stats long after the operator swapped a charged pack.

- OK-recovery transition now clears `action_taken` AND notifies the new `on_action_cleared` callback (outside the lock).
- Facade hooks the new callback to write a paired `BATTERY_ACTION_CLEARED` audit row.
- One existing test (`test_action_taken_not_overwritten_by_none_return`) asserted the old sticky-for-session behavior — replaced with `test_action_taken_cleared_on_recovery` pinning the new semantics.

### R3-3 (medium, tuning-trap)

Schema only enforced `critical < low`. An operator setting `low_threshold_pct = 95` on a USV with `shared_battery = true` triggered graceful-stop on a fresh pack.

- New soft warning in `validate_config()`: when `[battery] low_threshold_pct > 50` AND any `[vehicle.*]` section ships `shared_battery = true`, emit a warning naming the offending profile(s).
- Surfaces via the existing `validation.warnings` path — boot-time `logger.warning` and the `/api/preflight` checklist row. No new endpoint needed.
- Boundary: 50 is safe, 51 triggers.

## Deferred (file separate issues)

- **R1-2 / R3-4 (medium, mode-change-race):** `mavlink.set_mode` is fire-and-forget. Needs COMMAND_ACK polling on the mavlink_io surface — new subsystem.
- **R3-2 (medium, mode-precedence):** Check FC mode via HEARTBEAT before override so `set_mode(HOLD)` doesn't fight an in-flight RTL/LAND. Needs HEARTBEAT polling primitive.
- **R1-4 (medium, audit-trail):** Post-action audit row with realized outcomes (`set_mode_ok`, `servo_safe_ok`, `statustext_sent`). Depends on R1-2 confirmation primitive.

## LOC

317 production lines, 599 test lines, 7 files. Under the 350 LOC cap on the production side.

## Test plan

- [x] `python -m pytest tests/test_battery_monitor.py tests/test_config_schema.py tests/test_servo_tracker.py tests/test_servo_api.py` -- 168 passed, 9 platform-skipped (Linux-only fcntl path).
- [x] R3-1 test: `disable_pan` called from `_graceful_stop_for_shared_battery`, audit row records `pan_disabled=True`, set_servo failure path still latches.
- [x] R1-1 test: OK to LOW to OK to LOW within 30s window with `min_callback_interval_sec=60` fires the callback exactly once. Beyond the window, fires again.
- [x] R2-1 test: LOW transition sets `action_taken`, OK transition clears it AND fires `on_action_cleared`.
- [x] R3-3 test: `low_threshold_pct=95` with `shared_battery=true` produces the soft warning; with `shared_battery=false` it stays silent.
- [x] Schema test: `min_callback_interval_sec` accepts 0 / positive float, rejects negative / non-numeric / >3600.
- [x] No regression on the 13 existing `TestSharedBatteryGracefulStop` tests (semantics for action-cleared rewritten per R2-1 spec).
- [x] flake8 clean on all changed files.

## Adversarial doc

`docs/adversarial/<this-PR>.md` -- separate commit, `git add -f` (folder gitignored on main).