### PR TITLE
fix(autonomy): read autonomous config section in capability_status (#247)

### DIFF
--- a/docs/adversarial/252.md
+++ b/docs/adversarial/252.md
@@ -1,0 +1,69 @@
+# Adversarial Analysis — PR #252 (fix/issue-247-autonomy-section-key)
+
+**Generated:** 2026-05-19T00:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/252
+**PR head:** 5cf5cb1861c9ff54355a826e63f85eaa0f8667fb
+**Base:** main at 078170f5
+**Diff size:** +28 / -5 across 2 files (hydra_detect/capability_status.py, tests/test_capability_status.py)
+
+## Summary
+
+- **Round 1:** 3 findings (0 high · 1 medium · 2 low). Pattern-match check on the five-literal rename, callers of the patched code path, and whether anything else in the tree still reads the wrong section name.
+- **Round 2:** 2 second-order findings, framed as the back-compat / downgrade scenario. Confirmed R1-1, added the "operator already deployed with `[autonomy]` in their config.ini" deprecation question.
+- **Round 3:** orthogonal sweep with a named framing-break — both prior rounds audited the rename in isolation and did not check whether the config-fallback path is even the right place to read autonomy state, or what happens on the inverse drift (autonomy_ref present but mis-implemented).
+- **Consolidated:** 0 blockers · 0 gates · 4 follow-ups.
+
+## Round 1 — Pattern Match
+
+3 findings. Dominant pattern: a literal-string section rename across five lines in one branch of one function. Failure modes are operator-config drift, not algorithmic.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | back-compat | capability_status.py:272-285 | The rename silently changes which config section is read. Any deployed unit with `[autonomy]` in its local `config.ini` — written before the canonical schema was settled — will now read defaults (autonomy disabled, no geofence) where it used to read its operator-tuned values. No deprecation path, no migration warning. |
+| R1-2 | low | grep-coverage | tree-wide | Grep confirms the five literals at capability_status.py:272-285 were the only schema-misaligned `"autonomy"` section reads. Other `"autonomy"` matches are UI view names (`command-palette.js`, `view-router.js:11` maps the view to `'config'`) and a test fixture token — none touch ConfigParser. Low confidence that the grep covered runtime template paths and external config-writer scripts under `ops/` or `scripts/`. |
+| R1-3 | low | schema-routing | capability_status.py vs. config_schema.py | The PR body acknowledges this. The schema dict at `config_schema.py:455` is keyed by string and not re-exported. A second hardcoded copy of `"autonomous"` now exists in `capability_status.py` and will re-drift if the schema is ever renamed. Follow-up only — fixing it would expand scope beyond P1. |
+
+## Round 2 — Counter-Critique
+
+**Challenged:** none — R1 findings stand. R1-1 is the load-bearing concern and deserves the back-compat downgrade scenario worked out explicitly.
+
+**Downgrade scenario for R1-1.** Assume a SORCC operator hand-tuned `config.ini` against an older commit that wrote `[autonomy]` (the same name the buggy code on main read from). On that unit, today, the capability_status report shows autonomy BLOCKED because the cfg fallback path returns False for everything — but the operator's `autonomy_ref` is probably also wired (this is the common case in deployed pipelines), so the bug is masked by the live reference and the operator never saw a problem. Post-fix the cfg-fallback path will read `[autonomous]`, get defaults, and still report False — same observable outcome on a unit where `autonomy_ref` is wired. **The back-compat risk only materializes for units where (a) `autonomy_ref` is not wired *and* (b) the operator has a literal `[autonomy]` section in their config.** That intersection is the early-development bench units, not fielded SORCC platforms. Concrete impact: low. Mitigation: a one-line deprecation log when `cfg.has_section("autonomy")` and `not cfg.has_section("autonomous")` — file as follow-up issue, not a gate.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | low | deprecation-path | capability_status.py:270 | No log line warning operators whose configs still carry `[autonomy]`. They will silently fall to defaults. Cheap to add (one `logger.warning` guarded by `cfg.has_section("autonomy") and not cfg.has_section("autonomous")`); intentionally deferred to keep this PR scope-tight. |
+| R2-2 | low | test-coverage | tests/test_capability_status.py | The new regression test asserts the positive case (`[autonomous]` section reads correctly). It does not assert the negative case: a config with *only* a legacy `[autonomy]` section now returns False/dryrun. That asymmetry is fine for closing #247, but would be the second test if R2-1's deprecation warning lands. |
+
+## Round 3 — Orthogonal Sweep
+
+### Round 3
+
+**Shared framing of R1+R2:** *Both rounds audited the rename and the back-compat tail in isolation — "is the new section name correct, who still writes the old one." Neither round asked (a) whether the cfg-fallback path is the right primary source for capability_status to read autonomy state from at all, or (b) what happens on the inverse drift: `autonomy_ref` is wired but its `enabled` attribute drifts from the actual config schema, so the cfg path is bypassed and a different stale value is reported.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R3-1 | medium | layering | capability_status.py:259-290 | The cfg-fallback path duplicates schema knowledge (section name, field names, types — bool parsing, float parsing, polygon split) that `config_schema.py` already encodes with `FieldSpec`. Even after this PR, the fallback re-implements `enabled.lower() in ("1","true","yes")` instead of reusing the schema's BOOL coercer. The rename is correct; the duplication is the deeper issue. Follow-up: have the fallback delegate to a `config_schema.load_section("autonomous", cfg)` helper, so a future field add does not require touching two files. |
+| R3-2 | low | inverse-drift | capability_status.py:259-269 | When `autonomy_ref is not None`, the cfg path is skipped entirely. If the runtime autonomy controller's `enabled` attribute ever diverges from what the live config says (e.g. controller was constructed from an older snapshot of the cfg), capability_status will report the controller's view, not the config's. Not a gate — that is arguably the correct behavior — but worth a test that asserts the precedence is intentional. |
+| R3-3 | nit | terminology | dataclass field name | `state.autonomy_enabled` is named after the *capability* (autonomy as a feature), while the *config section* is `autonomous` (the noun). The terminology straddles the two namespaces with no comment. Adding a one-line comment near the SystemState dataclass would help the next operator reading this code. |
+
+### Consistency-bias callouts
+
+- **R1 and R2 both rated the rename "safe" because the grep showed only five literals.** R3-1 challenges that frame — the literals are safe to rename; the duplication of schema knowledge is what makes this class of bug recurrent. The original codex finding called this out ("Consider whether `capability_status.py` should call into `config_schema` directly"); the PR explicitly defers it. Calling out here so it does not get lost.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | layering | R3-1 | cfg-fallback re-implements schema knowledge already in `config_schema.py`. Route it through a `load_section` helper so further drift is impossible. | R3-1 | follow-up issue |
+| low | back-compat | R1-1 + R2-1 | Units with legacy `[autonomy]` section in config.ini silently fall to defaults post-merge. Add a deprecation `logger.warning` when the legacy section is present and the canonical one is absent. | R1-1, R2-1 | follow-up issue |
+| low | test-coverage | R2-2 | Add a negative-case test: legacy-only `[autonomy]` config reports defaults (paired with the R2-1 warning). | R2-2 | follow-up issue |
+| low | inverse-drift | R3-2 | Add a test that exercises precedence: `autonomy_ref` wins over cfg, with a comment explaining why. | R3-2 | follow-up issue |
+
+## Recommendation
+
+**No gates.** Merge as-is. The fix is a minimal correct rename of five literals; the regression test exercises the exact failure path codex identified; the full-suite delta vs. main is net zero new failures (Windows-specific pre-existing failures in `test_config_api.py`, `test_zero_touch.py`, `test_vocabulary.py` reproduce on clean main). The four follow-ups (R1-1/R2-1 deprecation warning, R2-2 negative test, R3-1 schema-routing, R3-2 precedence test) are scoped beyond P1 and intentionally deferred per the PR body.

--- a/hydra_detect/capability_status.py
+++ b/hydra_detect/capability_status.py
@@ -269,20 +269,20 @@ def build_system_state(
             pass
     elif cfg is not None:
         try:
-            mode_raw = cfg.get("autonomy", "mode", fallback="dryrun").strip().lower()
+            mode_raw = cfg.get("autonomous", "mode", fallback="dryrun").strip().lower()
             if mode_raw in ("dryrun", "shadow", "live"):
                 state.autonomy_mode = mode_raw
-            enabled_raw = cfg.get("autonomy", "enabled", fallback="false").strip()
+            enabled_raw = cfg.get("autonomous", "enabled", fallback="false").strip()
             state.autonomy_enabled = enabled_raw.lower() in ("1", "true", "yes")
             # Geofence presence: any non-zero centre, or a polygon with 3+ pts.
-            poly_raw = cfg.get("autonomy", "geofence_polygon", fallback="").strip()
+            poly_raw = cfg.get("autonomous", "geofence_polygon", fallback="").strip()
             if poly_raw:
                 pts = [p for p in poly_raw.split(";") if "," in p]
                 state.autonomy_geofence_present = len(pts) >= 3
             if not state.autonomy_geofence_present:
                 try:
-                    lat = float(cfg.get("autonomy", "geofence_lat", fallback="0").strip())
-                    lon = float(cfg.get("autonomy", "geofence_lon", fallback="0").strip())
+                    lat = float(cfg.get("autonomous", "geofence_lat", fallback="0").strip())
+                    lon = float(cfg.get("autonomous", "geofence_lon", fallback="0").strip())
                     state.autonomy_geofence_present = (lat != 0.0 or lon != 0.0)
                 except (ValueError, TypeError):
                     pass

--- a/tests/test_capability_status.py
+++ b/tests/test_capability_status.py
@@ -1057,6 +1057,29 @@ class TestBuildSystemStateExtensions:
         assert state.autonomy_geofence_present is False
         assert state.identity_callsign == ""
 
+    def test_cfg_autonomous_section_populates_autonomy_fields(self):
+        """Regression for #247: build_system_state must read the 'autonomous'
+        config section (the schema-canonical name), not 'autonomy'. Before the
+        fix, every correctly-configured unit reported autonomy_enabled=False
+        and autonomy_geofence_present=False in the cfg fallback path."""
+        import configparser
+        from hydra_detect.capability_status import build_system_state
+
+        cfg = configparser.ConfigParser()
+        cfg.read_dict({
+            "autonomous": {
+                "enabled": "true",
+                "mode": "live",
+                "geofence_lat": "34.123",
+                "geofence_lon": "-118.456",
+            },
+        })
+        # autonomy_ref intentionally None so the cfg fallback path is exercised.
+        state = build_system_state(cfg=cfg, autonomy_ref=None)
+        assert state.autonomy_enabled is True
+        assert state.autonomy_mode == "live"
+        assert state.autonomy_geofence_present is True
+
 
 # ---------------------------------------------------------------------------
 # Placeholder capabilities — Drop, RF Hunt


### PR DESCRIPTION
## Summary

`hydra_detect/capability_status.py::build_system_state` was reading `cfg.get("autonomy", ...)` in the cfg-fallback path, but the schema-canonical section name (`config_schema.py`, `pipeline/facade.py`) is `autonomous`. On any correctly-configured fielded unit without an `autonomy_ref` wired, `autonomy_enabled` and `autonomy_geofence_present` silently defaulted to `False`, so Autonomy Dryrun / Shadow / Live reported BLOCKED.

This PR switches all five occurrences in that block (mode, enabled, geofence_polygon, geofence_lat, geofence_lon) to the canonical `autonomous` section name and adds a regression test.

## Scope notes

- Minimal literal-string fix; no schema-routing plumbing. The schema dict in `config_schema.py` does not currently expose its section names as importable constants, so routing through `config_schema` would require new API surface. Left as follow-up; flagged in the issue's "Consider whether..." bullet.
- No other code in the repo reads section `"autonomy"` from config — grep confirms the five buggy literals were the only schema-misaligned references. The remaining `"autonomy"` matches in the tree are UI view names (`command-palette.js`, `view-router.js`) and unrelated test fixtures.

## Test plan

- [x] Added `TestBuildSystemStateExtensions::test_cfg_autonomous_section_populates_autonomy_fields` — builds a ConfigParser with only `[autonomous]` populated, calls `build_system_state(cfg=cfg, autonomy_ref=None)`, asserts `autonomy_enabled is True`, `autonomy_mode == "live"`, `autonomy_geofence_present is True`.
- [x] Verified test fails on unpatched code (RED), passes after fix (GREEN).
- [x] `pytest tests/test_capability_status.py` — 106 passed, 8 skipped.
- [x] Full suite delta vs `main`: net zero new failures. Pre-existing Windows-only failures in `test_config_api.py`/`test_zero_touch.py`/`test_vocabulary.py` are atomic-rename / vocabulary lint issues unrelated to this change (reproduced on clean main).

Closes #247