### PR TITLE
feat(ops): alert on expected-but-absent partition labels

### DIFF
--- a/docs/adversarial/255.md
+++ b/docs/adversarial/255.md
@@ -1,0 +1,65 @@
+# Adversarial Analysis — PR #255 (followup/issue-248-absent-partition-alert)
+
+**Generated:** 2026-05-20T00:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/255
+**PR head:** bfae724996fc62d899ced9481cfd96ee349bc828
+**Base:** main at 1a13e8c
+**Diff size:** +112 / -2 across 2 files (hydra_detect/observability/health.py, tests/test_observability.py)
+
+## Summary
+
+- **Round 1:** 4 findings (0 high · 2 medium · 2 low). Pattern-match against how PR #253 handled the producer side and against the structured-warning convention in `observability/`.
+- **Round 2:** 1 downgrade scenario — does the new `partition_absent` warning create false alarms for any partition that can legitimately be absent, and is the alarm strong enough given it is "just another log line"?
+- **Round 3:** 3 findings, framing identified — *both prior rounds treated `partition_absent` as a self-contained log emission and asked "is it noisy, is it false-positive-prone." Neither asked whether a log-only warning is the right alarm tier at all, or how this interacts with the duplicate-warning concern PR #253 already raised (R1-1) for the producer side.*
+
+## Round 1 — Pattern Match
+
+This PR is the direct follow-up the #253 adversarial doc asked for: #253's R3-2 said "the producer fix is correct but the consumer-side alarm for label-disappeared-mid-mission is unbuilt." This change builds exactly that. It matches the dominant pattern in `observability/`: there is no dedicated alert object, so a structured `_log.warning` line is the idiomatic alarm. The `partition_absent:` prefix mirrors the existing `disk_probe:` prefix so operators have a greppable token. The alert is placed in `health_snapshot` — the caller that already resolves the configured partition list — leaving `_partition_usage`'s omit+warn contract untouched.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | warning-rate | health.py `_alert_absent_partitions` | Same volume concern #253 R1-1 raised for the producer: on a 10 s `/api/health` cadence a partition absent since first boot (`./output_data` pre-mkdir) emits one `partition_absent` line every tick — 8,640/day — on top of the `disk_probe` line from the producer. Two steady-state lines per tick per missing label. A real mid-mission drop is now buried in twice the noise. State-change-only emission via a per-label last-seen cache would fix both; out of scope here but worth a follow-up. |
+| R1-2 | low | double-emission | health.py producer + consumer | For an absent path the operator now sees two warnings per tick describing one fact: `disk_probe: path does not exist` (producer) and `partition_absent: expected partition label missing` (consumer). They are deliberately different viewpoints (a bad path vs. a watched mount gone), but a log reader skimming for distinct incidents may count them as two. Acceptable; the prefixes disambiguate. |
+| R1-3 | low | docstring-coverage | health.py `health_snapshot` docstring | The function docstring documents `disk_free_pct`/`disk_bytes` shape and the omit-not-zero behavior but does not mention that `health_snapshot` now also emits a `partition_absent` warning as a side effect. A caller reading only the docstring would not know the alarm exists. One sentence would close it. |
+| R1-4 | medium | exporter-untouched | metrics.py `render_metrics` | The alarm is wired into `health_snapshot` only. The Prometheus exporter path (`render_metrics`) does not call `health_snapshot` and gets no `partition_absent` signal — a deployment scraping `/api/metrics` but not `/api/health` sees nothing. This PR is scoped to `/api/health` (where the configured list is known) and that is a defensible single-concern boundary, but the gap should be named so it is a deliberate choice, not an oversight. |
+
+## Round 2 — Counter-Critique (downgrade scenario)
+
+**The false-alarm question.** The alert fires for any label in the configured list absent from the computed metrics. The task brief explicitly flagged the stop-condition: if a partition can be legitimately absent (an optional mount) and that is indistinguishable from a failure, do not emit. Checked: `_default_partitions()` returns exactly `root` and `output_data`, both intended mounts; `disk_partitions` overrides are an explicit `{label: path}` mapping the caller chose to pass. There is **no** "optional partition" flag anywhere in the data model — every configured label is, by construction, a mount Hydra was told to watch. An operator who does not want a partition watched simply does not configure it. So "configured but absent" is unambiguously alarm-worthy and there is no false-positive class to suppress. Stop-condition does not trigger.
+
+**Downgrade scenario — is a log line a strong enough alarm?** Counter-argument: the disk *subsystem* uses `_warn`/`_fail` status dicts that bubble into the top-level `status` field and flip the HTTP code to 503. `partition_absent` does none of that — a dropped `output_data` mount leaves overall `status` at `ok` and `/api/health` returning 200. One could argue the alarm is too weak: a load balancer or Docker HEALTHCHECK keying on the HTTP code will not notice. Verdict: **downgrade rejected, but narrowly.** Promoting an absent partition to `fail` would take the Jetson out of rotation for a non-root mount loss, which is heavier than warranted and changes existing HTTP-code semantics — out of scope and arguably wrong. A log line consumed by a log-shipping alert rule is the right tier for "a watched mount dropped." The honest gap is that the in-tree alarm story ends at the log line; a Prometheus `absent()` rule (already recommended as a follow-up in #253's register) is the production-grade consumer. Not gate-worthy for this PR, but the limitation is real.
+
+### Round 3
+
+**Shared framing of R1+R2:** *Both rounds treated `_alert_absent_partitions` as a self-contained emission and asked "is it noisy (R1-1), is it false-positive-prone (R2), is it documented (R1-3)." Both implicitly accepted that a `_log.warning` is the alarm. Neither round stepped outside the log-line frame to ask the orthogonal question: **alarms have lifecycle — fire, observe, clear — and a partition that comes back has no `partition_present`/recovery signal at all.** A mount that flaps drops a stream of `partition_absent` lines and then goes silent on recovery, indistinguishable from "the daemon stopped running."*
+
+**Named framing-break:** *the absent-detection is edge-blind — it detects a state, not a transition, and emits no recovery event, so a consumer cannot tell "mount still down" from "monitoring stopped" and cannot auto-resolve an alert when the mount returns.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | medium | no-recovery-event | health.py `_alert_absent_partitions` | The function emits only on the absent state. When the mount returns there is no `partition_recovered` / `partition_present` line. A log-based alert rule that opened an incident on `partition_absent` has nothing to auto-close it — the incident stays open until a human clears it, or the rule times out and silently drops it (then re-opens on the next absent tick). Pairing the emission with a once-per-transition recovery line would make the signal an actual edge, not a level. Follow-up. |
+| R3-2 | medium | warning-rate-compound | health.py + #253 R1-1 | #253 R1-1 already flagged the producer's once-per-tick `disk_probe` warning as noisy and recommended state-change emission. This PR adds a *second* once-per-tick line for the same condition. The two should be de-noised together with a shared per-label state cache — fixing only one leaves half the noise. The compounding was foreseeable from #253's own register and should be the single follow-up issue, not two. |
+| R3-3 | low | test-blind-to-transition | tests/test_observability.py `TestAbsentPartitionAlert` | Both new tests assert a *single* `health_snapshot` call's behavior (absent → 1 alert; all-valid → 0 alerts). Neither exercises the transition the feature exists for: present-tick → absent-tick → present-tick across successive calls. A test that calls `health_snapshot` three times with the path created/removed/recreated would lock the mid-mission-drop semantics and would also immediately expose the missing recovery event (R3-1). Follow-up. |
+
+### Consistency-bias callouts
+
+- **R1 ranked the exporter gap (R1-4) and the warning-rate (R1-1) both medium, but treated them as independent.** They are not: a deployment that scrapes `/api/metrics` only gets neither the alarm *nor* the noise — the gap and the noise are two ends of the same "which surface carries the signal" question. The honest framing is "the `partition_absent` signal lives only on `/api/health`; pick that surface deliberately or carry it on both."
+- **No round questioned the brief's claim that the alert mechanism is `_log.warning`.** It was taken as given because `observability/` genuinely has no alert object. That is correct for this PR, but the deeper truth surfaced in R2/R3-1 is that a log line is a *transport*, not an *alarm* — the alarm only exists once a log-shipping rule consumes it. The PR delivers the transport; the alarm proper is the `absent()` rule already on #253's follow-up register. The two follow-ups (#253 R3-1/R3-2 and this doc's R3-1) describe one coherent piece of unbuilt work: a proper partition-availability alert with edges and recovery.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | no-recovery-event | R3-1 | Absent-detection emits on state, not transition; no recovery line, so log-based incidents cannot auto-close. Add a once-per-transition recovery emission. | R3-1 | follow-up issue |
+| medium | warning-rate-compound | R3-2 / R1-1 | Producer (`disk_probe`) and consumer (`partition_absent`) each emit once per 10 s tick for the same absent path — twice the steady-state noise. De-noise both with a shared per-label state cache. | R1-1, R3-2 | follow-up issue |
+| medium | exporter-untouched | R1-4 | `partition_absent` is wired into `/api/health` only; `/api/metrics`-only deployments get no signal. Deliberate single-concern scope — name it or carry the signal on both surfaces. | R1-4 | accept (documented) |
+| low | test-blind-to-transition | R3-3 | New tests assert single-call behavior, not the present→absent→present transition the feature exists for. Add a multi-call transition test. | R3-3 | follow-up issue |
+| low | double-emission | R1-2 | Two distinct-prefix warnings per tick describe one fact; prefixes disambiguate. | R1-2 | accept |
+| low | docstring-coverage | R1-3 | `health_snapshot` docstring does not mention the `partition_absent` side-effect emission. Add one sentence. | R1-3 | nit |
+
+## Recommendation
+
+**No gates.** The change is correct, minimal, single-concern, and is precisely the consumer-side alarm PR #253's adversarial doc (R3-2) identified as unbuilt. `_partition_usage`'s omit+warn contract is untouched and the false-alarm stop-condition was checked and does not trigger — every configured partition is by construction expected. The real residual work — a transition-aware, recovery-emitting, de-noised partition-availability alert backed by a Prometheus `absent()` rule — is genuinely additional scope, not a defect in this PR, and should be filed as one consolidated follow-up issue against this merge commit alongside the still-open #253 register items.

--- a/hydra_detect/observability/health.py
+++ b/hydra_detect/observability/health.py
@@ -306,6 +306,39 @@ def compute_disk_bytes(
     return out
 
 
+def _alert_absent_partitions(
+    expected: tuple[tuple[str, str], ...],
+    present: Dict[str, Any],
+) -> None:
+    """Emit a structured warning for each expected partition label missing
+    from the computed disk metrics.
+
+    Issue #248 / PR #253 made ``_partition_usage`` omit a label (with a
+    ``disk_probe`` warning) when its path does not exist, instead of walking
+    up to an ancestor partition. That removed the silent-rewrite bug but left
+    a downstream gap: when a configured mount (e.g. ``output_data``) drops
+    mid-mission, its ``disk_free_pct`` series simply disappears and nothing
+    flags it. ``_partition_usage`` warns from the probe's point of view ("a
+    path was bad"); this function warns from the *config's* point of view
+    ("a partition we were told to watch is gone"), which is the signal an
+    operator actually alerts on.
+
+    Every label in the configured/expected list is, by construction, a mount
+    Hydra is told to watch — there is no "optional partition" marker in the
+    data model, so a configured-but-absent label is always alert-worthy.
+    Uses the same ``_log.warning`` structured-line mechanism the rest of
+    this module uses; the observability package has no separate alert object.
+    """
+    for label, path in expected:
+        if label not in present:
+            _log.warning(
+                "partition_absent: expected partition label missing from "
+                "disk metrics — configured mount may have dropped "
+                "label=%r path=%r",
+                label, path,
+            )
+
+
 def _worst(items: Dict[str, Dict[str, str]]) -> str:
     worst_rank = 0
     for v in items.values():
@@ -368,10 +401,24 @@ def health_snapshot(
     subsystems["audit"] = _safe_probe(_probe_audit, audit_sink)
     subsystems["disk"] = _safe_probe(lambda _r: _probe_disk(disk_path), None)
 
+    disk_free_pct = compute_disk_free(disk_partitions)
+    disk_bytes = compute_disk_bytes(disk_partitions)
+
+    # Consumer-side absent-partition detection (issue #248 follow-up). The
+    # producers above omit a label whose path is unreadable; here — where the
+    # configured/expected partition list is known — compare expected against
+    # present and warn for any expected label that dropped out, so a mount
+    # failure surfaces as an alert rather than a silently missing series.
+    if disk_partitions is None:
+        expected = _default_partitions()
+    else:
+        expected = tuple(disk_partitions.items())
+    _alert_absent_partitions(expected, disk_free_pct)
+
     return {
         "status": _worst(subsystems),
         "ts": time.time(),
         "subsystems": subsystems,
-        "disk_free_pct": compute_disk_free(disk_partitions),
-        "disk_bytes": compute_disk_bytes(disk_partitions),
+        "disk_free_pct": disk_free_pct,
+        "disk_bytes": disk_bytes,
     }

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -236,6 +236,69 @@ class TestHealthSnapshotDiskFreePct:
 
 
 # ---------------------------------------------------------------------------
+# Absent-partition alerting — issue #248 follow-up to PR #253.
+# PR #253 made a missing partition path OMIT its label (correct). This left a
+# gap: a configured mount that drops mid-mission just loses its disk_free_pct
+# series with nothing watching for it. health_snapshot now compares the
+# expected/configured label set against the present one and emits a
+# structured ``partition_absent`` warning per expected-but-absent label.
+# ---------------------------------------------------------------------------
+
+
+class TestAbsentPartitionAlert:
+    def test_expected_partition_missing_emits_alert(self, tmp_path, caplog):
+        # Configure two partitions: one valid (a real tmpdir) and one whose
+        # path does not exist. The bad label must be ABSENT from the metrics
+        # AND must produce a structured partition_absent warning.
+        valid = tmp_path / "valid"
+        valid.mkdir()
+        nonexistent = tmp_path / "does" / "not" / "exist"
+        with caplog.at_level(
+            logging.WARNING, logger="hydra_detect.observability.health",
+        ):
+            snap = health_snapshot(
+                stats={"camera_ok": True, "fps": 10.0},
+                disk_partitions={
+                    "good": str(valid),
+                    "dropped": str(nonexistent),
+                },
+            )
+        # Producer contract (PR #253) intact: bad label omitted, good present.
+        assert "dropped" not in snap["disk_free_pct"]
+        assert "good" in snap["disk_free_pct"]
+        # Consumer-side alert: a partition_absent warning naming the label.
+        alerts = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "partition_absent" in r.getMessage()
+        ]
+        assert len(alerts) == 1, [r.getMessage() for r in caplog.records]
+        assert "dropped" in alerts[0].getMessage()
+
+    def test_all_valid_partitions_emits_no_alert(self, tmp_path, caplog):
+        # Every configured partition resolves — no partition_absent warning.
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        with caplog.at_level(
+            logging.WARNING, logger="hydra_detect.observability.health",
+        ):
+            snap = health_snapshot(
+                stats={"camera_ok": True, "fps": 10.0},
+                disk_partitions={"a": str(a), "b": str(b)},
+            )
+        assert "a" in snap["disk_free_pct"]
+        assert "b" in snap["disk_free_pct"]
+        alerts = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING
+            and "partition_absent" in r.getMessage()
+        ]
+        assert alerts == [], [r.getMessage() for r in alerts]
+
+
+# ---------------------------------------------------------------------------
 # disk_bytes sibling field + partition-resolve hardening (issue #232)
 # Adversarial follow-ups R3-1, R3-3, R3-4, R1-5 on PR #227.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Follow-up to issue #248 / PR #253. PR #253 correctly stopped `_partition_usage` from rewriting a missing partition path to an existing ancestor — a missing mount now OMITS its label (with a `disk_probe` warning) rather than silently reporting the wrong partition. But that created a downstream gap: when a configured mount (e.g. `output_data`) drops mid-mission, its `disk_free_pct` series simply disappears and nothing watches for an expected-but-absent label, so a mount failure became silent instead of alarming. This PR adds consumer-side detection: `health_snapshot` resolves the expected/configured partition list the same way `compute_disk_free` does, compares it against the labels actually present in the computed metrics, and emits a structured `partition_absent` warning per missing expected label — using the module's existing `_log.warning` structured-line mechanism (the observability package has no separate alert object). `_partition_usage`'s omit+warn contract is left intact; the new alert lives in the caller that already knows the configured list.

## Test plan

- [x] `tests/test_observability.py` — new `TestAbsentPartitionAlert`: configured-but-missing partition is absent from metrics AND emits one `partition_absent` alert; all-valid partitions emit no alert.
- [x] Red/green proven: reverting the `health.py` change makes `test_expected_partition_missing_emits_alert` fail (0 alerts); restoring it passes.
- [x] `python -m pytest tests/test_observability.py -v` — 43 passed.
- [x] Full suite green except one pre-existing Windows-only failure (`test_config_api.py::test_post_config_writes_values`, atomic-rename `WinError 5`) that fails identically on clean `main` and is unrelated to this change.