### PR TITLE
fix(autonomy): warn on legacy config section, single-source section name

### DIFF
--- a/docs/adversarial/256.md
+++ b/docs/adversarial/256.md
@@ -1,0 +1,69 @@
+# Adversarial Analysis — PR #256 (followup/issue-247-autonomy-hardening)
+
+**Generated:** 2026-05-20T00:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/256
+**PR head:** 09b3879b30a0127fa616f234182b6f7339d9ff4f
+**Base:** main at 1a13e8cf
+**Diff size:** +107 / -6 across 3 files (hydra_detect/capability_status.py, hydra_detect/config_schema.py, tests/test_capability_status.py)
+
+## Summary
+
+- **Round 1:** 3 findings (0 high · 1 medium · 2 low). Pattern-match on the new logger, the constant, and whether the legacy-warning guard fires in exactly the intended cases.
+- **Round 2:** counter-critique with a downgrade scenario — what does an operator on a fielded SORCC unit actually see, and does the warning ever cry wolf.
+- **Round 3:** orthogonal sweep with a named framing-break — both prior rounds audited the cfg-fallback path in isolation and never asked whether the warning belongs there at all versus at config-load time.
+- **Consolidated:** 0 blockers · 0 gates · 3 follow-ups.
+
+## Round 1 — Pattern Match
+
+3 findings. This PR is the explicit close-out of #252's own deferred follow-ups (R1-1/R2-1 deprecation warning, R1-3/R3-1 schema-routing constant). The change is small and additive: a constant, an import, a guarded log line, two tests.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | log-placement | capability_status.py:302-320 | The legacy-section warning lives inside `build_system_state`, which the readiness page calls on a TTL-cached poll. The warning fires once per uncached `build_system_state` call, not once per process. On a unit with the misconfiguration, the operator gets a repeating WARNING in the app log every cache-expiry interval. That is noisy but arguably correct — the misconfig persists until they fix it — and the cache (see capability_api TTL) bounds the rate. Noted, not gated. |
+| R1-2 | low | import-coupling | capability_status.py:24 | `capability_status.py` now imports from `config_schema.py` at module load. config_schema imports only stdlib, so there is no cycle today. If config_schema ever grows an import back into capability_status (unlikely — schema is a leaf), this becomes a circular import. Low probability; the dependency direction (status reads schema) is the natural one. |
+| R1-3 | low | constant-scope | config_schema.py:14 | Only the `[autonomous]` section name was promoted to a constant. The same drift class exists for every other section literal hardcoded across `facade.py` (~20 reads), `config_api.py`, and the settings JS. This PR deliberately scoped to the one section #247 touched; the broader single-sourcing is a separate, larger change and correctly out of scope here. |
+
+## Round 2 — Counter-Critique
+
+**Challenged:** R1-1. Is the repeating-log concern real, or is it the desired behavior? Worked the downgrade scenario.
+
+**Downgrade scenario.** Take the unit class #252's own R2 identified as the only one where the back-compat tail bites: an early-development bench unit with a literal `[autonomy]` section in `config.ini` and **no** `autonomy_ref` wired (so the cfg-fallback path runs). Pre-this-PR that unit silently reported autonomy BLOCKED with no explanation. Post-this-PR the operator gets a specific WARNING naming the legacy section and telling them to rename it. That is a strict improvement — the "noise" in R1-1 is a true positive that recurs precisely because the misconfig recurs. The warning cannot cry wolf: the guard is `has_section("autonomy") and not has_section("autonomous")`, so a unit with the canonical section never trips it, and a unit with *both* sections also never trips it (canonical present). The only false-ish case is a config that legitimately has neither autonomy section — that does not trip the guard either. Conclusion: R1-1 stands as a noted-not-gated observation; no downgrade.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | low | warn-vs-fix | capability_status.py:310 | The warning tells the operator to rename the section but the code does not auto-migrate. That is the right call for a status evaluator (it must not mutate operator config), but it means the warning will recur until a human acts. A future config-migration pass (config_migrate.py) is the correct home for an actual rename — out of scope here. |
+| R2-2 | low | partial-section | capability_status.py:302 | The guard treats section *presence* as binary. A config with `[autonomous]` present but empty (no keys) suppresses the warning even though the operator's tuned values — if they live in a stray `[autonomy]` — are still ignored. Edge case; an empty canonical section is itself unusual and would surface as autonomy-disabled in the report. Not worth guarding. |
+
+## Round 3 — Orthogonal Sweep
+
+### Round 3
+
+**Framing-break — "the warning is in the wrong layer."** Both R1 and R2 audited the warning *as placed* — inside `build_system_state`, on the readiness-poll path. Neither asked the orthogonal question: the canonical place to detect a stale config section is at config *load/validation* time, not on every status poll. `config_schema.py` already has `validate_config()` which walks every section and emits `result.warnings` for unknown sections — a legacy `[autonomy]` section already produces an "unknown section" style signal there (via the unknown-key path on its contents, though not a section-level message). The status-page warning is therefore a *second* detection of the same fault, in a noisier location. This PR's placement is defensible (it warns exactly where the silent-default behavior happens, which is pedagogically clear) and matches #252's own R2-1 recommendation verbatim — but a reviewer should know the schema-validation layer is the more durable home, and that this is a knowingly-pragmatic placement, not an oversight.
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R3-1 | medium | layering | config_schema.py / capability_status.py | The more durable fix for legacy-section detection is a section-level "unknown/legacy section" warning in `validate_config()`, surfaced once at boot through the facade's existing `validation.warnings` loop. The status-poll warning added here is correct but is the second-best layer. Follow-up: add a known-legacy-section list to `config_schema.py` so `validate_config` flags `[autonomy]` at load time. |
+| R3-2 | low | constant-test | tests/test_capability_status.py | The new tests assert the *warning behavior* but no test asserts `SECTION_AUTONOMOUS == "autonomous"` or that `SCHEMA` is keyed by it. If someone edits the constant value, the schema dict and every cfg read move together (good) — but a typo'd constant would pass silently until an integration test caught it. A one-line `assert SECTION_AUTONOMOUS in SCHEMA` test would pin it. |
+| R3-3 | nit | message-precision | capability_status.py:311-316 | The warning text says values "will fall to defaults (disabled, no geofence)". It does not mention `mode` also falls to `dryrun`. Minor — the two named defaults are the operationally significant ones and listing every field would bloat the line. |
+
+### Consistency-bias callouts
+
+- **R1 and R2 both accepted the warning's placement because it matches #252's R2-1 recommendation.** R3-1 deliberately breaks that frame: "the prior PR recommended it" is provenance, not correctness. The recommendation was sound for closing #247 cheaply; it is not the architecturally durable layer. Flagged so the layering follow-up is not lost the way #252's follow-ups nearly were.
+- The PR is itself the close-out of deferred follow-ups. There is a mild risk of treating "we are paying down #252's debt" as proof the new code incurs none. R3-1 and R3-2 are the new debt items.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | layering | R3-1 | Legacy-section detection is more durable in `validate_config()` at config-load time than on the status poll. Add a known-legacy-section list to config_schema. | R3-1 | follow-up issue |
+| low | constant-test | R3-2 | Add `assert SECTION_AUTONOMOUS in SCHEMA` so a typo'd constant fails fast. | R3-2 | follow-up issue |
+| low | constant-scope | R1-3 | The other ~20 section literals in facade.py/config_api.py remain hardcoded. Single-source them in a later pass. | R1-3 | follow-up issue |
+
+## Recommendation
+
+**No gates.** Merge after CI passes. The change is small, additive, and closes #252's own deferred R1-1/R2-1 (legacy warning) and R1-3/R3-1 (schema-routing constant). Red/green is proven — the legacy-warning regression test fails without the source change. The full suite shows zero new failures versus clean main (45 failed on the branch vs. 46 on main; the delta is the pre-existing Windows-only permission failures in `test_config_api.py`, `test_zero_touch.py`, and `test_vocabulary.py`, all of which reproduce on a clean main checkout). The three follow-ups — schema-layer legacy detection (R3-1), the constant-pinning test (R3-2), and tree-wide section single-sourcing (R1-3) — are each larger than this PR's one-concern scope and are intentionally deferred.

