### PR TITLE
fix(ops): omit missing partitions in health._partition_free_pct (#248)

### DIFF
--- a/docs/adversarial/253.md
+++ b/docs/adversarial/253.md
@@ -1,0 +1,70 @@
+# Adversarial Analysis — PR #253 (fix/issue-248-partition-fallback)
+
+**Generated:** 2026-05-19T00:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/253
+**PR head:** 7b57ce54cf52d667a3c74a9c9fcfadbb7e1c59e7
+**Base:** main at 078170f
+**Diff size:** +51 / -45 across 2 files (hydra_detect/observability/health.py, tests/test_observability.py)
+
+## Summary
+
+- **Round 1:** 4 findings (0 high · 2 medium · 2 low). Pattern-match against how other missing-resource cases are handled in `hydra_detect/observability/` and against the codex finding contract.
+- **Round 2:** 1 downgrade scenario — does any operator dashboard or alert rule implicitly rely on the ancestor-fallback always returning a number for the `output_data` label?
+- **Round 3:** 3 findings, framing identified — *both prior rounds audited the single producer (`_partition_usage`) in isolation. Neither asked what dashboards, alert rules, or Prometheus consumers downstream of `/api/health` do when a label they used to see every tick now disappears mid-mission.*
+
+## Round 1 — Pattern Match
+
+The fix matches the dominant pattern in `observability/`: when a probe cannot resolve its data source, it emits a single structured `logger.warning` and the consumer omits the field rather than zeroing it. The existing `TestProbeWarnsOnFailure` test (around line 319 of `test_observability.py`) already encodes that contract for the `shutil.disk_usage` raise path. The codex finding on #227 calls out the path-does-not-exist branch as the one place the contract is violated. This PR closes that gap.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | duplicate-warning | health.py:215-217 | Probe now emits a WARNING every snapshot tick for a partition that simply does not exist yet (e.g. `./output_data` on first boot pre-mkdir). With a 10 s `/api/health` cadence that's 8,640 lines/day of the same line — noisy enough that a real "mount disappeared" warning will be drowned in the steady-state stream. |
+| R1-2 | low | log-key-shape | health.py:215-227 | Two warning sites use slightly different keys (`path=%r` only vs `path=%r err=%s`). Grep is fine, but a single structured `extra={"path": path, "reason": ...}` would let downstream log-shipping route the events. Out of scope for this PR; flag for the broader observability key audit. |
+| R1-3 | medium | docstring-drift | health.py:162-176 | The block comment above `_DEFAULT_OUTPUT_DATA_PATH` was updated to say "omits the label entirely (with a warning) instead of walking up to an ancestor partition" — accurate. But the docstring for `_default_partitions` and the `compute_disk_free` Returns block both still imply "labels whose disk_usage call fails are omitted, not zeroed." That wording was true under the old fallback (only total-resolve failure omitted) and is now load-bearing for a wider class of inputs. Tighten on follow-up. |
+| R1-4 | low | first-boot | health.py:208-213 | `./output_data` is the default path and is relative. On a fresh checkout / first container boot, the directory may not exist until the daemon creates it. Under the old behavior that resolved to CWD's partition; under the new behavior the label is omitted until first write. Acceptable per the contract but operators will see "output_data missing from disk_free_pct for the first 30 s of boot" as a new symptom. |
+
+## Round 2 — Counter-Critique (downgrade scenario)
+
+**What is lost by removing the fallback.** The fallback existed because (a) on first boot `./output_data` may not exist yet, and (b) deep test/config paths in fresh installs sometimes pointed several levels below an existing mount. In both cases the fallback let the operator see *some* number rather than a missing key.
+
+**Does any operator rely on this implicitly?** Worth checking:
+
+- **Dashboards.** The ops sidebar reads `disk_free_pct.output_data` for the per-partition pressure tile. If the key disappears the tile renders as "—" (missing). That is the explicitly-documented contract from issue #248: tile-missing is *correct* signal when the mount is gone, *incorrect* signal would be the tile showing 87 % from the root partition. Net win.
+- **Alert rules.** A Prometheus alert keyed on `disk_free_pct{label="output_data"}` will fire `absent()` instead of evaluating thresholds when the mount is gone. That is also the correct failure mode — silent root-disk substitution under the `output_data` label is exactly the masked-mount-failure case codex flagged.
+- **Phone-home consumers.** Any consumer that previously read `disk_free_pct["output_data"]` without a presence check will `KeyError`. We do not have such a consumer in-tree (the Prometheus exporter iterates the dict, dashboards probe by key). External consumers should be probing first.
+
+**Downgrade verdict:** the loss is a real ergonomic regression on *first-boot* (`./output_data` not yet created) and that surfaces as a brief "label missing" warning in the boot log. That is acceptable cost for closing the masked-mount-failure class. Not gate-worthy.
+
+### Round 3
+
+**Shared framing of R1+R2:** *Both rounds audited the single producer (`_partition_usage`) and asked "is the contract right, is the wording right, does anyone rely on the old behavior." Neither round asked what happens at the **consumer** side when a label that was present for every prior tick disappears mid-mission — specifically whether `/api/health` shape contracts, the metrics exporter, the in-tree alert rules, and the JSON schema consumed by mission UIs all tolerate a key vanishing.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | medium | absent-vs-zero | health_snapshot caller + Prometheus exposition | `compute_disk_free` and `compute_disk_bytes` both omit the label on failure. The Prometheus exporter (`render_metrics`) iterates whatever dict it receives — fine when the label is absent throughout, but downstream PromQL queries that join on `label` across scrape intervals will see a series end and a new one begin if the partition flaps. Prefer either (a) a stable label set sourced from `_default_partitions()` with a sentinel NaN series for omitted labels, or (b) document that `disk_free_pct{label="output_data"}` is allowed to disappear and add a dashboard panel for `absent(disk_free_pct{label="output_data"}) == 1`. |
+| R3-2 | medium | mid-mission-drop | health_snapshot every 10 s tick | The contract is correct for *startup* (label absent → mount not yet mounted). For a *mid-mission* mount drop the operator-visible behavior changes: yesterday they saw `output_data: 87 %` go to `output_data: 87 %` (silently still root); today they see `output_data: 87 %` go to `output_data` missing from the response. The UI/dashboard must surface "label disappeared" as the alarm condition. We do not have a dashboard panel for `absent()`; this PR closes the producer-side bug but the consumer-side alarm is unbuilt. |
+| R3-3 | low | test-symmetry | tests/test_observability.py | The new regression test asserts `"phantom" not in result` and a warning was emitted. It does *not* assert the **other** labels are still present (e.g. that `compute_disk_free({"phantom": <bad>, "good": str(tmp_path)})` returns `{"good": ...}` without the bad one). The current implementation handles this correctly (per-label loop), but a one-line addition to the test would lock the per-label isolation in. Follow-up. |
+
+### Consistency-bias callouts
+
+- **R1+R2 ranked "first-boot ergonomic regression" (R1-4) higher than the consumer-side alarm gap (R3-2).** That is upside-down: the first-boot symptom is a one-time log line at startup; the consumer-side gap is the actual operator-visible question ("how do I tell when the mount drops?"). The producer fix is necessary but not sufficient — a follow-up issue should add the `absent()` alert/panel.
+- **No round considered the env-override path** (`HYDRA_OUTPUT_DATA_PATH`). In production the override points at `/data` (an absolute bind mount). If that mount is gone the new behavior is exactly what we want: label absent + warning, no silent root-disk substitution. The fix is most valuable in exactly the deployed-container case.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | mid-mission-drop | R3-2 | Producer-side fix is correct but the consumer-side alarm for "label disappeared mid-mission" is unbuilt. Add a `absent(disk_free_pct{label="output_data"})` rule and a dashboard tile. | R3-2 | follow-up issue |
+| medium | absent-vs-zero | R3-1 | Prometheus series will start/end on partition flap. Document the allowed-absent contract or emit a sentinel NaN series for omitted labels. | R3-1 | follow-up issue |
+| medium | duplicate-warning | R1-1 | One WARNING per 10 s `/api/health` tick for a non-existent path is enough volume to drown a real "mount disappeared" warning. Consider once-per-state-change emission via a small per-label state cache. | R1-1 | follow-up issue |
+| medium | docstring-drift | R1-3 | Tighten `_default_partitions` and `compute_disk_free` Returns wording to reflect the wider class of inputs that now omit. | R1-3 | follow-up issue |
+| low | test-symmetry | R3-3 | Add a one-line "other labels still present" assertion. | R3-3 | follow-up issue |
+| low | log-key-shape | R1-2 | Migrate warning sites to structured `extra=` keys when the broader observability key audit happens. | R1-2 | nit |
+| low | first-boot | R1-4 | Operators will see `output_data` briefly absent during boot before the directory is created. Acceptable. | R1-4 | accept |
+
+## Recommendation
+
+**No gates.** The producer-side fix is correct and matches the documented contract on issue #248. The downstream consumer-side alarm (R3-2) and the WARNING-rate concern (R1-1) are real but out of scope for this PR — they describe additional work, not a defect in this change. File as follow-up issues against this PR's merge commit.

--- a/hydra_detect/observability/health.py
+++ b/hydra_detect/observability/health.py
@@ -164,13 +164,11 @@ def _probe_disk(path: str = "/") -> Dict[str, str]:
 # ``subsystems.disk`` status string — phone-home consumers want a number, not
 # a sentence.
 #
-# The ``output_data`` default path is relative — ``_partition_usage`` walks
-# ancestors when it doesn't exist, which means CWD at probe time decides
-# which partition gets reported. Inside the production Docker container,
-# ``output_data/`` lives at ``/data`` (bind-mounted from the host) and the
-# CWD is ``/app`` where ``./output_data`` does not exist, so the probe would
-# silently fall back to ``/app`` (the container root partition) and mislabel
-# it as ``output_data``. Set ``HYDRA_OUTPUT_DATA_PATH`` in the unit/env to
+# The ``output_data`` default path is relative — when the configured path
+# does not exist, ``_partition_usage`` now omits the label entirely (with a
+# warning) instead of walking up to an ancestor partition. Issue #248: the
+# old ancestor fallback masked mount failures (a missing /data mount would
+# silently report /). Set ``HYDRA_OUTPUT_DATA_PATH`` in the unit/env to
 # anchor the probe at an absolute mount point. See systemd/hydra-detect.service
 # and adversarial finding R3-3 on #227.
 _DEFAULT_OUTPUT_DATA_PATH = "./output_data"
@@ -196,39 +194,33 @@ _DISK_FREE_PARTITIONS: tuple[tuple[str, str], ...] = _default_partitions()
 def _partition_usage(path: str) -> Optional[tuple[float, int, int]]:
     """Return ``(free_pct, free_bytes, total_bytes)`` for ``path``, or None.
 
-    Falls back to the parent directory when ``path`` does not exist yet
-    (output_data/ may not be created on first boot). Returns None only when
-    even the fallback fails — the field is omitted in that case, not zeroed,
-    so consumers can distinguish "really full" from "no data".
+    Returns None when the path does not exist or ``shutil.disk_usage`` fails
+    — the field is omitted in that case, not zeroed, so consumers can
+    distinguish "really full" from "no data" AND so a missing mount surfaces
+    as an absent label rather than being silently rewritten to an ancestor
+    partition (which masked mount failures — see issue #248).
 
-    Emits a single ``logger.warning`` when the probe ultimately fails, so an
-    operator looking at "why did output_data disappear from phone-home" has
-    something to grep for.
+    Emits a single ``logger.warning`` when the probe fails, so an operator
+    looking at "why did output_data disappear from phone-home" has something
+    to grep for.
     """
     p = Path(path)
-    target: Optional[Path] = p if p.exists() else None
-    if target is None:
-        # Walk up to the first existing ancestor; usually p.parent suffices
-        # but we guard against deep config paths in tests / fresh installs.
-        for ancestor in p.parents:
-            if ancestor.exists():
-                target = ancestor
-                break
-    if target is None:
-        _log.warning("disk_probe: no existing ancestor for path=%r", path)
+    if not p.exists():
+        _log.warning(
+            "disk_probe: path does not exist, omitting label path=%r", path,
+        )
         return None
     try:
-        usage = shutil.disk_usage(os.fspath(target))
+        usage = shutil.disk_usage(os.fspath(p))
     except OSError as exc:
         _log.warning(
-            "disk_probe: shutil.disk_usage failed for path=%r target=%r err=%s",
-            path, os.fspath(target), exc,
+            "disk_probe: shutil.disk_usage failed for path=%r err=%s",
+            path, exc,
         )
         return None
     if usage.total <= 0:
         _log.warning(
-            "disk_probe: total bytes <= 0 for path=%r target=%r",
-            path, os.fspath(target),
+            "disk_probe: total bytes <= 0 for path=%r", path,
         )
         return None
     pct = round((usage.free / usage.total) * 100.0, 2)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -175,22 +175,31 @@ class TestComputeDiskFree:
         assert "root" not in result
         assert "output_data" not in result
 
-    def test_missing_path_falls_back_to_existing_ancestor(self, tmp_path):
-        # Deeply non-existent path under a real tmpdir — falls back to tmpdir.
+    def test_missing_path_is_omitted_not_ancestor_rewritten(self, tmp_path, caplog):
+        # Issue #248: a configured partition path that does not exist must be
+        # OMITTED from the output (with a structured warning), not silently
+        # rewritten to an existing ancestor partition. The old ancestor
+        # fallback masked mount failures — a missing /mnt/data would report
+        # the root partition under the "data" label.
         nonexistent = tmp_path / "does" / "not" / "exist"
-        result = compute_disk_free({"phantom": str(nonexistent)})
-        # Fallback found tmp_path; we get a real number, not a missing key.
-        assert "phantom" in result
-        assert 0.0 <= result["phantom"] <= 100.0
+        with caplog.at_level(
+            logging.WARNING, logger="hydra_detect.observability.health",
+        ):
+            result = compute_disk_free({"phantom": str(nonexistent)})
+        # Label is absent, NOT mapped to tmp_path's free pct.
+        assert "phantom" not in result
+        # A structured warning was emitted naming the probe.
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "disk_probe" in r.getMessage()
+        ]
+        assert len(warnings) >= 1, [r.getMessage() for r in caplog.records]
 
     def test_unreadable_path_is_omitted_not_zeroed(self):
