### PR TITLE
feat(mavlink): confirmed set_mode + mode-precedence + post-action audit (#241)

### DIFF
--- a/docs/adversarial/246.md
+++ b/docs/adversarial/246.md
@@ -1,0 +1,81 @@
+# Adversarial Analysis — PR #246 (claude/wave5-241-setmode-confirmation)
+
+**Generated:** 2026-05-19T20:30:00Z
+**Target kind:** pr
+**Target:** rmeadomavic/Hydra PR for issue #241 — set_mode confirmation cluster
+**Base:** origin/main at 078170f
+**Closes (partial):** Wave 3 follow-ups for PR #240 — R1-2, R3-2, R3-4, R1-4
+**Diff size:** ~180 LOC production + ~190 LOC tests across 5 files
+
+## Summary
+
+- **Round 1:** Pattern match on the new `set_mode(wait_for_ack=True)` surface and its consumer in `_graceful_stop_for_shared_battery`. Five findings, all medium-or-lower. Dominant pattern: a confirmation path that uses a single `threading.Event` shared across all callers, with no per-call sequence number.
+- **Round 2:** Counter-critique on each R1 finding. R1-2 (event-sharing race) confirmed but contained — set_mode is only called from the LOW-callback (single producer in shared-battery context). R1-3 downgraded — `getfloat` with `fallback` is configparser-safe.
+- **Round 3:** Orthogonal sweep on operator workflow. Asked what the operator sees when the post-action audit row says `set_mode_ok=False set_mode_realized=MANUAL` — there's no dashboard widget, so the audit log is the only signal. Same framing-break as PR #240 R3-1.
+- **Consolidated:** 0 blockers · 0 gates · 4 follow-ups.
+
+## Round 1 — Pattern Match
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | event-stale | mavlink_io.py:set_mode (clear/set order) | We clear `_mode_change_event` BEFORE sending SET_MODE, then wait. If the reader thread happens to be in the middle of `_update_vehicle_mode` for a UNRELATED mode change (e.g. operator flipped a TX switch between the clear and our send), the event gets set by that unrelated change. We then "accept" the heartbeat as our confirmation. Sequence-number missing. |
+| R1-2 | medium | shared-event | mavlink_io.py:_mode_change_event (single Event for all callers) | The event is module-level instance state. If two callers race set_mode(wait_for_ack=True) — e.g. graceful-stop firing while the operator hits the web `/api/mode` endpoint — both callers wait on the same Event. The first heartbeat satisfies both, but only one of them asked for the realized mode that arrived. False positive on the loser. |
+| R1-3 | low | configparser-fallback | facade.py:self._cfg.getfloat("battery", "set_mode_ack_timeout_sec", fallback=2.0) | If the `[battery]` section is missing entirely, does `getfloat` honour the fallback? Re-read configparser docs — yes, both `NoSectionError` and `NoOptionError` are caught by the `fallback=` machinery. Confirmed safe. **Downgrade to nit.** |
+| R1-4 | medium | recovery-set-coverage | facade.py:recovery_modes = {"RTL", "LAND", "HOLD", "SMART_RTL", "BRAKE"} | The set is hand-curated. ArduPilot ground/water also has `AUTO`, `LOITER`, `RTL`, `MANUAL`, plus `INITIALIZING`. We treat `HOLD` as recovery (the USV/UGV safe mode IS HOLD, so this is "FC already there") but we DON'T treat `LOITER` as recovery (which IS the drone shared-battery safe mode). A drone in LOITER from `auto_loiter_on_detect` would have its in-flight loiter cancelled by our `set_mode(LOITER)` — same class as PR #240 R3-2, partially fixed. |
+| R1-5 | low | mode-name-case | facade.py:current_mode in recovery_modes | `get_vehicle_mode()` returns the name from the cached `_reverse_mode_map`, which is ArduPilot's canonical case (UPPERCASE). The set is uppercase. Safe. Pinned by the new test `test_callback_skips_set_mode_when_fc_already_in_recovery`. |
+
+## Round 2 — Counter-Critique
+
+**R1-1 (event-stale):** re-read the clear+wait pair. The window between `_mode_change_event.clear()` and `set_mode_apm()` is the only true race — and it's strictly an event-stale-from-PRIOR-mode-change window. After the clear, any subsequent HEARTBEAT-mode-change (including unrelated ones) will set the event, and we'll then check `realized == mode_name` to decide `accepted`. The `realized_mode` field already captures "the FC went somewhere else" — see `test_wait_for_ack_other_mode_observed`. The remaining gap is operator-flip-between-clear-and-send racing with the operator's intended mode (e.g. operator wanted RTL via TX switch, graceful-stop also wanted HOLD, RTL arrives first, we report `accepted=False realized=RTL`). That's the RIGHT answer — `set_mode_ok=False set_mode_realized=RTL` in the audit row is honest. **Confirmed but not a defect.**
+
+**R1-2 (shared-event):** confirmed. The current consumers of `wait_for_ack=True` are graceful-stop only (one caller). Web `/api/mode` endpoint uses the legacy fire-and-forget surface (it calls `ctrl.set_mode(mode)` which is the AutonomousController, NOT the MAVLink layer). Approach/dogleg also use fire-and-forget. **Single producer today; document as follow-up if a second confirmed caller lands.** Per-call sequence number is the right long-term fix.
+
+**R1-4 (recovery-set-coverage):** confirmed. For shared-battery USV/UGV (HOLD safe_mode), the set is correct — operator-facing class case is "USV in MANUAL → LOW → set_mode(HOLD) succeeds" and "USV in RTL from BATT_FS_LOW_ACT=2 → LOW → skip." The drone case (LOITER safe_mode) IS a gap — `LOITER` is not in `recovery_modes`, so a drone already loitering from `auto_loiter_on_detect` would get `set_mode(LOITER)` again. That's a no-op on the FC side (already in LOITER), but it cancels the implicit "this is autonomy-driven, don't override" semantic from PR #240 R3-2. **Follow-up: add `LOITER` to recovery_modes when safe_mode=LOITER. Conditional set.**
+
+R2 second-order:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | low | back-compat-overload | mavlink_io.py:set_mode return type | `set_mode` now returns `bool` OR `SetModeResult` based on `wait_for_ack`. Mypy/pyright would flag this. Existing callers continue to work but future callers reading the signature may not realise the kwarg flips the type. **Doc-only — already noted in docstring.** |
+| R2-2 | low | mock-shape-tolerance | facade.py:hasattr(result, "accepted") | The facade tolerates BOTH `SetModeResult` AND a bare bool from the mavlink call. This is a back-compat seatbelt for tests that haven't updated their mocks. After this PR lands and tests stabilize, this branch becomes dead code. **Doc-only — flag for cleanup in a follow-up.** |
+
+## Round 3 — Orthogonal Sweep
+
+**Framing-break:** R1+R2 audited the new state machine for internal correctness (does the event fire correctly, does the timeout cap, does the recovery-mode set match the shared-battery profiles). Neither asked: (a) what does the operator SEE on the dashboard when `set_mode_ok=False set_mode_realized=MANUAL` — does anything render the failed confirmation, or is the audit log the only signal? (b) how does the new post-action `BATTERY_GRACEFUL_STOP_RESULT` row interact with the existing /api/stats `action_taken` field — they tell different stories on a `set_mode` failure.
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R3-1 | medium | dashboard-divergence | web/server.py + BatteryMonitor.get_state | When `set_mode_ok=False`, BatteryMonitor's `action_taken` is still set to `"graceful_stop"` (we return that string regardless of the realized mavlink outcome). The dashboard reads `action_taken` and shows "graceful_stop" — but the FC may STILL be in MANUAL because the SET_MODE never landed. Operator sees "graceful stop took effect" while the platform is still autonomously driving. Same framing-break as PR #240 R3-1. |
+| R3-2 | low | result-row-noise | facade.py:BATTERY_GRACEFUL_STOP_RESULT | The post-action row format has 8 fields. On a slow Jetson, this is ~200 bytes per fire. With min_callback_interval_sec=60.0 (default) this is fine. But if the rate cap is set to 0 (some bench-test configs), and the pack oscillates at 5Hz, the audit log eats 1KB/sec just for graceful-stop result rows. **Doc-only — flag for log-rotation review.** |
+| R3-3 | low | skip-reason-naming | facade.py:set_mode_skipped="already_in_RTL" | The skip-reason string embeds the mode name. An operator grepping audit logs for "skip" rows will get hits — good. But machine parsers reading the audit row would need a regex to extract the mode. **Doc-only — consider splitting into `set_mode_skipped=True` + `set_mode_skip_reason=already_in_RTL` if a parser lands.** |
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | dashboard-divergence | R3-1 | `action_taken` says graceful_stop even when set_mode never landed. Dashboard lies to operator. | R3-1 | follow-up (web widget) |
+| medium | recovery-set-coverage | R1-4 | `LOITER` not in recovery_modes — drone shared-battery profile (if ever flagged) would re-issue LOITER mid-autonomous-loiter. | R1-4 | follow-up (conditional set) |
+| medium | event-stale | R1-1 | Single Event for all set_mode(wait_for_ack) callers — false positive on the loser if two callers race. | R1-2 | follow-up if second caller lands |
+| low | mock-shape-tolerance | R2-2 | `hasattr(result, "accepted")` branch is back-compat seatbelt — becomes dead code after tests stabilize. | R2-2 | cleanup follow-up |
+| low | back-compat-overload | R2-1 | `set_mode` return type depends on kwarg. Mypy would flag. | R2-1 | doc-only |
+| low | result-row-noise | R3-2 | Post-action row is ~200 bytes; rate-cap=0 + 5Hz pack oscillation = 1KB/sec. | R3-2 | doc-only |
+| low | skip-reason-naming | R3-3 | Embedded mode in skip reason string complicates machine parsing. | R3-3 | doc-only |
+| low | mode-name-case | R1-5 | get_vehicle_mode returns uppercase; recovery set is uppercase. Safe. | R1-5 | already pinned by test |
+| low | configparser-fallback | R1-3 (downgraded) | getfloat fallback handles missing section. Confirmed safe. | R1-3 | dropped |
+
+## Recommendation
+
+**No gates** for this PR. The three medium-severity findings (R1-1 event-stale, R1-2 shared-event, R3-1 dashboard-divergence) are all real but either contained to a single producer today (R1-1, R1-2) or replays the framing-break already on the books from PR #240 (R3-1). The recovery-mode set gap (R1-4) is the most worth landing-before-drone-ever-uses-shared-battery, but no drone profile ships shared_battery=true today.
+
+Two findings should be filed as follow-up issues:
+
+1. **R3-1 (dashboard-divergence):** dashboard widget for graceful-stop should render `set_mode_ok` alongside `action_taken` so operator sees confirmation status. Today the audit log is the only signal.
+2. **R1-4 (recovery-set-coverage):** when `safe_mode=LOITER` (drone profile), add `LOITER` to the recovery_modes set so we don't re-issue mid-autonomous-loiter.
+
+Everything else is normal post-merge cleanup.
+
+## Round 3 explicit framing-break
+
+R1+R2 audited the new code's internal correctness — does the Event fire, does the timeout cap, does the realised mode match. R3 asked: *given the audit row now records `set_mode_ok=False`, does anything operator-visible reflect that the graceful-stop did NOT take effect?* The answer is no — `action_taken="graceful_stop"` is what the dashboard renders, regardless of whether the FC actually entered the safe mode. That's the operator-experienced failure mode this PR does not yet protect against.

--- a/docs/adversarial/249.md
+++ b/docs/adversarial/249.md
@@ -1,4 +1,4 @@
-# Adversarial Analysis — PR #246 (claude/wave5-241-setmode-confirmation)
+# Adversarial Analysis — PR #249 (claude/wave5-241-setmode-confirmation)
 
 **Generated:** 2026-05-19T20:30:00Z
 **Target kind:** pr

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -349,6 +349,20 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
                 "rate cap. Issue #234 R1-1."
             ),
         ),