--- a/hydra_detect/capability_status.py
+++ b/hydra_detect/capability_status.py
@@ -13,12 +13,17 @@ Issue #146 — skeleton. Real ARMED gating follows #147.
 
 from __future__ import annotations
 
+import logging
 import shutil
 import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
+
+from hydra_detect.config_schema import SECTION_AUTONOMOUS
+
+logger = logging.getLogger(__name__)
 
 
 # ── Status levels ────────────────────────────────────────────────────────────
@@ -300,20 +305,50 @@ def build_system_state(
             pass
     elif cfg is not None:
         try:
-            mode_raw = cfg.get("autonomous", "mode", fallback="dryrun").strip().lower()
+            # Legacy-config guard (#247 / PR #252). The canonical schema
+            # section is [autonomous]; an early-development config.ini may
+            # carry a stale [autonomy] section. When the legacy section is
+            # present and the canonical one is absent, the reads below all
+            # fall to defaults — warn the operator instead of silently
+            # disabling autonomy on a unit they tuned.
+            try:
+                has_legacy = cfg.has_section("autonomy")
+                has_canonical = cfg.has_section(SECTION_AUTONOMOUS)
+            except Exception:
+                has_legacy = has_canonical = False
+            if has_legacy and not has_canonical:
+                logger.warning(
+                    "Config has a legacy [autonomy] section but no "
+                    "[%s] section — autonomy settings will fall to "
+                    "defaults (disabled, no geofence). Rename the section "
+                    "to [%s] to restore your tuned values.",
+                    SECTION_AUTONOMOUS, SECTION_AUTONOMOUS,
+                )
+
+            mode_raw = cfg.get(
+                SECTION_AUTONOMOUS, "mode", fallback="dryrun",
+            ).strip().lower()
             if mode_raw in ("dryrun", "shadow", "live"):
                 state.autonomy_mode = mode_raw
-            enabled_raw = cfg.get("autonomous", "enabled", fallback="false").strip()
+            enabled_raw = cfg.get(
+                SECTION_AUTONOMOUS, "enabled", fallback="false",
+            ).strip()
             state.autonomy_enabled = enabled_raw.lower() in ("1", "true", "yes")
             # Geofence presence: any non-zero centre, or a polygon with 3+ pts.
-            poly_raw = cfg.get("autonomous", "geofence_polygon", fallback="").strip()
+            poly_raw = cfg.get(
+                SECTION_AUTONOMOUS, "geofence_polygon", fallback="",
+            ).strip()
             if poly_raw:
                 pts = [p for p in poly_raw.split(";") if "," in p]
                 state.autonomy_geofence_present = len(pts) >= 3
             if not state.autonomy_geofence_present:
                 try:
-                    lat = float(cfg.get("autonomous", "geofence_lat", fallback="0").strip())
-                    lon = float(cfg.get("autonomous", "geofence_lon", fallback="0").strip())
+                    lat = float(cfg.get(
+                        SECTION_AUTONOMOUS, "geofence_lat", fallback="0",
+                    ).strip())
+                    lon = float(cfg.get(
+                        SECTION_AUTONOMOUS, "geofence_lon", fallback="0",
+                    ).strip())
                     state.autonomy_geofence_present = (lat != 0.0 or lon != 0.0)
                 except (ValueError, TypeError):
                     pass

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -11,6 +11,13 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+# Canonical config section names. Defined once here so callers that read
+# config sections by name (e.g. capability_status.py) do not re-hardcode the
+# literal and re-drift if the schema is renamed. See issue #247 / PR #252 —
+# the [autonomy] vs [autonomous] mismatch is exactly the drift this prevents.
+SECTION_AUTONOMOUS = "autonomous"
+
+
 class FieldType(Enum):
     BOOL = "bool"
     INT = "int"
@@ -466,7 +473,7 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             description="Dashboard color theme (locked to lattice)",
         ),
     },