-        # An absolute path whose parents also don't exist returns nothing.
-        # Use a label so completely synthetic that no ancestor can match.
+        # An absolute path that can never resolve — label is omitted, never
+        # zeroed (zero would falsely trigger "disk full" alarms).
         result = compute_disk_free({"nope": "\x00invalid\x00"})
-        # Either omitted (preferred) or a real number. Never a zero placeholder
-        # that would falsely trigger "disk full" alarms.
-        if "nope" in result:
-            assert result["nope"] > 0.0
+        assert "nope" not in result
 
 
 class TestHealthSnapshotDiskFreePct:
@@ -254,11 +263,16 @@ class TestComputeDiskBytes:
         assert "root" not in result
 
     def test_unreadable_path_is_omitted(self):
-        # Synthetic path with NUL bytes — no ancestor can resolve.
+        # Synthetic path that cannot resolve — issue #248 contract: omitted,
+        # not rewritten to an ancestor. No zero placeholder either.
         result = compute_disk_bytes({"nope": "\x00invalid\x00"})
-        # Omitted (preferred) or fell back; never a zero placeholder.
-        if "nope" in result:
-            assert result["nope"]["total"] > 0
+        assert "nope" not in result
+
+    def test_missing_path_is_omitted_not_ancestor_rewritten(self, tmp_path):
+        # Issue #248: same contract for the bytes surface.
+        nonexistent = tmp_path / "does" / "not" / "exist"
+        result = compute_disk_bytes({"phantom": str(nonexistent)})
+        assert "phantom" not in result
 
 
 class TestPartitionResolvesToCorrectMount:


### PR DESCRIPTION
## Summary

Closes #248.

`hydra_detect/observability/health.py::_partition_usage` walked the path tree to find an existing ancestor when the configured partition path was missing, then reported that ancestor's free pct under the configured label. This silently masked mount failures: a missing `/mnt/data` mount would report the root partition under the `data` label — exactly the failure mode the per-partition view was meant to surface (codex P1 follow-up on #227).

This drops the ancestor walk. When the configured path does not exist (or `shutil.disk_usage` raises), `_partition_usage` emits a structured `disk_probe:` warning and returns `None`, so the label is omitted from both `disk_free_pct` and `disk_bytes`. Phone-home consumers can now distinguish "really full" from "no data" from "wrong mount" by the presence/absence of the label.

## Changes

- `hydra_detect/observability/health.py`: remove the `Path.parents` ancestor-rewrite branch in `_partition_usage`; tighten warning lines; update the docstring and the surrounding section comment to reflect the new contract.
- `tests/test_observability.py`:
  - `test_missing_path_falls_back_to_existing_ancestor` -> `test_missing_path_is_omitted_not_ancestor_rewritten` (asserts label absent + warning emitted).
  - `test_unreadable_path_is_omitted_not_zeroed` tightened to assert absence rather than "absent or fell back".
  - `TestComputeDiskBytes.test_unreadable_path_is_omitted` tightened the same way.
  - New: `TestComputeDiskBytes.test_missing_path_is_omitted_not_ancestor_rewritten` covers the bytes surface.

## Verification

- Reverted the fix locally and confirmed the new regression tests fail (label present with ancestor's free pct).
- Restored the fix; full `tests/test_observability.py` is green (41 passed).
- The full suite outside observability has pre-existing Windows-only failures (config-file rename, template/vocabulary, unicode encoding) reproducible on `main`; not introduced here.

## Test plan

- [x] Regression test fails before fix
- [x] Regression test passes after fix
- [x] `tests/test_observability.py` green
- [ ] CI green on Linux