### PR TITLE
fix(safety): add FW guard to _handle_strike_command (#246)

### DIFF
--- a/docs/adversarial/254.md
+++ b/docs/adversarial/254.md
@@ -1,0 +1,89 @@
+# Adversarial Analysis — PR #254 (fix/issue-246-strike-fw-guard)
+
+**Generated:** 2026-05-19T00:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/254
+**PR head:** 678bcdf
+**Base:** main at 078170f
+**Diff size:** +38 / -0 across 2 files (hydra_detect/pipeline/facade.py, tests/test_fw_profile.py)
+**Closes:** #246
+
+## Summary
+
+- **Round 1 (pattern-match):** 3 findings (0 high · 2 medium · 1 low). The fix replicates the exact `if self._refuse_approach_for_fw("strike"): return False` pattern used by the four sibling handlers (`_handle_drop_command`, `_handle_follow_command`, `_handle_approach_strike_command`, `_handle_pixel_lock_command`). No drive-by edits. The "strike" action token is already in `_FW_FORBIDDEN_APPROACH_MODES`.
+- **Round 2 (counter-critique with downgrade scenario):** 2 second-order findings. Considered "predicate too strict / FW operator actually wants strike-servo dry-fire on the bench" downgrade — rejected. The safety contract from #70 is hard: FW is detection-only, no engagement primitives. Bench dry-fire belongs in a hardware-test harness, not the operational strike path.
+- **Round 3 (orthogonal sweep — framing break):** *Both prior rounds audited the new guard in isolation against its four siblings. Neither asked whether the strike-command code path has callers the sibling handlers do not — and it does. `_handle_strike_command` is wired into MAVLink RC-switch callbacks and the `on_strike` control wiring (see facade.py:893, 1166, 1489, 1714), while the approach-family handlers are reached only via web/API. The codex finding called this out; the test mirrors only the web path. Bench risk is the RC-switch path on a FW airframe with a strike servo wired up.*
+
+## Round 1 — Pattern Match
+
+The fix is a single early-return at the top of `_handle_strike_command`. The pattern matches the sibling handlers byte-for-byte:
+
+```
+if self._refuse_approach_for_fw("strike"):
+    return False
+```
+
+`_refuse_approach_for_fw` already:
+
+- short-circuits when `_vehicle` is unset or not FW (legacy fixtures + non-FW platforms unaffected)
+- emits `FW_PROFILE_REFUSED action=strike reason=detection_only` to `hydra.audit`
+- emits a STATUSTEXT to MAVLink at severity 4 ("FW: STRIKE not supported")
+- tolerates `_mavlink is None`
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | test-scope | tests/test_fw_profile.py | The three new tests exercise `_handle_strike_command` directly. Verified RED before the fix (assertion fails because the handler returns `True`); GREEN after. But the codex finding cites two reach paths — `/api/target/strike` and **MAVLink strike callbacks** — and the test only exercises the direct call, not the MAVLink callback wiring (see facade.py:893, 1166, 1489 where `on_strike=self._handle_strike_command` is registered). |
+| R1-2 | medium | action-token-overload | facade.py:1998-2076 vs. facade.py:2369-2407 | Both `_handle_strike_command` and `_handle_approach_strike_command` now refuse under the same `"strike"` action token. STATUSTEXT and audit log are byte-identical for the two paths — post-incident replay cannot distinguish which surface a FW operator hit. Acceptable for safety; mildly hostile to forensics. |
+| R1-3 | low | docstring-drift | facade.py:1998-2005 | The handler docstring still describes the full strike behaviour ("estimates target GPS, switches to GUIDED, and sends the waypoint") with no mention that the FW profile early-returns. Matches sibling-handler convention (none of the four sibling handlers updated their docstrings either), so this is consistency with the codebase pattern, not a regression. |
+
+## Round 2 — Counter-Critique
+
+**Downgrade scenario considered:** *what if the predicate is too strict?* Concrete case — a FW airframe on the bench, MAVLink disconnected, operator wants to fire the strike servo to validate wiring. Pre-fix code path: `_handle_strike_command` reached the `if self._mavlink is None:` branch and called `self._servo_tracker.fire_strike()` then returned `True`. Post-fix: refuses before reaching the servo path.
+
+**Rejected as a real concern.** The safety contract from #70 is that FW ships as detection-only. The bench/wiring-test path belongs in a hardware diagnostic harness, not the operational strike handler. If a SORCC FW operator needs to dry-fire a strike servo, they do it through a service-mode tool or by running with `--vehicle drone` on the bench. Surfacing an engagement primitive on the "detection-only" profile would re-open the exact safety hole #213 closed.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | low | observability | facade.py:2233-2268 | The refusal path is silent on `event_logger` — only `audit_log.info` and STATUSTEXT fire. Sibling handlers' refusals have the same gap. After-action review can mine `hydra.audit` records but the operator-facing event timeline shows no refusal. Out of scope for this PR; carry as a follow-up issue against `_refuse_approach_for_fw` itself, not against this fix. |
+| R2-2 | low | regression-symmetry | tests/test_fw_profile.py | New tests cover FW-refuses-strike-command and drone-still-allows-strike-command, but not USV/UGV. The sibling test `test_ugv_profile_still_allows_strike` covers `_handle_approach_strike_command` for UGV. Adding a parallel UGV test for `_handle_strike_command` would tighten the regression set; not load-bearing for #246 because the FW gate is the safety contract. |
+
+## Round 3 — Orthogonal Sweep
+
+**Framing break:** *both R1 and R2 audited the new guard in isolation against its four siblings — same pattern, same predicate, same refusal payload. Neither round asked whether `_handle_strike_command` has reach paths the sibling handlers do not. It does, and the codex finding called this out explicitly:*
+
+> `on_strike_command` is still wired to `_handle_strike_command` (see `hydra_detect/pipeline/control.py`), and that path can still command GUIDED navigation and fire the strike servo for `--vehicle fw`.
+
+The sibling handlers (`drop`, `follow`, `approach_strike`, `pixel_lock`) are reached only via web/API command flow. `_handle_strike_command` is additionally wired as the `on_strike` callback at four call sites in facade.py (lines 893, 1166, 1489, 1714) — that wires it into the MAVLink RC-switch handler and the autonomous control path. The new tests exercise the direct call but not the RC-switch path. The fix is correct (the guard runs regardless of caller), but the test surface area is narrower than the threat surface.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **medium** | **test-surface-gap** | tests/test_fw_profile.py + facade.py:893,1166,1489,1714 | New tests call `p._handle_strike_command(3)` directly. They do not exercise the MAVLink RC-switch path that registers `on_strike=self._handle_strike_command`. If a future refactor changes the callback registration (e.g. wraps the handler in a class that bypasses `self`), the new tests pass but FW can engage again. **Follow-up:** add an integration test that fires the RC strike switch and asserts no GUIDED command emits and no servo fires on FW. Not a gate for this PR — the underlying guard is in the right place. |
+| R3-2 | low | callsite-audit | hydra_detect/pipeline/control.py | The codex finding cites `control.py` as the wiring site for `on_strike_command`. Worth a one-line check that no other code path in `control.py` or the autonomous controller bypasses `_handle_strike_command` and reaches the GUIDED-command primitive directly (`self._mavlink.command_guided_to`). Quick grep across the repo for `command_guided_to(` outside `_handle_strike_command` would close this; out of scope for this PR. |
+| R3-3 | low | rc-switch-replay | facade.py + mavlink_io.py | RC strike switches latch high until the operator toggles them. On FW the refusal STATUSTEXT fires once per switch transition, but a stuck-high switch produces a single audit row and then silence. After-action review cannot reconstruct "operator was hammering the strike switch for 30 s" from one log line. Matches sibling-handler behaviour; not a regression introduced by this PR. |
+
+### Consistency-bias callouts
+
+- **R1 and R2 both anchored on "match the sibling pattern."** That made R3-1 invisible — the symmetry argument is correct for the *guard placement* but elides the asymmetry in *reach paths*. The fix is sound; the test coverage inherits the sibling test pattern but the threat surface for this handler is strictly larger than the siblings'.
+- The codex finding had this in plain text. R1 read it as "add the guard," not "add the guard *and* the wiring is the real concern." Worth recording as a calibration note: when a finding cites multiple reach paths (web + MAVLink + control wiring), the test plan should cover all reach paths, not just the easiest one to mock.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | test-surface-gap | R3-1 | New tests cover direct call only; the MAVLink RC-switch callback path (`on_strike` registration) is not exercised. The guard is correctly placed and will fire regardless of caller, so the fix is correct; but if a refactor wraps the callback, the regression test will not catch it. Add an integration test that fires the RC strike switch on a FW pipeline and asserts no GUIDED + no servo fire. | R3-1 | **follow-up issue, not a merge gate** |
+| medium | test-scope | R1-1 | Same as R3-1, narrower framing. Subsumed by R3-1. | R1-1 | merged into R3-1 |
+| medium | action-token-overload | R1-2 | `_handle_strike_command` and `_handle_approach_strike_command` produce identical refusal payloads (`action=strike`). Forensics cannot distinguish surfaces; safety not affected. | R1-2 | follow-up issue |
+| low | observability | R2-1 | Refusal does not write to `event_logger` — sibling-handler issue, not specific to this PR. | R2-1 | follow-up issue against `_refuse_approach_for_fw` |
+| low | regression-symmetry | R2-2 | No `test_ugv_profile_still_allows_strike_command` parallel to existing sibling tests. | R2-2 | nit |
+| low | docstring-drift | R1-3 | Handler docstring does not mention FW early-return. Matches sibling-handler convention. | R1-3 | nit |
+| low | callsite-audit | R3-2 | One-line grep for direct `command_guided_to` callers outside the guarded handler. | R3-2 | follow-up |
+| low | rc-switch-replay | R3-3 | Stuck-high RC switch produces one log row then silence on FW. Sibling-handler behaviour. | R3-3 | nit |
+
+## Recommendation
+
+**No merge gates.** The fix is minimal, mirrors the established sibling pattern, has a red-before-green regression test, and closes the codex-cited safety hole. The four sibling handlers in `_handle_*_command` use the exact same one-line guard pattern; this PR brings `_handle_strike_command` into that pattern.
+
+Two follow-ups worth filing as separate issues:
+
+1. **R3-1** — Integration test for the RC-switch path that registers `on_strike=self._handle_strike_command` at facade.py:893,1166,1489,1714. Apply the same coverage to the four sibling handlers if they have analogous callback registrations.
+2. **R1-2 / R2-1** — `_refuse_approach_for_fw` should emit one `event_logger` row per refusal and include the calling handler name so forensics can distinguish `strike_command` from `approach_strike_command`. Scope this against the helper itself, not against this PR.

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -2003,6 +2003,8 @@ class Pipeline:
         GUIDED, and sends the waypoint. Without MAVLink, the overlay
         still shows strike mode for visual confirmation.
         """
+        if self._refuse_approach_for_fw("strike"):
+            return False
         with self._state_lock:
             if self._last_track_result is None:
                 return False

--- a/tests/test_fw_profile.py
+++ b/tests/test_fw_profile.py
@@ -222,6 +222,8 @@ class TestFWPipelineRefusal:
         p._autonomous = None
         p._event_logger = MagicMock()
         p._drop_distance_m = 3.0
+        p._strike_distance_m = 3.0
+        p._servo_tracker = MagicMock()
         p._init_target_state()
         p._last_track_result = TrackingResult(
             tracks=[TrackedObject(
@@ -257,6 +259,40 @@ class TestFWPipelineRefusal:
         assert p._handle_pixel_lock_command(3) is False
         p._approach.start_pixel_lock.assert_not_called()
         assert p._locked_track_id is None
+
+    def test_fw_refuses_strike_command(self):
+        """Regression for issue #246: _handle_strike_command also bypasses GUIDED.
+
+        Sibling handlers (_handle_drop_command, _handle_follow_command,
+        _handle_approach_strike_command, _handle_pixel_lock_command) all carry
+        the FW guard; _handle_strike_command was missing it and could still
+        command GUIDED nav + fire the strike servo on fixed-wing.
+        """
+        p = self._make_pipeline("fw")
+        assert p._handle_strike_command(3) is False
+        # No GUIDED command should reach mavlink.
+        p._mavlink.command_guided_to.assert_not_called()
+        # Strike servo must not fire on refusal.
+        p._servo_tracker.fire_strike.assert_not_called()
+        # No lock should be set on refusal.
+        assert p._locked_track_id is None
+
+    def test_fw_strike_command_refusal_emits_audit_log(self, caplog):
+        """Strike-command refusal lands on hydra.audit, same as siblings."""
+        import logging
+        with caplog.at_level(logging.INFO, logger="hydra.audit"):
+            p = self._make_pipeline("fw")
+            p._handle_strike_command(3)
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "FW_PROFILE_REFUSED" in joined
+        assert "strike" in joined
+
+    def test_drone_profile_still_allows_strike_command(self):
+        """Regression: drone profile is unaffected — strike command still runs."""
+        p = self._make_pipeline("drone")
+        assert p._handle_strike_command(3) is True
+        p._mavlink.command_guided_to.assert_called_once()
+        p._servo_tracker.fire_strike.assert_called_once()
 
     def test_fw_refusal_emits_statustext(self):
         """Operator gets a STATUSTEXT explaining the refusal — not silent."""


### PR DESCRIPTION
## Summary

`_handle_strike_command` in `hydra_detect/pipeline/facade.py` was missing the fixed-wing detection-only guard that PR #213 added to the four sibling handlers (`_handle_drop_command`, `_handle_follow_command`, `_handle_approach_strike_command`, `_handle_pixel_lock_command`). On `--vehicle fw`, `/api/target/strike` and MAVLink strike callbacks could still command GUIDED nav and fire the strike servo, contradicting the detection-only safety contract from #70.

Adds `if self._refuse_approach_for_fw("strike"): return False` at the top of `_handle_strike_command`. The `"strike"` action is already in `_FW_FORBIDDEN_APPROACH_MODES`, so refusal produces the same structured log + `hydra.audit` entry + STATUSTEXT path as the siblings. No drive-by changes.

## Tests

Three regression tests added in `tests/test_fw_profile.py::TestFWPipelineRefusal`, mirroring the existing FW refusal tests:

- `test_fw_refuses_strike_command` — FW refuses, no GUIDED command reaches MAVLink, strike servo does not fire, no lock is set.
- `test_fw_strike_command_refusal_emits_audit_log` — refusal lands on `hydra.audit` logger with `FW_PROFILE_REFUSED` and `strike`.
- `test_drone_profile_still_allows_strike_command` — regression guard for non-FW platforms.

Verified red-before-fix: with the guard temporarily removed, `test_fw_refuses_strike_command` fails on `assert _handle_strike_command(3) is False` (returns `True`). With the guard restored, all three pass.

Closes #246