-    "autonomous": {
+    SECTION_AUTONOMOUS: {
         "enabled": FieldSpec(
             FieldType.BOOL,
             default=False,

--- a/tests/test_capability_status.py
+++ b/tests/test_capability_status.py
@@ -1179,6 +1179,65 @@ class TestBuildSystemStateExtensions:
 
 
 # ---------------------------------------------------------------------------
+# Legacy config section warning (#247 follow-up — R1-1 / R2-1 / R2-2)
+# ---------------------------------------------------------------------------
+
+class TestLegacyAutonomySectionWarning:
+    """A config carrying the pre-schema [autonomy] section name (instead of
+    the canonical [autonomous]) silently falls to defaults on the cfg
+    fallback path. build_system_state must warn the operator so they know
+    their tuned values are not being read."""
+
+    def test_warns_on_legacy_autonomy_section(self, caplog):
+        """Legacy [autonomy] present, canonical [autonomous] absent — warn."""
+        import configparser
+        from hydra_detect.capability_status import build_system_state
+
+        cfg = configparser.ConfigParser()
+        cfg.read_dict({
+            "autonomy": {
+                "enabled": "true",
+                "mode": "live",
+                "geofence_lat": "34.123",
+                "geofence_lon": "-118.456",
+            },
+        })
+        with caplog.at_level("WARNING", logger="hydra_detect.capability_status"):
+            state = build_system_state(cfg=cfg, autonomy_ref=None)
+
+        # Operator gets told the section name is stale.
+        assert any(
+            "legacy [autonomy]" in rec.message and rec.levelname == "WARNING"
+            for rec in caplog.records
+        ), caplog.text
+        # And the reads still fell to defaults — the warning is accurate.
+        assert state.autonomy_enabled is False
+        assert state.autonomy_geofence_present is False
+
+    def test_no_warning_on_canonical_autonomous_section(self, caplog):
+        """Canonical [autonomous] present — no legacy warning, values read."""
+        import configparser
+        from hydra_detect.capability_status import build_system_state
+
+        cfg = configparser.ConfigParser()
+        cfg.read_dict({
+            "autonomous": {
+                "enabled": "true",
+                "mode": "live",
+                "geofence_lat": "34.123",
+                "geofence_lon": "-118.456",
+            },
+        })
+        with caplog.at_level("WARNING", logger="hydra_detect.capability_status"):
+            state = build_system_state(cfg=cfg, autonomy_ref=None)
+
+        assert not any(
+            "legacy [autonomy]" in rec.message for rec in caplog.records
+        ), caplog.text
+        assert state.autonomy_enabled is True
+
+
+# ---------------------------------------------------------------------------
 # Placeholder capabilities — Drop, RF Hunt
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #247 / PR #252. PR #252 corrected `capability_status.py` to read the canonical `[autonomous]` config section instead of the misnamed `[autonomy]`, but left two loose ends flagged in its own adversarial review (R1-1/R2-1, R1-3/R3-1). This PR closes both: `build_system_state` now emits a `logger.warning` when a config carries a stale `[autonomy]` section and no canonical `[autonomous]` section, so operators of early-development units are told their tuned autonomy values are falling to defaults rather than being read; and the section name is now a single-source constant `SECTION_AUTONOMOUS` in `config_schema.py` (which also keys its own `SCHEMA` dict with it), imported by `capability_status.py` so the literal is no longer duplicated and cannot re-drift. Adds two regression tests in `tests/test_capability_status.py` — red/green proven: the legacy-warning test fails without the source change. Full suite shows zero new failures vs. main (the remaining failures in `test_config_api.py`, `test_zero_touch.py`, `test_vocabulary.py` are pre-existing Windows env permission issues that reproduce on clean main).