### PR TITLE
test(safety): cover RC-switch strike paths for FW refusal guard

### DIFF
--- a/docs/adversarial/257.md
+++ b/docs/adversarial/257.md
@@ -1,0 +1,82 @@
+# Adversarial Analysis — PR #257 (followup/issue-246-rc-strike-coverage)
+
+**Generated:** 2026-05-20T00:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/257
+**PR head:** 9fe8045
+**Base:** main at 1a13e8c
+**Diff size:** +129 / -0 across 1 file (tests/test_fw_profile.py)
+**Follow-up to:** #254 — addresses the #246 coverage gap
+
+## Summary
+
+- **Round 1 (pattern-match):** 3 findings (0 high · 1 medium · 2 low). This PR is the exact R3-1 follow-up the #254 adversarial doc recommended: an integration test for the RC-switch / MAVLink `on_strike` callback path. It mirrors `TestFWPipelineRefusal._make_pipeline` and the `MAVLinkIO` command-listener harness from `test_mavlink_commands.py`. Test-only — no production diff.
+- **Round 2 (counter-critique with downgrade scenario):** 2 second-order findings. Considered the downgrade "this is a redundant test — the guard already runs regardless of caller, so direct-call coverage is enough." Rejected: the threat is a future refactor of the callback wiring, which a direct-call test cannot catch.
+- **Round 3 (orthogonal sweep — framing break):** *Both prior rounds treated "RC switch" as synonymous with the MAVLink command listener. Named framing-break: the RC switch never speaks to the companion computer directly. The mapping from a physical switch position to a Hydra strike command lives in autopilot Lua / GCS scripting, off-board of this repo. This PR tests the on-board half of the path and labels it "RC-switch," which is accurate for what the repo can test but should not be read as end-to-end RC coverage.*
+
+## Round 1 — Pattern Match
+
+The diff adds one test class, `TestFWStrikeViaRCSwitchPaths`, with five tests and three small helpers. It is guarded by the same `_skip_no_fcntl` marker as `TestFWPipelineRefusal` and reuses that class's `_make_pipeline` static method directly. The MAVLink side reuses the `MAVLinkIO(connection_string="/dev/null")` + `MagicMock` `_mav` pattern from `tests/test_mavlink_commands.py`.
+
+The wiring under test:
+
+```
+mav.set_command_callbacks(on_strike=pipeline._handle_strike_command)
+mav._handle_command_long(CMD_STRIKE msg, audit)   # COMMAND_LONG path
+mav._handle_named_value_int(NV_STRIKE msg, audit)  # NAMED_VALUE_INT path
+```
+
+This is the real `MAVLinkIO` command listener calling the real FW-profile `_handle_strike_command`. The guard `_refuse_approach_for_fw("strike")` runs inside that callback, so the test exercises the integration, not a mock.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | red-green-proof-not-in-CI | tests/test_fw_profile.py | The PR description claims red/green was verified by temporarily removing the guard. That verification was done locally by also temporarily disabling the `_skip_no_fcntl` marker on Windows; CI never sees the RED state. The five tests are skipped on win32 and only execute on Linux CI — where they will pass — so CI proves GREEN but not that the tests are meaningful. Mitigation: the red/green transcript is in the PR thread and the test asserts a `MAV_RESULT_FAILED` ack, which a no-op guard cannot produce. Acceptable, but the proof-of-meaningfulness lives outside CI. |
+| R1-2 | low | helper-duplication | tests/test_fw_profile.py | `_command_long` / `_named_value_int` re-implement `_make_command_long_msg` / `_make_named_value_int_msg` from `test_mavlink_commands.py` instead of importing them. Keeps `test_fw_profile.py` self-contained (matches its existing convention of inlining fixtures) but duplicates MAVLink message-shape knowledge across two files. If the message contract changes, two files need editing. Nit. |
+| R1-3 | low | reach-path-count | tests/test_fw_profile.py | The #254 doc cited four `on_strike` registration sites (TAK input, MAVLink command callbacks, MAVLink reconnect, autonomous evaluate). This PR exercises the MAVLink command-listener path. The TAK and autonomous paths funnel into the same `_handle_strike_command` and are out of scope here, but the test class docstring says "the RC-switch strike paths" (plural) — slightly broader than what is covered. The guard runs regardless of caller, so the safety claim holds; the wording just over-promises. |
+
+## Round 2 — Counter-Critique
+
+**Downgrade scenario considered:** *what if this test is redundant?* The #254 guard is a single early-return at the top of `_handle_strike_command`. It runs for every caller — direct, web, MAVLink command, TAK, autonomous. `TestFWPipelineRefusal.test_fw_refuses_strike_command` already proves the guard refuses. So why add five more tests for a code path that, by construction, cannot bypass a guard at the function's first line?
+
+**Rejected as a real concern.** The value is not "does the guard fire today" — it is "will a future change to the callback wiring silently re-open FW engagement." The #254 R3-1 finding spelled out the exact failure mode: a refactor that wraps `_handle_strike_command` in a class or adapter that strips `self`, or that registers a different handler for the MAVLink path. A direct-call test passes through all of that. An integration test that goes `set_command_callbacks(on_strike=...)` -> `_handle_command_long` -> callback catches a broken registration. The test is a regression tripwire on the wiring, not a re-test of the guard. That is exactly what #254's adversarial doc asked for and is not redundant.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | low | ack-assertion-asymmetry | tests/test_fw_profile.py | `test_fw_refuses_strike_via_command_long` asserts the `MAV_RESULT_FAILED` (4) ack; `test_fw_refuses_strike_via_named_value_int` does not assert any ack — correct, because `_handle_named_value_int` sends no `COMMAND_ACK` (it is fire-and-forget). The asymmetry is intentional and matches `mavlink_io.py`, but a future reader may mistake it for an oversight. A one-line comment on the NV test would prevent that. Nit. |
+| R2-2 | low | drone-regression-only | tests/test_fw_profile.py | The regression tests cover FW (refuse) and drone (allow) through the RC path, but not USV/UGV. The #254 doc raised the same `R2-2` symmetry point for the direct path. UGV is an effector platform; a UGV strike via the MAVLink command path should still succeed. Not load-bearing — the FW gate is the safety contract and drone proves the allow-path is intact — but a UGV case would fully mirror the sibling-handler regression set. |
+
+## Round 3 — Orthogonal Sweep
+
+**Framing break — "the RC switch is off-board":** *R1 and R2 both accepted the PR's framing that `_handle_command_long(CMD_STRIKE)` and `_handle_named_value_int(NV_STRIKE)` ARE "the RC-switch path." They are not — they are the on-board terminus of it.* A physical switch on the RadioMaster transmitter produces an RC channel PWM value. ArduPilot receives that as an `RC_CHANNELS` value. Nothing in this repo turns an `RC_CHANNELS` value into a `CMD_STRIKE` `COMMAND_LONG` — that translation is autopilot-side Lua scripting or a GCS macro, neither of which lives in the Hydra repo. `mavlink_io.py` even caches `RC_CHANNELS` (`_rc_channels`) but no Hydra code maps a channel to a strike. So the true end-to-end RC path is: transmitter switch -> ELRS link -> autopilot RC input -> **autopilot Lua** -> `COMMAND_LONG`/`NAMED_VALUE_INT` -> Hydra. This PR tests the last hop. That is the correct and only hop the repo CAN test, and the coverage is genuinely valuable — but the doc and PR title should not let a reader believe a flipped switch is proven refused end-to-end. The unmodeled link is the Lua/GCS layer.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **medium** | **off-board-gap** | tests/test_fw_profile.py + (no repo file) | The transmitter-switch-to-MAVLink-command mapping is off-board (autopilot Lua / GCS). This PR cannot and does not test it. If a SORCC FW airframe is fielded with a Lua script that emits `CMD_STRIKE`, the Hydra side now provably refuses — but a misconfigured Lua script that emits a *different* command (e.g. raw `command_guided_to` via `MAV_CMD_NAV_WAYPOINT`, or a mode change) bypasses `_handle_strike_command` entirely and Hydra never sees it as a "strike." That is an autopilot-config concern, not a Hydra-code concern, but it is the residual risk the title "cover RC-switch strike paths" papers over. **Follow-up:** a one-page note in `docs/` stating that FW strike-refusal is guaranteed only for strikes routed through `CMD_STRIKE`/`NV_STRIKE`, and that FW airframe Lua/GCS configs must not expose other engagement primitives. Not a merge gate. |
+| R3-2 | low | autonomous-path-uncovered | tests/test_fw_profile.py + facade.py:1754 | `on_strike` is also passed to `self._autonomous.evaluate(...)` (facade.py:1754). An autonomous controller that decides to strike calls the same `_handle_strike_command` and is therefore also refused on FW — but no test exercises that path. FW config already disables autonomy (`autonomous.enabled` not in `default_features`), so this is defence-in-depth, not a live gap. Worth a one-line test if the autonomous evaluate path is ever cheaply mockable. |
+| R3-3 | low | skip-marker-coupling | tests/test_fw_profile.py | The new class inherits `TestFWPipelineRefusal._make_pipeline` by direct cross-class reference (`TestFWPipelineRefusal._make_pipeline("fw")`). Both classes carry `@_skip_no_fcntl`, so they skip together — fine today. But if someone splits the file or removes the marker from one class only, `TestFWStrikeViaRCSwitchPaths` would call a method on a class that may not have collected. A module-level `_make_fw_pipeline` helper would decouple them. Nit, matches the file's existing inline-fixture style. |
+
+### Consistency-bias callouts
+
+- **R1 and R2 accepted "RC-switch path" at face value** because the PR, the issue (#246), and the #254 adversarial doc all use that phrase. The phrase is load-bearing shorthand for "the MAVLink `on_strike` callback path" — but a literal reading implies physical-switch coverage the repo cannot provide. R3-1 is only visible once you refuse the shared vocabulary and trace where an RC switch value actually becomes a strike command.
+- This PR is itself the remediation of #254's R3-1 finding. There is a mild closing-the-loop bias: it is satisfying to mark a prior follow-up "done," which can make a reviewer under-scrutinise whether the new test fully covers the threat. It covers the on-board hop well; it does not (and cannot) cover the off-board hop. Recording that explicitly so the loop is closed honestly.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | off-board-gap | R3-1 | The transmitter-switch-to-MAVLink-command mapping is autopilot-side and untestable from this repo. FW strike-refusal is proven only for strikes routed through `CMD_STRIKE`/`NV_STRIKE`. A Lua/GCS misconfig emitting a different primitive bypasses `_handle_strike_command`. | R3-1 | **follow-up doc note, not a merge gate** |
+| medium | red-green-proof-not-in-CI | R1-1 | Red/green was proven locally by disabling the win32 skip; CI only ever sees GREEN. The `MAV_RESULT_FAILED` ack assertion is a structural safeguard a no-op guard cannot satisfy. | R1-1 | none — transcript in PR thread |
+| low | autonomous-path-uncovered | R3-2 | The `on_strike` autonomous-evaluate registration (facade.py:1754) is not exercised; FW disables autonomy so it is defence-in-depth. | R3-2 | nit |
+| low | drone-regression-only | R2-2 | No USV/UGV regression through the RC path; FW + drone are sufficient for the safety contract. | R2-2 | nit |
+| low | ack-assertion-asymmetry | R2-1 | NV test asserts no ack (correct — NV is fire-and-forget) but lacks a comment explaining why. | R2-1 | nit |
+| low | helper-duplication | R1-2 | `_command_long`/`_named_value_int` duplicate helpers from `test_mavlink_commands.py`. | R1-2 | nit |
+| low | reach-path-count | R1-3 | Class docstring says "paths" (plural); covers the MAVLink command-listener path, not the TAK/autonomous registrations. | R1-3 | nit |
+| low | skip-marker-coupling | R3-3 | Cross-class reference to `TestFWPipelineRefusal._make_pipeline` couples the two classes' skip behaviour. | R3-3 | nit |
+
+## Recommendation
+
+**No merge gates.** This PR is test-only, mirrors the established `TestFWPipelineRefusal` and `test_mavlink_commands.py` patterns, and is the direct remediation of the #254 R3-1 finding. The five tests prove that a strike fired through the real `MAVLinkIO` command listener with a real FW-profile `_handle_strike_command` registered as `on_strike` is refused end-to-end on the on-board hop: no GUIDED nav, no servo fire, no lock, and a `MAV_RESULT_FAILED` ack back to the radio. Red/green was verified locally (three FW-refusal tests fail with the guard removed; drone regressions stay green; all five pass with the guard restored).
+
+One follow-up worth filing as a separate issue:
+
+1. **R3-1** — A short `docs/` note scoping the FW strike-refusal guarantee: it holds for strikes routed through `CMD_STRIKE`/`NV_STRIKE`, and FW airframe autopilot Lua / GCS configs must not expose other engagement primitives that bypass `_handle_strike_command`. This closes the off-board half of the threat surface with documentation, since code in this repo cannot reach it.

--- a/tests/test_fw_profile.py
+++ b/tests/test_fw_profile.py
@@ -345,6 +345,135 @@ class TestFWPipelineRefusal:
 
 
 @_skip_no_fcntl
+class TestFWStrikeViaRCSwitchPaths:
+    """Follow-up to PR #254 / issue #246: cover the RC-switch strike paths.
+
+    PR #254 added the FW refusal guard to ``_handle_strike_command`` and
+    proved it on the DIRECT call path. ``_handle_strike_command`` is also
+    bound to the ``on_strike`` callback of MAVLinkIO (facade.py wires it in
+    ``set_command_callbacks``). An RC switch flipped on the pilot's radio is
+    delivered to the companion computer as a MAVLink command — either a
+    COMMAND_LONG (MAV_CMD_USER_2 / CMD_STRIKE) or a NAMED_VALUE_INT
+    (HYDRA_STK / NV_STRIKE) — which MAVLinkIO routes into that callback.
+
+    These tests drive a strike through the real MAVLinkIO command listener
+    with a real FW-profile ``_handle_strike_command`` as the registered
+    callback, and assert the strike is refused end-to-end: no GUIDED nav,
+    no servo fire, no lock, and a FAILED ack back to the radio.
+    """
+
+    @staticmethod
+    def _wire_mavlink_to_pipeline(pipeline):
+        """Build a MAVLinkIO with the pipeline's strike handler registered.
+
+        Mirrors facade.py: ``set_command_callbacks(on_strike=p._handle_
+        strike_command, ...)``. The pipeline's own ``_mavlink`` MagicMock
+        stays in place so the strike handler can still attempt (and we can
+        assert it does NOT attempt) a GUIDED command.
+        """
+        from unittest.mock import MagicMock
+        from hydra_detect.mavlink_io import MAVLinkIO
+
+        mav = MAVLinkIO(connection_string="/dev/null", baud=115200)
+        mav._mav = MagicMock()
+        mav._mav.mav = MagicMock()
+        mav.set_command_callbacks(on_strike=pipeline._handle_strike_command)
+        return mav
+
+    @staticmethod
+    def _command_long(command: int, param1: float) -> "object":
+        from unittest.mock import MagicMock
+        msg = MagicMock()
+        msg.get_type.return_value = "COMMAND_LONG"
+        msg.command = command
+        msg.param1 = param1
+        return msg
+
+    @staticmethod
+    def _named_value_int(name: str, value: int) -> "object":
+        from unittest.mock import MagicMock
+        msg = MagicMock()
+        msg.get_type.return_value = "NAMED_VALUE_INT"
+        msg.name = name
+        msg.value = value
+        return msg
+
+    def test_fw_refuses_strike_via_command_long(self):
+        """RC switch -> COMMAND_LONG (CMD_STRIKE) is refused on FW."""
+        import logging
+        p = TestFWPipelineRefusal._make_pipeline("fw")
+        mav = self._wire_mavlink_to_pipeline(p)
+
+        msg = self._command_long(mav.CMD_STRIKE, param1=3.0)
+        mav._handle_command_long(msg, logging.getLogger("hydra.audit"))
+
+        # Strike must not reach the autopilot or the servo.
+        p._mavlink.command_guided_to.assert_not_called()
+        p._servo_tracker.fire_strike.assert_not_called()
+        # No lock set on refusal.
+        assert p._locked_track_id is None
+        # Radio gets a FAILED ack (MAV_RESULT_FAILED == 4), not ACCEPTED.
+        mav._mav.mav.command_ack_send.assert_called_once_with(
+            mav.CMD_STRIKE, 4,
+        )
+
+    def test_fw_refuses_strike_via_named_value_int(self):
+        """RC switch -> NAMED_VALUE_INT (NV_STRIKE) is refused on FW."""
+        import logging
+        p = TestFWPipelineRefusal._make_pipeline("fw")
+        mav = self._wire_mavlink_to_pipeline(p)
+
+        msg = self._named_value_int(mav.NV_STRIKE, 3)
+        mav._handle_named_value_int(msg, logging.getLogger("hydra.audit"))
+
+        p._mavlink.command_guided_to.assert_not_called()
+        p._servo_tracker.fire_strike.assert_not_called()
+        assert p._locked_track_id is None
+
+    def test_fw_strike_via_command_long_emits_audit_log(self, caplog):
+        """RC-triggered strike refusal still lands on hydra.audit."""
+        import logging
+        p = TestFWPipelineRefusal._make_pipeline("fw")
+        mav = self._wire_mavlink_to_pipeline(p)
+
+        with caplog.at_level(logging.INFO, logger="hydra.audit"):
+            msg = self._command_long(mav.CMD_STRIKE, param1=3.0)
+            mav._handle_command_long(msg, logging.getLogger("hydra.audit"))
+
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "FW_PROFILE_REFUSED" in joined
+        assert "strike" in joined
+
+    def test_drone_strike_via_command_long_still_runs(self):
+        """Regression: drone profile still strikes through the RC-switch path."""
+        import logging
+        p = TestFWPipelineRefusal._make_pipeline("drone")
+        mav = self._wire_mavlink_to_pipeline(p)
+
+        msg = self._command_long(mav.CMD_STRIKE, param1=3.0)
+        mav._handle_command_long(msg, logging.getLogger("hydra.audit"))
+
+        p._mavlink.command_guided_to.assert_called_once()
+        p._servo_tracker.fire_strike.assert_called_once()
+        # Radio gets an ACCEPTED ack (MAV_RESULT_ACCEPTED == 0).
+        mav._mav.mav.command_ack_send.assert_called_once_with(
+            mav.CMD_STRIKE, 0,
+        )
+
+    def test_drone_strike_via_named_value_int_still_runs(self):
+        """Regression: drone profile still strikes via NAMED_VALUE_INT."""
+        import logging
+        p = TestFWPipelineRefusal._make_pipeline("drone")
+        mav = self._wire_mavlink_to_pipeline(p)
+
+        msg = self._named_value_int(mav.NV_STRIKE, 3)
+        mav._handle_named_value_int(msg, logging.getLogger("hydra.audit"))
+
+        p._mavlink.command_guided_to.assert_called_once()
+        p._servo_tracker.fire_strike.assert_called_once()
+
+
+@_skip_no_fcntl
 class TestFWHelpers:
     """Direct tests for the FW gating helpers."""
 


### PR DESCRIPTION
## Summary

Follow-up to PR #254, which added the fixed-wing refusal guard at the top of `_handle_strike_command` and proved it on the **direct** call path. `_handle_strike_command` is also bound to the `MAVLinkIO` `on_strike` callback in `facade.py` — the path an RC switch on the pilot's radio takes when its `COMMAND_LONG` (`MAV_CMD_USER_2` / `CMD_STRIKE`) or `NAMED_VALUE_INT` (`HYDRA_STK` / `NV_STRIKE`) reaches the companion computer. This PR adds `TestFWStrikeViaRCSwitchPaths`, which drives a strike through the real `MAVLinkIO` command listener with a real FW-profile `_handle_strike_command` registered as `on_strike`, and asserts the strike is refused end-to-end on a fixed-wing platform: no GUIDED nav, no servo fire, no lock set, and a `MAV_RESULT_FAILED` ack returned to the radio. Drone-profile regression tests confirm the RC-switch path still strikes on effector platforms. This is test-only — production code is unchanged. Verified meaningful via red/green: temporarily removing the guard fails the three FW-refusal assertions; restoring it passes all five. Addresses the coverage gap left by #246/#254.

## Test plan

- [ ] `pytest tests/test_fw_profile.py -v` green on Linux CI (5 new tests in `TestFWStrikeViaRCSwitchPaths`)
- [ ] Full suite `pytest -x -q` green on Linux CI