+        "set_mode_ack_timeout_sec": FieldSpec(
+            FieldType.FLOAT,
+            min_val=0.1,
+            max_val=10.0,
+            default=2.0,
+            description=(
+                "Wall-clock seconds the shared-battery graceful-stop will "
+                "wait for HEARTBEAT-mode-change confirmation after sending "
+                "set_mode(safe_mode). On timeout the post-action audit row "
+                "records set_mode_ok=false so post-incident replay shows "
+                "the FC never confirmed the override. Issue #241 / PR #240 "
+                "R1-2."
+            ),
+        ),
     },
     "alerts": {
         "light_bar_enabled": FieldSpec(

--- a/hydra_detect/mavlink_io.py
+++ b/hydra_detect/mavlink_io.py
@@ -7,10 +7,21 @@ import logging
 import math
 import threading
 import time
-from collections import deque
+from collections import deque, namedtuple
 from typing import Any, Callable, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+
+# Result of a confirmed set_mode call. ``accepted`` is True only when the
+# HEARTBEAT-mode-change ground truth (or COMMAND_ACK ACCEPTED, where the
+# autopilot emits one) was observed before the timeout. ``realized_mode`` is
+# the mode name observed in the next HEARTBEAT after the call. ``timeout`` is
+# True when neither signal arrived within the window.
+SetModeResult = namedtuple(
+    "SetModeResult",
+    ["accepted", "realized_mode", "ack_received", "timeout"],
+)
 
 
 class MAVLinkIO:
@@ -110,6 +121,9 @@ class MAVLinkIO:
         self._vehicle_mode: Optional[str] = None
         self._vehicle_mode_lock = threading.Lock()
         self._reverse_mode_map: dict[int, str] | None = None
+        # Signaled by _update_vehicle_mode whenever the cached mode changes.
+        # set_mode(wait_for_ack=True) waits on this to confirm realization.
+        self._mode_change_event = threading.Event()
 
         # MAVLink command callbacks (set by pipeline)
         self._cmd_callbacks: Dict[str, Callable] = {}
@@ -371,8 +385,15 @@ class MAVLinkIO:
                 else:
                     return
             mode_name = self._reverse_mode_map.get(heartbeat_msg.custom_mode)
+            changed = False
             with self._vehicle_mode_lock:
-                self._vehicle_mode = mode_name
+                if self._vehicle_mode != mode_name:
+                    self._vehicle_mode = mode_name
+                    changed = True
+            if changed:
+                # Wake any set_mode(wait_for_ack=True) caller blocked on
+                # HEARTBEAT-mode-change ground truth (issue #241).
+                self._mode_change_event.set()
         except Exception as exc:
             logger.warning("Failed to parse vehicle mode from heartbeat: %s", exc)
 
@@ -1129,21 +1150,92 @@ class MAVLinkIO:
         else:
             logger.info("Alert class filter cleared — alerting on all classes.")
 
-    def set_mode(self, mode_name: str) -> bool:
-        """Set the vehicle flight mode by name. Returns True on success."""
+    def set_mode(
+        self,
+        mode_name: str,
+        wait_for_ack: bool = False,
+        ack_timeout_sec: float = 2.0,
+    ):
+        """Set the vehicle flight mode by name.
+
+        Args:
+            mode_name: ArduPilot mode name (e.g. ``"HOLD"``, ``"LOITER"``).
+            wait_for_ack: When False (default), behaves exactly like the
+                legacy fire-and-forget surface — sends SET_MODE, returns
+                ``True`` if the send went out cleanly. When True, blocks
+                up to ``ack_timeout_sec`` for HEARTBEAT-mode-change ground
+                truth and returns a :class:`SetModeResult`.
+            ack_timeout_sec: Wall-clock seconds to wait for the next
+                HEARTBEAT carrying the new mode (or any mode change, in
+                case the FC went to a different mode like an in-flight
+                failsafe). Ignored when ``wait_for_ack`` is False.
+
+        Returns:
+            ``bool`` when ``wait_for_ack`` is False (back-compat), or
+            :class:`SetModeResult` when ``wait_for_ack`` is True.
+
+        Safety note: callers that need the legacy fire-and-forget contract
+        (approach.py, dogleg_rtl.py, web mode_api) keep their current
+        behaviour. New safety-critical paths (graceful-stop) should pass
+        ``wait_for_ack=True`` and inspect the result.
+        """
         if self._mav is None:
+            if wait_for_ack:
+                return SetModeResult(
+                    accepted=False,
+                    realized_mode=None,
+                    ack_received=False,
+                    timeout=False,
+                )
             return False
         try:
             mode_map = self._mav.mode_mapping()
-            if mode_name in mode_map:
-                with self._send_lock:
-                    self._mav.set_mode_apm(mode_map[mode_name])
-                logger.info("Vehicle set to %s mode.", mode_name)
+            if mode_name not in mode_map:
+                logger.warning("Mode %s not found in mode mapping.", mode_name)
+                if wait_for_ack:
+                    return SetModeResult(
+                        accepted=False,
+                        realized_mode=self.get_vehicle_mode(),
+                        ack_received=False,
+                        timeout=False,
+                    )
+                return False
+
+            # Clear the mode-change event BEFORE sending so we don't
+            # mis-attribute a prior HEARTBEAT to this set_mode call.
+            if wait_for_ack:
+                self._mode_change_event.clear()
+
+            with self._send_lock:
+                self._mav.set_mode_apm(mode_map[mode_name])
+            logger.info("Vehicle set to %s mode.", mode_name)
+
+            if not wait_for_ack:
                 return True
-            logger.warning("Mode %s not found in mode mapping.", mode_name)
-            return False
+
+            # Wait for HEARTBEAT-mode-change ground truth. ArduPilot does
+            # not reliably emit COMMAND_ACK for SET_MODE — the next
+            # HEARTBEAT carrying the new custom_mode is the source of
+            # truth. Cap the wait so the caller never blocks forever.
+            timeout = max(0.1, min(10.0, float(ack_timeout_sec)))
+            signalled = self._mode_change_event.wait(timeout=timeout)
+            realized = self.get_vehicle_mode()
+            accepted = signalled and realized == mode_name
+            return SetModeResult(
+                accepted=accepted,
+                realized_mode=realized,
+                ack_received=signalled,
+                timeout=not signalled,
+            )
         except Exception as exc:
             logger.warning("Failed to set mode %s: %s", mode_name, exc)
+            if wait_for_ack:
+                return SetModeResult(
+                    accepted=False,
+                    realized_mode=self.get_vehicle_mode(),
+                    ack_received=False,
+                    timeout=False,
+                )
             return False
 
     def get_rc_channels(self) -> list[int]:

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -2502,15 +2502,80 @@ class Pipeline:
             )
             return None
 
+        # Pre-action audit row records the intent and the snapshot at
+        # decision time. The realized outcomes (set_mode_ok, servo_safe_ok,
+        # pan_disabled, statustext_sent) are written in the post-action
+        # row below (issue #241 / PR #240 R1-4).
+        audit_log.warning(
+            "BATTERY_GRACEFUL_STOP vehicle=%s callsign=%s pre_voltage_v=%s "
+            "pre_pct=%s safe_mode=%s",
+            getattr(self, "_vehicle", None),
+            self._callsign,
+            pre_v,
+            pre_pct,
+            safe_mode,
+        )
+
         # 1) Mode change first — gets the FC into a stable hold while
-        # Jetson still has rail. set_mode is best-effort but logs.
+        # Jetson still has rail. Now uses wait_for_ack=True so the
+        # post-action audit row reflects ground truth, not just the
+        # send (PR #240 R1-2 / R3-4).
+        #
+        # FC-mode precedence (PR #240 R3-2): if the autopilot is already
+        # in a recovery or hold mode (RTL/LAND/HOLD/SMART_RTL/BRAKE),
+        # don't fight it — Jetson set_mode(HOLD) competing with an
+        # autopilot-driven RTL from BATT_FS_LOW_ACT=2 cancels the
+        # safer behaviour. Skip the override and record why.
+        ack_timeout = self._cfg.getfloat(
+            "battery", "set_mode_ack_timeout_sec", fallback=2.0,
+        )
+        recovery_modes = {"RTL", "LAND", "HOLD", "SMART_RTL", "BRAKE"}
+        current_mode = None
         try:
-            self._mavlink.set_mode(safe_mode)
+            current_mode = self._mavlink.get_vehicle_mode()
         except Exception as exc:
             logger.warning(
-                "Shared-battery LOW: set_mode(%s) raised %s",
-                safe_mode, exc,
+                "Shared-battery LOW: get_vehicle_mode raised %s", exc,
             )
+
+        set_mode_skipped_reason = None
+        set_mode_ok = False
+        set_mode_realized = current_mode
+        if current_mode in recovery_modes:
+            set_mode_skipped_reason = f"already_in_{current_mode}"
+            # An autopilot-driven recovery counts as a successful safe
+            # state from the operator's perspective — record realized=
+            # current mode and set_mode_ok=True so downstream logic
+            # doesn't try a second override.
+            set_mode_ok = True
+            set_mode_realized = current_mode
+            logger.info(
+                "Shared-battery LOW: FC already in %s — skipping "
+                "set_mode(%s) override.",
+                current_mode, safe_mode,
+            )
+        else:
+            try:
+                result = self._mavlink.set_mode(
+                    safe_mode,
+                    wait_for_ack=True,
+                    ack_timeout_sec=ack_timeout,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Shared-battery LOW: set_mode(%s) raised %s",
+                    safe_mode, exc,
+                )
+                result = None
+            # Back-compat: legacy fire-and-forget returns bool. The
+            # wait_for_ack=True path returns SetModeResult; tolerate
+            # either shape so mocked tests don't break.
+            if hasattr(result, "accepted"):
+                set_mode_ok = bool(result.accepted)
+                set_mode_realized = result.realized_mode
+            else:
+                set_mode_ok = bool(result)
+                set_mode_realized = None
 
         # 2) Zero the servo tracker if it's holding a pan/strike PWM —
         # otherwise the platform sits at the last commanded angle until
@@ -2518,10 +2583,12 @@ class Pipeline:
         # but does NOT prevent the frame loop from re-driving the pan
         # channel — disable_pan() gates further update() calls so a pan
         # sweep can't be the load draining the pack (issue #234 R3-1).
+        servo_safe_ok = False
         pan_disabled = False
         if self._servo_tracker is not None:
             try:
                 self._servo_tracker.safe()
+                servo_safe_ok = True
             except Exception as exc:
                 logger.warning(
                     "Shared-battery LOW: servo.safe() raised %s", exc,
@@ -2533,26 +2600,37 @@ class Pipeline:
                     "Shared-battery LOW: servo.disable_pan() raised %s", exc,
                 )
 
-        audit_log.warning(
-            "BATTERY_GRACEFUL_STOP vehicle=%s callsign=%s pre_voltage_v=%s "
-            "pre_pct=%s safe_mode=%s pan_disabled=%s",
-            getattr(self, "_vehicle", None),
-            self._callsign,
-            pre_v,
-            pre_pct,
-            safe_mode,
-            pan_disabled,
-        )
-
         # 3) Best-effort operator notification beyond the STATUSTEXT path
         # (which the battery monitor itself emits on the LOW transition).
+        statustext_sent = False
         try:
             self._mavlink.send_statustext(
                 f"{self._callsign}: GRACEFUL STOP (shared batt)",
                 severity=2,  # CRITICAL — paints red in Mission Planner
             )
+            statustext_sent = True
         except Exception:
             pass  # send is best-effort
+
+        # Post-action audit row: realized outcomes, not just intent
+        # (PR #240 R1-4). Pairs with the pre-action row above so
+        # post-incident replay can see what was attempted AND what
+        # actually happened.
+        audit_log.warning(
+            "BATTERY_GRACEFUL_STOP_RESULT vehicle=%s callsign=%s "
+            "safe_mode=%s set_mode_ok=%s set_mode_realized=%s "
+            "set_mode_skipped=%s servo_safe_ok=%s pan_disabled=%s "
+            "statustext_sent=%s",
+            getattr(self, "_vehicle", None),
+            self._callsign,
+            safe_mode,
+            set_mode_ok,
+            set_mode_realized,
+            set_mode_skipped_reason,
+            servo_safe_ok,
+            pan_disabled,
+            statustext_sent,
+        )
         return "graceful_stop"
 
     def _audit_action_cleared(self, label: str) -> None:

--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -1132,7 +1132,15 @@ class TestGracefulStopFacadeCallback:
         return pipe
 
     def test_callback_calls_servo_safe_and_disable_pan(self):
+        from hydra_detect.mavlink_io import SetModeResult
         mav = MagicMock()
+        # Pre-check returns a non-recovery mode so we exercise the
+        # set_mode path (PR #240 R3-2).
+        mav.get_vehicle_mode.return_value = "MANUAL"
+        mav.set_mode.return_value = SetModeResult(
+            accepted=True, realized_mode="HOLD",
+            ack_received=True, timeout=False,
+        )
         servo = MagicMock()
         servo.disable_pan.return_value = True
         pipe = self._make_pipeline_stub(mav, servo)
@@ -1143,7 +1151,12 @@ class TestGracefulStopFacadeCallback:
         assert result == "graceful_stop"
         servo.safe.assert_called_once()
         servo.disable_pan.assert_called_once()
-        mav.set_mode.assert_called_once_with("HOLD")
+        # set_mode is now called with wait_for_ack=True for confirmation
+        # (PR #240 R1-2 / R3-4).
+        mav.set_mode.assert_called_once()
+        args, kwargs = mav.set_mode.call_args
+        assert args[0] == "HOLD"
+        assert kwargs.get("wait_for_ack") is True
 
     def test_callback_records_pan_disabled_true_in_audit(self, caplog):
         import logging
@@ -1205,6 +1218,92 @@ class TestGracefulStopFacadeCallback:
         # Must not raise
         result = pipe._graceful_stop_for_shared_battery(snapshot)
         assert result == "graceful_stop"
+
+    def test_callback_skips_set_mode_when_fc_already_in_recovery(self, caplog):
+        """PR #240 R3-2: if FC is already in RTL/LAND/HOLD/etc., don't
+        fight the autopilot — skip the set_mode override and record why."""
+        import logging
+        mav = MagicMock()
+        mav.get_vehicle_mode.return_value = "RTL"  # autopilot-driven
+        servo = MagicMock()
+        servo.disable_pan.return_value = True
+        pipe = self._make_pipeline_stub(mav, servo)
+        snapshot = BatteryState(
+            voltage_v=11.8, remaining_pct=19, level=LEVEL_LOW,
+        )
+        with caplog.at_level(logging.WARNING, logger="hydra.audit"):
+            result = pipe._graceful_stop_for_shared_battery(snapshot)
+        assert result == "graceful_stop"
+        # set_mode must NOT be called — autopilot is already driving recovery
+        mav.set_mode.assert_not_called()
+        # Servo ladder still runs (pan disable is independent of FC mode)
+        servo.safe.assert_called_once()
+        servo.disable_pan.assert_called_once()
+        # Post-action audit row records the skip reason
+        audit = [r for r in caplog.records if "BATTERY_GRACEFUL_STOP" in r.message]
+        result_rows = [r for r in audit if "_RESULT" in r.message]
+        assert result_rows, "expected BATTERY_GRACEFUL_STOP_RESULT row"
+        assert any(
+            "set_mode_skipped=already_in_RTL" in r.message
+            for r in result_rows
+        )
+
+    def test_callback_writes_post_action_result_row(self, caplog):
+        """PR #240 R1-4: post-action audit row records realized outcomes."""
+        import logging
+        from hydra_detect.mavlink_io import SetModeResult
+        mav = MagicMock()
+        mav.get_vehicle_mode.return_value = "MANUAL"
+        mav.set_mode.return_value = SetModeResult(
+            accepted=True, realized_mode="HOLD",
+            ack_received=True, timeout=False,
+        )
+        servo = MagicMock()
+        servo.disable_pan.return_value = True
+        pipe = self._make_pipeline_stub(mav, servo)
+        snapshot = BatteryState(
+            voltage_v=11.8, remaining_pct=19, level=LEVEL_LOW,
+        )
+        with caplog.at_level(logging.WARNING, logger="hydra.audit"):
+            pipe._graceful_stop_for_shared_battery(snapshot)
+        rows = [r for r in caplog.records if "BATTERY_GRACEFUL_STOP" in r.message]
+        # Pre-action AND post-action rows are present
+        pre = [r for r in rows if "_RESULT" not in r.message]
+        post = [r for r in rows if "_RESULT" in r.message]
+        assert pre, "pre-action BATTERY_GRACEFUL_STOP row missing"
+        assert post, "post-action BATTERY_GRACEFUL_STOP_RESULT row missing"
+        msg = post[0].message
+        assert "set_mode_ok=True" in msg
+        assert "set_mode_realized=HOLD" in msg
+        assert "servo_safe_ok=True" in msg
+        assert "pan_disabled=True" in msg
+        assert "statustext_sent=True" in msg
+
+    def test_callback_result_row_records_set_mode_timeout(self, caplog):
+        """If the FC never confirms mode change, post-action row shows
+        set_mode_ok=False (PR #240 R1-2 / R1-4)."""
+        import logging
+        from hydra_detect.mavlink_io import SetModeResult
+        mav = MagicMock()
+        mav.get_vehicle_mode.return_value = "MANUAL"
+        mav.set_mode.return_value = SetModeResult(
+            accepted=False, realized_mode="MANUAL",
+            ack_received=False, timeout=True,
+        )
+        servo = MagicMock()
+        servo.disable_pan.return_value = True
+        pipe = self._make_pipeline_stub(mav, servo)
+        snapshot = BatteryState(
+            voltage_v=11.8, remaining_pct=19, level=LEVEL_LOW,
+        )
+        with caplog.at_level(logging.WARNING, logger="hydra.audit"):
+            pipe._graceful_stop_for_shared_battery(snapshot)
+        rows = [
+            r for r in caplog.records
+            if "BATTERY_GRACEFUL_STOP_RESULT" in r.message
+        ]
+        assert rows
+        assert "set_mode_ok=False" in rows[0].message
 
     def test_audit_action_cleared_writes_audit_row(self, caplog):
         import logging

--- a/tests/test_mavlink_safety.py
+++ b/tests/test_mavlink_safety.py
@@ -104,6 +104,93 @@ class TestSetMode:
 
 
 # ---------------------------------------------------------------------------
+# set_mode confirmation path (PR #240 R1-2 / R3-4 / issue #241)
+# ---------------------------------------------------------------------------
+
+
+class TestSetModeWithAck:
+    def test_wait_for_ack_no_connection_returns_result(self):
+        from hydra_detect.mavlink_io import SetModeResult
+        m = _make_mavlink()
+        r = m.set_mode("HOLD", wait_for_ack=True, ack_timeout_sec=0.1)
+        assert isinstance(r, SetModeResult)
+        assert r.accepted is False
+        assert r.realized_mode is None
+        assert r.ack_received is False
+
+    def test_wait_for_ack_unknown_mode_returns_result(self):
+        from hydra_detect.mavlink_io import SetModeResult
+        m = _make_mavlink()
+        m._mav = MagicMock()
+        m._mav.mode_mapping.return_value = {"AUTO": 3}
+        r = m.set_mode("HOLD", wait_for_ack=True, ack_timeout_sec=0.1)
+        assert isinstance(r, SetModeResult)
+        assert r.accepted is False
+
+    def test_wait_for_ack_heartbeat_confirms(self):
+        from hydra_detect.mavlink_io import SetModeResult
+        m = _make_mavlink()
+        m._mav = MagicMock()
+        m._mav.mode_mapping.return_value = {"HOLD": 4}
+
+        # Simulate a HEARTBEAT arriving immediately after set_mode_apm:
+        # set the cached mode and signal the event the reader normally
+        # would.
+        def _send_and_signal(_mode_int):
+            m._vehicle_mode = "HOLD"
+            m._mode_change_event.set()
+        m._mav.set_mode_apm.side_effect = _send_and_signal
+        r = m.set_mode("HOLD", wait_for_ack=True, ack_timeout_sec=1.0)
+        assert isinstance(r, SetModeResult)
+        assert r.accepted is True
+        assert r.realized_mode == "HOLD"
+        assert r.ack_received is True
+        assert r.timeout is False
+
+    def test_wait_for_ack_timeout(self):
+        from hydra_detect.mavlink_io import SetModeResult
+        m = _make_mavlink()
+        m._mav = MagicMock()
+        m._mav.mode_mapping.return_value = {"HOLD": 4}
+        # No HEARTBEAT signal — should time out.
+        r = m.set_mode("HOLD", wait_for_ack=True, ack_timeout_sec=0.15)
+        assert isinstance(r, SetModeResult)
+        assert r.accepted is False
+        assert r.ack_received is False
+        assert r.timeout is True
+
+    def test_wait_for_ack_other_mode_observed(self):
+        """If the FC ends up in a DIFFERENT mode (e.g. autopilot-driven
+        RTL beat us), ack_received is True but accepted is False."""
+        from hydra_detect.mavlink_io import SetModeResult
+        m = _make_mavlink()
+        m._mav = MagicMock()
+        m._mav.mode_mapping.return_value = {"HOLD": 4}
+        # Simulate the autopilot winning the race — HEARTBEAT carries
+        # a DIFFERENT mode than what we asked for.
+
+        def _send_and_signal(_mode_int):
+            m._vehicle_mode = "RTL"  # autopilot won the race
+            m._mode_change_event.set()
+        m._mav.set_mode_apm.side_effect = _send_and_signal
+        r = m.set_mode("HOLD", wait_for_ack=True, ack_timeout_sec=1.0)
+        assert isinstance(r, SetModeResult)
+        assert r.accepted is False
+        assert r.realized_mode == "RTL"
+        assert r.ack_received is True
+
+    def test_legacy_fire_and_forget_still_returns_bool(self):
+        """Existing callers that don't pass wait_for_ack must still
+        get bool (back-compat for approach.py / dogleg_rtl.py / web).
+        """
+        m = _make_mavlink()
+        m._mav = MagicMock()
+        m._mav.mode_mapping.return_value = {"HOLD": 4}
+        assert m.set_mode("HOLD") is True
+        assert m.set_mode("HOLD", wait_for_ack=False) is True
+
+
+# ---------------------------------------------------------------------------
 # Target position estimation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes the PR #240 follow-up cluster from issue #241: confirmed `set_mode`, FC-mode precedence pre-check, and post-action audit row with realized outcomes. This is the "mavlink set_mode confirmation" mini-project flagged in the #241 triage notes.

From issue #241, the items addressed in this PR are the PR #240 sub-bullets:

- [x] **PR #240 R1-2 / R3-4** — COMMAND_ACK / HEARTBEAT-mode-change confirmation on `set_mode(safe_mode)`. New `wait_for_ack` kwarg returns `SetModeResult(accepted, realized_mode, ack_received, timeout)`. Fire-and-forget contract preserved for existing callers.
- [x] **PR #240 R3-2** — FC-mode precedence check. `_graceful_stop_for_shared_battery` reads `get_vehicle_mode()` first; if FC is already in `RTL`, `LAND`, `HOLD`, `SMART_RTL`, or `BRAKE` it skips the override and records `set_mode_skipped=already_in_<mode>` instead of fighting an autopilot-driven `BATT_FS_LOW_ACT=2` recovery.
- [x] **PR #240 R1-4** — Post-action `BATTERY_GRACEFUL_STOP_RESULT` audit row records realized outcomes (`set_mode_ok`, `set_mode_realized`, `set_mode_skipped`, `servo_safe_ok`, `pan_disabled`, `statustext_sent`). Pairs with the existing pre-action `BATTERY_GRACEFUL_STOP` row.

Issue #241 stays open (14 bullets total; this PR closes 3 of them). The remaining items belong to other PR-#240 follow-ups or to PRs #236-#239 follow-ups.

## Backward compatibility

`mavlink_io.set_mode` keeps its legacy bool-returning contract when called without `wait_for_ack`. All existing callers continue to work unchanged: `approach.py` (3 sites), `dogleg_rtl.py` (2 sites), `pipeline/facade.py` set-mode handler (2 sites), `web/server.py` mode API. Only `_graceful_stop_for_shared_battery` opts into the confirmed path. Pinned by `test_legacy_fire_and_forget_still_returns_bool`.

## Schema

`[battery] set_mode_ack_timeout_sec` (FLOAT, 0.1-10.0, default 2.0) — wall-clock seconds to wait for HEARTBEAT-mode-change ground truth before recording `set_mode_ok=False` in the post-action audit row.

## Tests

- 5 new in `tests/test_mavlink_safety.py` covering: no-connection, unknown-mode, heartbeat-confirms, timeout, other-mode-observed (FC-driven race), legacy-bool back-compat.
- 3 new in `tests/test_battery_monitor.py` covering: skip-on-recovery-mode, post-action-result-row contents, set_mode-timeout audit.
- 1 existing test updated to feed `SetModeResult` through the mock.

`python -m pytest tests/test_mavlink_safety.py tests/test_mavlink_commands.py tests/test_battery_monitor.py -q` -> 131 passed, 12 skipped.

`python -m flake8 hydra_detect/ tests/` -> clean.

Production LOC ~190 (under 300 cap). Adversarial doc at `docs/adversarial/246.md` (force-added; folder gitignored since PR #209).

## Test plan

- [ ] CI green
- [ ] Adversarial gate (Round 3 present in docs/adversarial/246.md)
- [ ] Manual: bench a USV with shared-battery profile and confirm post-action audit row shows `set_mode_ok=True set_mode_realized=HOLD` on a successful graceful-stop
- [ ] Manual: bench an FC already in RTL (force via failsafe) and confirm audit row shows `set_mode_skipped=already_in_RTL` with no SET_MODE on the wire