### PR TITLE
test: make Windows-incompatible tests skip or portable

### DIFF
--- a/docs/adversarial/258.md
+++ b/docs/adversarial/258.md
@@ -1,0 +1,76 @@
+# Adversarial Analysis — PR #258 (followup/windows-test-suite-hygiene)
+
+**Generated:** 2026-05-20T00:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/258
+**PR head:** ba8d420e1acc956ecd331dfcafca59d298a7b6e3
+**Base:** main at b0a91cd
+**Diff size:** +146 / -36 across 12 files, all under `tests/`
+
+## Summary
+
+- **Round 1:** 4 findings (0 high · 3 medium · 1 low). Pattern-match against the repo's existing `_skip_on_windows` precedent in `tests/test_config_api.py` and against how the suite already handles platform-incompatible code.
+- **Round 2:** 1 downgrade scenario — does a `skipif(win)` mark hide a real regression that would otherwise have been caught, by silencing the test on the only platform a developer runs locally?
+- **Round 3:** 3 findings, framing identified — *both prior rounds audited the marks one test file at a time and asked "is this skip honest." Neither asked what the aggregate effect of 35 new Windows skips does to the developer's local signal: how much of the config/mode/kismet write surface is now completely unverified on the one platform most pre-commit runs happen on.*
+
+## Round 1 — Pattern Match
+
+The change matches the dominant pattern already in the repo. `tests/test_config_api.py` defined `_skip_on_windows` with the exact rationale this PR reuses ("write_config flock pattern incompatible with Windows os.replace ... production target is Jetson/Linux"). This PR applies that established, maintainer-blessed pattern consistently to the sibling tests that exercise the same write path but were never marked. The bucket-C encoding fixes (`encoding="utf-8"` on `read_text`) are the textbook portable-I/O fix and match `test_easter_loads_before_main`, which already reads `base.html` with explicit `encoding="utf-8"`.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | skip-creep | test_operating_mode.py, test_config_freeze.py, test_zero_touch.py | The PR adds 35 Windows skips. Each is individually justified, but a future test that genuinely regresses the config-write path on Linux can now be authored, marked `@_skip_on_windows` by copy-paste habit, and the Windows-only developer never sees it fail. The mark is honest today; it lowers the bar for dishonest use tomorrow. Mitigation: the marks carry a specific `reason` string naming the exact mechanism, which keeps them auditable. |
+| R1-2 | medium | prod-defect-deferred | test_review.py:1-20 | The three `test_review.py` skips paper over a real production defect in `review_export.py` (no `encoding=` on `write_text`/`open`). The PR correctly reports it as bucket-A rather than patching it, but a skip on the *test* means CI will stay green on Linux and the defect has no failing test anywhere tracking it. The follow-up issue must be filed or the finding evaporates. |
+| R1-3 | medium | individual-method-marks | test_config_api.py, test_config_freeze.py, test_operating_mode.py | Marks were applied to individual methods, not whole classes, because some methods in the same class pass (they reject the write before `os.replace`). Correct and surgical — but it means a *new* write-exercising method added to `TestConfigPostEndpoint` later will fail on Windows and the author must know to add the mark. A class-level mark would have been blunter but self-maintaining. Trade-off accepted; flagged so reviewers know it is deliberate. |
+| R1-4 | low | encoding-blanket-sed | test_topbar.py, test_vocabulary.py, test_safety_invariants.py | The `encoding="utf-8"` was applied by blanket substitution to every `.read_text()` in four files, including reads of pure-ASCII `.js`/`.py` source where it is a no-op. Harmless and arguably more consistent, but it is wider than the failing lines strictly required. No correctness risk. |
+
+## Round 2 — Counter-Critique (downgrade scenario)
+
+**The scenario: does a `skipif(win)` mark downgrade a real regression to invisible?**
+
+Concretely: suppose a future commit breaks `write_config` on *all* platforms — say it introduces a logic error that corrupts the `.ini` on every write, Linux included. Before this PR, a Windows developer running `pytest` locally would see those config tests fail (for the wrong reason — WinError 5 — but fail loudly, and a careful reader would notice the failure mode changed). After this PR those tests are skipped on Windows, so the Windows developer's local run is green. The regression is now caught **only** on Linux CI.
+
+**Is that a real downgrade?** Partially. The honest accounting:
+
+- Linux CI still runs every one of these tests unconditionally — the `skipif` is `sys.platform`-gated, verified by `git diff` (no unconditional skips). So the regression is still caught *before merge*. CI is the gate that matters; it is not weakened.
+- What is genuinely lost is **local pre-commit signal on Windows**. A Windows dev who breaks `write_config` logic now gets a clean local run and discovers the break only when CI goes red. That is slower feedback, not missed feedback.
+- The counter-counter: before this PR those same tests were *already* failing on Windows for an unrelated reason (WinError 5). A Windows dev could not distinguish "my change broke it" from "it was already red." The noise made the local signal nearly worthless for these files already. Moving from "always-red, uninformative" to "skipped, explicitly labelled" is not a downgrade of usable signal — it is a wash on signal and a win on noise.
+
+**Downgrade verdict:** No real regression is hidden — CI coverage is identical. The cost is purely local pre-commit latency on Windows for the config/mode write paths, and that signal was already destroyed by the pre-existing WinError-5 noise. Not gate-worthy. But see R3-2: the *aggregate* of 35 skips is worth a conscious look.
+
+### Round 3
+
+**Shared framing of R1+R2:** *Both rounds evaluated the marks one file (or one mechanism) at a time — "is this particular skip honest, does this particular skip hide a regression." Neither round stepped back to ask the orthogonal question: across the whole PR, how much of the product's behaviour is now unverified on Windows, and does that blind spot cluster dangerously around one subsystem?*
+
+**Named framing-break:** the prior rounds treated each skip as an independent decision. They are not independent — 33 of the 35 skips concentrate on a single subsystem: **atomic config persistence** (`write_config`, `_write_mode_atomic`, factory-reset, import). After this PR, a Windows developer has *zero* local test coverage of the entire config-write surface. That is not 35 small blind spots; it is one large, subsystem-shaped blind spot.
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | medium | subsystem-blindspot | test_config_api/freeze/zero_touch/operating_mode | The skips cluster: the entire atomic-config-write subsystem is now untested on Windows. The *real* fix for the WinError-5 root cause is portable production code — open the lock fd, `flock`, write tmp, close the fd, **then** `os.replace`. On Windows you would skip only the `flock` (advisory, no Windows equivalent) and the rename-over-closed-handle works. That would let every one of these 33 tests run on Windows. This PR correctly does not touch production code, but the *recommended follow-up* is not "pin encoding in review_export" — it is "make `write_config`/`_write_mode_atomic` close the lock fd before `os.replace` so they are portable," which would delete most of these skips. |
+| R3-2 | low | reason-string-drift | all six skip-mark definitions | Six near-identical `_skip_on_windows` definitions were copied into six files with slightly varying `reason` strings. If the production code is later made portable (per R3-1) someone must hunt down all six and remove them. A single shared helper in `tests/conftest.py` (e.g. `skip_on_windows_write_config`) would centralise the removal. Test-only nit; out of scope but worth a follow-up. |
+| R3-3 | low | easter-test-still-order-fragile | test_integration_wiring.py | The easter fix correctly sets `configure_morale_features(True)` and resets it in a `finally`. Good. But the *sibling* `test_sentience_overlay_preserved_when_morale_enabled` resets the flag with a bare statement (no `finally`) — if its `client.get("/")` raises, the global stays `True` and leaks into later tests. This PR's fix is correct; it just highlights that the global-state pattern in this file is fragile across the board. Pre-existing, not introduced here. |
+
+### Consistency-bias callouts
+
+- **R1 and R2 both implicitly accepted "skip" as the terminal answer.** R3-1 breaks that: the WinError-5 failures are *fixable in production code* (close fd before rename) without breaking Linux. The PR's hard rule (test-only) is correct for *this* PR, but the adversarial honest position is that the skips are a holding action, not the destination. The PR body's recommended follow-up should be expanded to include the portable-write fix, not just the `review_export` encoding fix.
+- **No round questioned the bucket-A classification of `review_export.py`.** Re-examined: it is correctly bucket A — the defect (`write_text` without encoding) affects any non-UTF-8-locale platform, Linux included (e.g. a Linux box with `LC_ALL=C`), it is merely *surfaced* on Windows. Classification holds.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | subsystem-blindspot | R3-1 | The whole atomic-config-write subsystem is untested on Windows after this PR. Real fix is portable production code (close lock fd before `os.replace`); recommend a follow-up issue to do that and delete the skips. | R3-1 | follow-up issue |
+| medium | prod-defect-deferred | R1-2 | `review_export.py` encoding defect (bucket A) has no failing test tracking it once the `test_review` tests are skipped. File the follow-up issue or the finding is lost. | R1-2 | follow-up issue |
+| medium | skip-creep | R1-1 | 35 new skips lower the bar for future copy-paste misuse of `@_skip_on_windows`. Specific `reason` strings keep them auditable. | R1-1 | accept |
+| medium | individual-method-marks | R1-3 | Per-method (not per-class) marks mean a new write-exercising method needs the mark added by hand. Deliberate trade-off for surgical accuracy. | R1-3 | accept |
+| low | reason-string-drift | R3-2 | Six copied skip-mark definitions; centralise in conftest for one-place removal later. | R3-2 | nit |
+| low | easter-order-fragile | R3-3 | Sibling test resets the morale global without `finally`; pre-existing fragility, not introduced here. | R3-3 | follow-up nit |
+| low | encoding-blanket-sed | R1-4 | `encoding="utf-8"` applied wider than strictly-failing lines. No-op on ASCII files, harmless. | R1-4 | accept |
+
+## Recommendation
+
+**No gates.** The PR does exactly what it claims — moves Windows-incompatible tests to honest skips or makes non-portable tests portable, with zero production-code change and zero impact on Linux CI coverage (every `skipif` is `sys.platform`-gated). The before/after (54 → 0 Windows failures) is verified.
+
+Two follow-up issues should be filed against the merge commit: (1) make `write_config` and `_write_mode_atomic` portable by closing the lock fd before `os.replace`, which would let ~33 of these skips be deleted (R3-1); (2) pin `encoding="utf-8"` in `review_export.py` lines 173/187/505 to fix the bucket-A defect (R1-2). Neither is in scope for a test-hygiene PR — they are correctly deferred, not defects in this change.

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -76,6 +76,7 @@ class TestConfigGetEndpoint:
 
 
 class TestConfigPostEndpoint:
+    @_skip_on_windows
     def test_post_config_writes_values(self, client, tmp_config):
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
             resp = client.post("/api/config/full", json={
@@ -97,6 +98,7 @@ class TestConfigPostEndpoint:
         config.read(tmp_config)
         assert config["web"]["api_token"] == "secret-test-token"
 
+    @_skip_on_windows
     def test_post_config_creates_backup(self, client, tmp_config):
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
             resp = client.post("/api/config/full", json={
@@ -116,6 +118,7 @@ class TestConfigPostEndpoint:
             resp = client.post("/api/config/full", json=huge)
         assert resp.status_code == 413
 
+    @_skip_on_windows
     def test_post_config_returns_restart_required_fields(self, client, tmp_config):
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
             resp = client.post("/api/config/full", json={
@@ -165,6 +168,7 @@ class TestConfigAuthPositiveCases:
         assert resp.status_code == 200
         assert "camera" in resp.json()
 
+    @_skip_on_windows
     def test_post_config_with_valid_token(self, client, tmp_config):
         configure_auth("my-token")
         headers = {"Authorization": "Bearer my-token"}
@@ -258,6 +262,7 @@ class TestAtomicConfigWrite:
     """Config writes must be crash-safe — a power cut mid-write must not
     leave a partial config.ini (issue #60)."""
 
+    @_skip_on_windows
     def test_write_uses_tmp_then_replace(self, client, tmp_config):
         """Verify the write path calls os.replace with a .tmp source."""
         import hydra_detect.web.config_api as cfg_api
@@ -355,6 +360,7 @@ def tmp_config_with_factory(tmp_path):
 class TestFactoryReset:
     """Issue #75 — student-facing factory reset."""
 
+    @_skip_on_windows
     def test_factory_reset_restores_defaults(self, client, tmp_config_with_factory):
         with patch(
             "hydra_detect.web.config_api.get_config_path",
@@ -375,6 +381,7 @@ class TestFactoryReset:
         # port was 9999, factory says 8080.
         assert cfg["web"]["port"] == "8080"
 
+    @_skip_on_windows
     def test_factory_reset_preserves_identity(self, client, tmp_path):
         """R3-2: [identity] (api_token, hash, callsign) must survive reset.
 
@@ -429,6 +436,7 @@ class TestFactoryReset:
             == "pbkdf2:sha256:600000$salt$hash"
         )
 
+    @_skip_on_windows
     def test_factory_reset_no_identity_when_none_present(
         self, client, tmp_config_with_factory,
     ):
@@ -449,6 +457,7 @@ class TestFactoryReset:
         assert not cfg.has_section("identity")
         assert cfg["camera"]["fps"] == "30"
 
+    @_skip_on_windows
     def test_factory_reset_creates_timestamped_backup(
         self, client, tmp_config_with_factory,
     ):

--- a/tests/test_config_freeze.py
+++ b/tests/test_config_freeze.py
@@ -13,6 +13,7 @@ from hydra_detect.web.config_api import (
     set_engagement_check,
     write_config,
 )
+from hydra_detect.autonomous import AutonomousController
 
 # write_config holds an open fd for advisory flock on POSIX, then calls
 # os.replace on the same path. Windows refuses to rename over an open file
@@ -23,7 +24,6 @@ _skip_on_windows = pytest.mark.skipif(
     sys.platform.startswith("win"),
     reason="write_config flock pattern incompatible with Windows os.replace",
 )
-from hydra_detect.autonomous import AutonomousController
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_config_freeze.py
+++ b/tests/test_config_freeze.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import configparser
+import sys
 import time
 from unittest.mock import patch
 
@@ -11,6 +12,16 @@ import pytest
 from hydra_detect.web.config_api import (
     set_engagement_check,
     write_config,
+)
+
+# write_config holds an open fd for advisory flock on POSIX, then calls
+# os.replace on the same path. Windows refuses to rename over an open file
+# (WinError 5). The production target is Jetson/Linux — tests that drive a
+# real write_config write path skip on Windows dev workstations.
+# Mirrors tests/test_config_api.py::_skip_on_windows.
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="write_config flock pattern incompatible with Windows os.replace",
 )
 from hydra_detect.autonomous import AutonomousController
 
@@ -77,6 +88,7 @@ class TestConfigFreezeDuringEngagement:
         config.read(tmp_config)
         assert config["autonomous"]["min_confidence"] == "0.85"
 
+    @_skip_on_windows
     def test_servo_tracking_locked_fields_rejected(self, tmp_config):
         """Only the specific servo_tracking keys are locked."""
         set_engagement_check(lambda: True)
@@ -98,6 +110,7 @@ class TestConfigFreezeDuringEngagement:
         assert config["servo_tracking"]["strike_channel"] == "2"  # unchanged
         assert config["servo_tracking"]["pan_pwm_center"] == "1600"  # changed
 
+    @_skip_on_windows
     def test_non_safety_fields_allowed_during_engagement(self, tmp_config):
         """Non-safety sections (camera, detector) are writable during engagement."""
         set_engagement_check(lambda: True)
@@ -115,6 +128,7 @@ class TestConfigFreezeDuringEngagement:
         assert config["camera"]["width"] == "1280"
         assert config["detector"]["yolo_confidence"] == "0.60"
 
+    @_skip_on_windows
     def test_fields_allowed_when_no_engagement(self, tmp_config):
         """Safety fields are writable when no engagement is active."""
         set_engagement_check(lambda: False)
@@ -132,6 +146,7 @@ class TestConfigFreezeDuringEngagement:
         assert config["autonomous"]["min_confidence"] == "0.50"
         assert config["servo_tracking"]["strike_channel"] == "5"
 
+    @_skip_on_windows
     def test_fields_allowed_when_no_callback_registered(self, tmp_config):
         """Without an engagement callback, all fields are writable."""
         # _reset_engagement_cb already clears it; just verify
@@ -146,6 +161,7 @@ class TestConfigFreezeDuringEngagement:
         config.read(tmp_config)
         assert config["autonomous"]["min_confidence"] == "0.50"
 
+    @_skip_on_windows
     def test_locked_key_in_return_dict(self, tmp_config):
         """The return dict always contains a 'locked' key."""
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):

--- a/tests/test_integration_wiring.py
+++ b/tests/test_integration_wiring.py
@@ -99,7 +99,14 @@ class TestScriptTags:
         assert "/static/js/autonomy.js" in html
 
     def test_easter_script_tag_present(self, client):
-        resp = client.get("/")
+        """easter.js is gated behind {% if morale_features_enabled %} in
+        base.html, so the flag must be toggled on for the tag to render.
+        Mirrors test_sentience_overlay_preserved_when_morale_enabled."""
+        configure_morale_features(True)
+        try:
+            resp = client.get("/")
+        finally:
+            configure_morale_features(False)
         html = resp.text
         assert "/static/js/easter.js" in html
 

--- a/tests/test_operating_mode.py
+++ b/tests/test_operating_mode.py
@@ -17,6 +17,7 @@ Covers:
 from __future__ import annotations
 
 import configparser
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -30,6 +31,17 @@ from hydra_detect.operating_mode import (
     set_mode,
 )
 from hydra_detect.web.server import app, configure_auth, stream_state
+
+# set_mode() -> _write_mode_atomic() imports fcntl (POSIX-only) and uses the
+# flock + os.replace-over-open-handle pattern. _write_mode_atomic itself
+# documents that the call fails on Windows because the production target is
+# Linux/Jetson. Tests that drive a real mode write skip on Windows dev
+# workstations. Mirrors tests/test_config_api.py::_skip_on_windows.
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="_write_mode_atomic uses fcntl + os.replace, POSIX-only "
+    "(production targets Linux/Jetson)",
+)
 
 
 # ---------------------------------------------------------------------------
@@ -153,6 +165,7 @@ class TestCurrentMode:
 # ---------------------------------------------------------------------------
 
 class TestSetMode:
+    @_skip_on_windows
     def test_set_mode_persists_to_config(self, tmp_config: Path):
         with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
             cfg = configparser.ConfigParser()
@@ -163,6 +176,7 @@ class TestSetMode:
         cfg2.read(tmp_config)
         assert cfg2.get("system", "mode") == "FIELD"
 
+    @_skip_on_windows
     def test_set_mode_reads_back_correctly(self, tmp_config: Path):
         with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
             cfg = configparser.ConfigParser()
@@ -180,6 +194,7 @@ class TestSetMode:
             with pytest.raises(ModeTransitionError, match="ARMED"):
                 set_mode(cfg, OperatingMode.ARMED, reason="hot range", confirmed_twice=False)
 
+    @_skip_on_windows
     def test_armed_succeeds_with_confirmed_twice_true(self, tmp_config: Path):
         with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
             cfg = configparser.ConfigParser()
@@ -190,6 +205,7 @@ class TestSetMode:
         cfg2.read(tmp_config)
         assert cfg2.get("system", "mode") == "ARMED"
 
+    @_skip_on_windows
     def test_other_modes_do_not_require_confirmed_twice(self, tmp_config: Path):
         for mode in [OperatingMode.BENCH, OperatingMode.MAINTENANCE, OperatingMode.SIM]:
             with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
@@ -204,6 +220,7 @@ class TestSetMode:
 # ---------------------------------------------------------------------------
 
 class TestModeTransitionEvent:
+    @_skip_on_windows
     def test_event_written_on_transition(self, tmp_config: Path):
         mock_logger = MagicMock()
         with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
@@ -224,6 +241,7 @@ class TestModeTransitionEvent:
         assert details["to"] == "FIELD"
         assert details["reason"] == "pre-sortie"
 
+    @_skip_on_windows
     def test_event_includes_from_and_to(self, tmp_config: Path):
         mock_logger = MagicMock()
         with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
@@ -239,6 +257,7 @@ class TestModeTransitionEvent:
         assert details["from"] == "OBSERVE"
         assert details["to"] == "BENCH"
 
+    @_skip_on_windows
     def test_event_includes_actor(self, tmp_config: Path):
         mock_logger = MagicMock()
         with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
@@ -253,6 +272,7 @@ class TestModeTransitionEvent:
         )
         assert "actor" in details
 
+    @_skip_on_windows
     def test_no_event_when_no_logger(self, tmp_config: Path):
         """set_mode works even when no event logger is registered."""
         with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
@@ -304,6 +324,7 @@ class TestModeGetEndpoint:
 # ---------------------------------------------------------------------------
 
 class TestModePostEndpoint:
+    @_skip_on_windows
     def test_post_transitions_mode(self, client, tmp_config: Path):
         with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
             with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
@@ -335,6 +356,7 @@ class TestModePostEndpoint:
                 })
         assert resp.status_code == 400
 
+    @_skip_on_windows
     def test_post_armed_with_confirm_and_reason_succeeds(self, client, tmp_config: Path):
         with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
             with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):
@@ -360,6 +382,7 @@ class TestModePostEndpoint:
                                headers={"content-type": "application/json"})
         assert resp.status_code == 400
 
+    @_skip_on_windows
     def test_post_persists_across_get(self, client, tmp_config: Path):
         with patch("hydra_detect.web.mode_api.get_config_path", return_value=tmp_config):
             with patch("hydra_detect.operating_mode.get_config_path", return_value=tmp_config):

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -7,6 +7,15 @@ import sys
 
 import pytest
 
+from hydra_detect.review_export import (
+    build_summary,
+    generate_html,
+    parse_csv_log,
+    parse_jsonl,
+    parse_log,
+    main as export_main,
+)
+
 # review_export.main() writes the HTML report via Path.write_text() with no
 # explicit encoding. The report contains non-ASCII glyphs (e.g. U+2192 "->").
 # On Windows the default text encoding is cp1252, which cannot encode those
@@ -18,15 +27,6 @@ _skip_on_windows = pytest.mark.skipif(
     sys.platform.startswith("win"),
     reason="review_export.main() writes report without encoding='utf-8' "
     "(production defect) — fails under cp1252 on Windows",
-)
-
-from hydra_detect.review_export import (
-    build_summary,
-    generate_html,
-    parse_csv_log,
-    parse_jsonl,
-    parse_log,
-    main as export_main,
 )
 
 

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -3,8 +3,22 @@
 from __future__ import annotations
 
 import json
+import sys
 
 import pytest
+
+# review_export.main() writes the HTML report via Path.write_text() with no
+# explicit encoding. The report contains non-ASCII glyphs (e.g. U+2192 "->").
+# On Windows the default text encoding is cp1252, which cannot encode those
+# characters, so the CLI raises UnicodeEncodeError. This is a portability
+# defect in hydra_detect/review_export.py (production code), not a test bug;
+# the export CLI's deployment target is the Linux Jetson, where it works.
+# Skip on Windows dev workstations until review_export.py pins encoding="utf-8".
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="review_export.main() writes report without encoding='utf-8' "
+    "(production defect) — fails under cp1252 on Windows",
+)
 
 from hydra_detect.review_export import (
     build_summary,
@@ -139,6 +153,7 @@ class TestGenerateHtml:
 # ---------------------------------------------------------------------------
 
 class TestExportCli:
+    @_skip_on_windows
     def test_jsonl_export(self, jsonl_file, tmp_path):
         output = tmp_path / "report.html"
         result = export_main([str(jsonl_file), "-o", str(output)])
@@ -148,6 +163,7 @@ class TestExportCli:
         assert "mine" in content
         assert "leaflet" in content.lower()
 
+    @_skip_on_windows
     def test_csv_export(self, csv_file, tmp_path):
         output = tmp_path / "report.html"
         result = export_main([str(csv_file), "-o", str(output)])
@@ -158,6 +174,7 @@ class TestExportCli:
         result = export_main(["/nonexistent/file.jsonl", "-o", str(tmp_path / "out.html")])
         assert result == 1
 
+    @_skip_on_windows
     def test_empty_log(self, tmp_path):
         empty = tmp_path / "empty.jsonl"
         empty.write_text("")

--- a/tests/test_rf_kismet_manager.py
+++ b/tests/test_rf_kismet_manager.py
@@ -4,12 +4,24 @@ from __future__ import annotations
 
 import os
 import subprocess
+import sys
 import threading
 from unittest.mock import MagicMock, patch, mock_open
 
+import pytest
 import requests
 
 from hydra_detect.rf.kismet_manager import KismetManager
+
+# KismetManager.stop() kills the process group via os.getpgid/os.killpg,
+# which do not exist on Windows. Kismet is a Linux-only RF capture tool
+# (libpcap wireless monitor mode) and never runs on a Windows host, so the
+# stop() process-group path is exercised only on Linux/Jetson.
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="KismetManager.stop() uses os.getpgid/os.killpg, POSIX-only "
+    "(Kismet is a Linux-only RF tool)",
+)
 
 
 class TestKismetManagerDependencyPolicy:
@@ -151,6 +163,7 @@ class TestKismetManagerStart:
 
 
 class TestKismetManagerStop:
+    @_skip_on_windows
     def test_stop_kills_owned_process(self):
         mgr = KismetManager(
             source="rtl433-0",
@@ -180,6 +193,7 @@ class TestKismetManagerStop:
 
         mgr.stop()  # should not raise
 
+    @_skip_on_windows
     def test_stop_sigkill_fallback(self):
         mgr = KismetManager(
             source="rtl433-0",

--- a/tests/test_safety_hardening.py
+++ b/tests/test_safety_hardening.py
@@ -85,6 +85,11 @@ class TestRTSPBindAddress:
 # ---------------------------------------------------------------------------
 
 class TestConfigWriteFsync:
+    @pytest.mark.skipif(
+        sys.platform.startswith("win"),
+        reason="write_config flock pattern incompatible with Windows os.replace "
+        "(mirrors tests/test_config_api.py::_skip_on_windows)",
+    )
     def test_write_config_calls_fsync(self, tmp_path):
         """write_config should call os.fsync after writing."""
         config = configparser.ConfigParser()

--- a/tests/test_safety_invariants.py
+++ b/tests/test_safety_invariants.py
@@ -157,20 +157,20 @@ def test_sim_gps_flag_surfaces_to_stats_and_topbar():
     # (a) MAVLinkIO exposes the is_sim_gps property.
     from hydra_detect import mavlink_io
 
-    src = pathlib.Path(mavlink_io.__file__).read_text()
+    src = pathlib.Path(mavlink_io.__file__).read_text(encoding="utf-8")
     assert "def is_sim_gps" in src, "MAVLinkIO.is_sim_gps property missing"
 
     # (b) facade.py pushes is_sim_gps into the stats_update dict every frame.
-    facade_src = (HD_ROOT / "pipeline" / "facade.py").read_text()
+    facade_src = (HD_ROOT / "pipeline" / "facade.py").read_text(encoding="utf-8")
     assert 'stats_update["is_sim_gps"]' in facade_src, \
         "pipeline/facade.py must publish is_sim_gps in stats_update"
 
     # (c) Frontend surfaces it via SIM pill + SIM dot + (SIM) suffix.
-    base_html = (HD_ROOT / "web" / "templates" / "base.html").read_text()
+    base_html = (HD_ROOT / "web" / "templates" / "base.html").read_text(encoding="utf-8")
     assert "sim-gps-pill" in base_html, "SIM pill element missing from base.html"
-    main_js = (HD_ROOT / "web" / "static" / "js" / "main.js").read_text()
+    main_js = (HD_ROOT / "web" / "static" / "js" / "main.js").read_text(encoding="utf-8")
     assert "is_sim_gps" in main_js, "main.js must toggle SIM pill from is_sim_gps"
-    sim_js = (HD_ROOT / "web" / "static" / "js" / "ui" / "sim-gps.js").read_text()
+    sim_js = (HD_ROOT / "web" / "static" / "js" / "ui" / "sim-gps.js").read_text(encoding="utf-8")
     assert "(SIM)" in sim_js, "sim-gps.js must append (SIM) suffix"
 
 
@@ -241,7 +241,7 @@ def test_abort_endpoint_source_wraps_callbacks_in_try_except():
     """Parse web/server.py and assert api_abort's callback-invocation
     block is inside a try/except. A crash in on_set_mode_command must
     never prevent the instructor from seeing a response."""
-    src = (HD_ROOT / "web" / "server.py").read_text()
+    src = (HD_ROOT / "web" / "server.py").read_text(encoding="utf-8")
     tree = ast.parse(src)
 
     api_abort = None
@@ -289,7 +289,7 @@ def test_abort_endpoint_source_wraps_callbacks_in_try_except():
 def test_abort_path_is_in_public_prefixes():
     """/api/abort must bypass auth — instructor safety exception.
     If this regresses, an unauthenticated instructor can't abort."""
-    src = (HD_ROOT / "web" / "server.py").read_text()
+    src = (HD_ROOT / "web" / "server.py").read_text(encoding="utf-8")
     # _PUBLIC_PATH_PREFIXES tuple must include /api/abort.
     match = re.search(
         r"_PUBLIC_PATH_PREFIXES\s*=\s*\(([^)]*)\)", src, re.DOTALL,

--- a/tests/test_topbar.py
+++ b/tests/test_topbar.py
@@ -27,13 +27,13 @@ MAIN_JS = REPO_ROOT / "hydra_detect" / "web" / "static" / "js" / "main.js"
 
 class TestTopbarMarkup:
     def test_topbar_has_mock_data_attribute(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         assert 'class="topbar" data-mock="1"' in html, (
             "Topbar must carry data-mock=1 so base.css overrides win cascade."
         )
 
     def test_logo_lockup_elements_present(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         # Lockup container
         assert 'id="tb-lockup"' in html
         assert 'class="tb-lockup"' in html
@@ -50,14 +50,14 @@ class TestTopbarMarkup:
         assert "ogt_horizontal_white.png" in html
 
     def test_six_health_blips_present(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         for blip in ("mav", "gps", "sim", "kis", "tak", "cam"):
             assert f'data-blip="{blip}"' in html, f"missing blip data-blip={blip!r}"
         # Each blip uses the tb-dot primitive
         assert html.count("tb-dot") >= 6
 
     def test_sim_pill_present_and_hidden(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         assert 'id="sim-gps-pill"' in html
         # The pill is the new tb-sim-pill styling and must be hidden by default
         assert 'class="tb-sim-pill sim-gps-pill"' in html
@@ -69,7 +69,7 @@ class TestTopbarMarkup:
         assert "hidden" in tag, f"SIM pill tag missing hidden attr: {tag!r}"
 
     def test_abort_button_present_with_danger_lg(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         assert 'id="tb-abort"' in html
         # btn-danger-lg is the spec-named class; btn btn-danger is the base
         assert "btn-danger-lg" in html
@@ -77,7 +77,7 @@ class TestTopbarMarkup:
         assert "ABORT" in html
 
     def test_emergency_flash_overlay_present(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         assert 'id="emergency-flash"' in html
         # Sanity: the overlay is a standalone div (not nested inside topbar)
         idx = html.index('id="emergency-flash"')
@@ -87,15 +87,15 @@ class TestTopbarMarkup:
 
 class TestTopbarCss:
     def test_pulse_red_keyframe_defined(self):
-        css = BASE_CSS.read_text()
+        css = BASE_CSS.read_text(encoding="utf-8")
         assert "@keyframes pulse-red" in css
 
     def test_pulse_glow_keyframe_preserved(self):
-        css = BASE_CSS.read_text()
+        css = BASE_CSS.read_text(encoding="utf-8")
         assert "@keyframes pulse-glow" in css
 
     def test_topbar_mock_height_and_gradient(self):
-        css = BASE_CSS.read_text()
+        css = BASE_CSS.read_text(encoding="utf-8")
         assert '.topbar[data-mock="1"]' in css
         # Mock spec: height 64px and linear-gradient(180deg,#141414,#0a0a0a)
         start = css.index('.topbar[data-mock="1"] {')
@@ -104,7 +104,7 @@ class TestTopbarCss:
         assert "linear-gradient(180deg, #141414, #0a0a0a)" in block
 
     def test_body_emerg_attr_drives_abort_and_flash(self):
-        css = BASE_CSS.read_text()
+        css = BASE_CSS.read_text(encoding="utf-8")
         assert 'body[data-emerg="1"] .topbar[data-mock="1"] .tb-abort' in css
         assert 'body[data-emerg="1"] #emergency-flash' in css
 
@@ -114,7 +114,7 @@ class TestPreservationGuards:
         """main.js:36-42 rewrites document.title and the topbar brand to
         `${callsign} — SORCC` on first /api/stats. Preservation rule says
         this block must remain verbatim across any topbar rewrite."""
-        js = MAIN_JS.read_text()
+        js = MAIN_JS.read_text(encoding="utf-8")
         assert "if (data.callsign && !callsignSet) {" in js
         assert "document.querySelector('.topbar-brand')" in js
         assert "brandEl.textContent = `${data.callsign}`;" in js
@@ -122,13 +122,13 @@ class TestPreservationGuards:
         assert "callsignSet = true;" in js
 
     def test_duplicate_callsign_warning_preserved(self):
-        js = MAIN_JS.read_text()
+        js = MAIN_JS.read_text(encoding="utf-8")
         # main.js:45-48 multi-team collision warning
         assert "duplicate_callsign" in js
         assert "DUPLICATE CALLSIGN" in js
 
     def test_sentience_overlay_preserved(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         assert 'id="sentience-overlay"' in html
         assert 'id="sentience-terminal"' in html
         assert 'id="sentience-crosshair"' in html
@@ -136,13 +136,13 @@ class TestPreservationGuards:
         assert "⊕" in html
 
     def test_power_user_modal_preserved(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         assert 'id="power-user-modal"' in html
         assert 'id="power-user-cancel"' in html
         assert 'id="power-user-enable"' in html
 
     def test_footer_preserved(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         assert 'class="footer"' in html
         assert "UNCLASSIFIED" in html
         assert "SORCC Payload Integrator" in html

--- a/tests/test_topbar_order.py
+++ b/tests/test_topbar_order.py
@@ -26,7 +26,7 @@ def _positions(haystack: str, needles: list[str]) -> list[int]:
 
 class TestTopbarBlipOrder:
     def test_five_spec_blips_are_in_order_cam_mav_gps_kis_tak(self):
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         spec = [
             'data-blip="cam"',
             'data-blip="mav"',
@@ -42,7 +42,7 @@ class TestTopbarBlipOrder:
 
     def test_sim_pill_is_sibling_of_blips(self):
         """SIM pill stays as separate element beside blips."""
-        html = BASE_HTML.read_text()
+        html = BASE_HTML.read_text(encoding="utf-8")
         blips_start = html.index('class="tb-blips"')
         blips_end = html.index("</div>", blips_start)
         pill_pos = html.index('id="sim-gps-pill"')
@@ -53,7 +53,7 @@ class TestTopbarBlipOrder:
 
 class TestCockpitStripOrder:
     def test_cockpit_cells_in_order_servo_tak_sdr(self):
-        html = OPS_HTML.read_text()
+        html = OPS_HTML.read_text(encoding="utf-8")
         ids = [
             'id="ops-cockpit-servo"',
             'id="ops-cockpit-tak"',
@@ -66,6 +66,6 @@ class TestCockpitStripOrder:
         )
 
     def test_cockpit_strip_container_present(self):
-        html = OPS_HTML.read_text()
+        html = OPS_HTML.read_text(encoding="utf-8")
         assert 'id="ops-cockpit-strip"' in html
         assert 'class="cockpit-strip"' in html

--- a/tests/test_vocabulary.py
+++ b/tests/test_vocabulary.py
@@ -91,7 +91,7 @@ class TestForbiddenTokensAbsent:
 
     def test_no_unmanned_anywhere_in_templates(self):
         for tpl in TEMPLATES_DIR.glob("*.html"):
-            text = tpl.read_text()
+            text = tpl.read_text(encoding="utf-8")
             assert "unmanned" not in text.lower(), (
                 f"Forbidden token 'unmanned' in {tpl.name}; use 'uncrewed'."
             )
@@ -116,7 +116,7 @@ class TestForbiddenTokensAbsent:
         HYDRA-{team}-{vehicle}.
         """
         for tpl in TEMPLATES_DIR.glob("*.html"):
-            raw = tpl.read_text()
+            raw = tpl.read_text(encoding="utf-8")
             # Drop the HYDRA-{team}-{vehicle} literal so the remaining corpus
             # can be checked strictly.
             scrubbed = raw.replace("HYDRA-{team}-{vehicle}", "HYDRA-CALLSIGN")
@@ -165,14 +165,14 @@ class TestKeepClauses:
         """The event logger still carries mission_name — the Python-side
         data contract must not track the UI vocabulary rename.
         """
-        src = (REPO_ROOT / "hydra_detect" / "event_logger.py").read_text()
+        src = (REPO_ROOT / "hydra_detect" / "event_logger.py").read_text(encoding="utf-8")
         assert "_mission_name" in src or "mission_name" in src
 
     def test_callsign_placeholder_preserved_in_setup(self):
         """The callsign format literal {vehicle} must survive the sweep —
         renaming it would break an operator-facing contract.
         """
-        html = (TEMPLATES_DIR / "setup.html").read_text()
+        html = (TEMPLATES_DIR / "setup.html").read_text(encoding="utf-8")
         assert "HYDRA-{team}-{vehicle}" in html
 
 
@@ -254,14 +254,14 @@ class TestJsStringsSwept:
     """
 
     def test_ops_js_toast_uses_sortie(self):
-        src = (JS_DIR / "ops.js").read_text()
+        src = (JS_DIR / "ops.js").read_text(encoding="utf-8")
         assert "'Sortie ended'" in src
         assert "'Mission ended'" not in src
         assert "End current sortie" in src
         assert "End current mission" not in src
 
     def test_config_js_toast_uses_sortie(self):
-        src = (JS_DIR / "config.js").read_text()
+        src = (JS_DIR / "config.js").read_text(encoding="utf-8")
         assert "Sortie started: " in src
         assert "Sortie ended" in src
         assert "End current sortie" in src
@@ -274,7 +274,7 @@ class TestJsStringsSwept:
         assert "Enter a mission name before starting" not in src
 
     def test_config_js_confirm_uses_platform(self):
-        src = (JS_DIR / "config.js").read_text()
+        src = (JS_DIR / "config.js").read_text(encoding="utf-8")
         assert "'Command platform to LOITER?'" in src
         assert "'Resume AUTO sortie?'" in src
         assert "Platform will switch to GUIDED mode." in src
@@ -283,12 +283,12 @@ class TestJsStringsSwept:
         assert "Vehicle will switch to GUIDED mode." not in src
 
     def test_instructor_js_uses_sortie_and_platform(self):
-        src = (JS_DIR / "instructor.js").read_text()
+        src = (JS_DIR / "instructor.js").read_text(encoding="utf-8")
         assert "'Sortie'" in src
         assert "platform unreachable" in src
         assert "vehicle unreachable" not in src
 
     def test_autonomy_js_uses_platform_modes_label(self):
-        src = (JS_DIR / "autonomy.js").read_text()
+        src = (JS_DIR / "autonomy.js").read_text(encoding="utf-8")
         assert "'Allowed platform modes'" in src
         assert "'Allowed vehicle modes'" not in src

--- a/tests/test_zero_touch.py
+++ b/tests/test_zero_touch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import configparser
+import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,6 +11,17 @@ import pytest
 from fastapi.testclient import TestClient
 
 from hydra_detect.web.server import app, configure_auth, stream_state
+
+# write_config holds an open fd for advisory flock on POSIX, then calls
+# os.replace on the same path. Windows refuses to rename over an open file
+# (WinError 5), so setup-save / factory-reset / import endpoints return 500.
+# The production target is Jetson/Linux — tests that drive a real config
+# write skip on Windows dev workstations.
+# Mirrors tests/test_config_api.py::_skip_on_windows.
+_skip_on_windows = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="write_config flock pattern incompatible with Windows os.replace",
+)
 
 
 @pytest.fixture(autouse=True)
@@ -108,6 +120,7 @@ class TestSetupDevices:
 # ── Setup Save API ─────────────────────────────────────────────
 
 class TestSetupSave:
+    @_skip_on_windows
     def test_save_writes_config(self, client, tmp_config):
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
             resp = client.post("/api/setup/save", json={
@@ -129,6 +142,7 @@ class TestSetupSave:
         assert config["mavlink"]["connection_string"] == "/dev/ttyACM0"
         assert config["tak"]["callsign"] == "HYDRA-3-USV"
 
+    @_skip_on_windows
     def test_save_with_explicit_callsign(self, client, tmp_config):
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
             resp = client.post("/api/setup/save", json={
@@ -173,6 +187,7 @@ class TestSetupSave:
 # ── Factory Reset ─────────────────────────────────────────────
 
 class TestFactoryReset:
+    @_skip_on_windows
     def test_factory_reset_restores_defaults(self, client, tmp_config, tmp_factory):
         # First modify the config
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
@@ -193,6 +208,7 @@ class TestFactoryReset:
         assert resp.status_code == 404
         assert "No factory defaults" in resp.json()["error"]
 
+    @_skip_on_windows
     def test_factory_reset_creates_backup(self, client, tmp_config, tmp_factory):
         # Issue #75 — factory-reset writes a timestamped pre-reset snapshot
         # that survives the next save (the rolling .bak does not).
@@ -204,6 +220,7 @@ class TestFactoryReset:
         assert Path(backup_path).exists()
         assert "before-reset." in Path(backup_path).name
 
+    @_skip_on_windows
     def test_factory_reset_does_not_trigger_in_process_restart(
         self, client, tmp_config, tmp_factory,
     ):
@@ -270,6 +287,7 @@ class TestConfigExport:
 # ── Config Import ─────────────────────────────────────────────
 
 class TestConfigImport:
+    @_skip_on_windows
     def test_import_writes_config(self, client, tmp_config):
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
             resp = client.post("/api/config/import", json={
@@ -284,6 +302,7 @@ class TestConfigImport:
         assert config["camera"]["source"] == "/dev/video4"
         assert config["tak"]["callsign"] == "IMPORTED"
 
+    @_skip_on_windows
     def test_import_returns_restart_required(self, client, tmp_config):
         with patch("hydra_detect.web.config_api.get_config_path", return_value=tmp_config):
             resp = client.post("/api/config/import", json={


### PR DESCRIPTION
## Summary

Triages the ~54 test failures seen running `python -m pytest` on Windows dev workstations that do **not** occur on Linux CI. Pure test-hygiene change — **no production code touched** (all 12 changed files are under `tests/`).

Windows failure count: **54 -> 0** (2556 passed, 103 skipped, was 2540 passed / 65 skipped on main). Linux CI behaviour is unchanged — every `skipif` is `sys.platform`-gated, never unconditional.

## Triage table

| Bucket | Group | Count | Root cause | Action |
|--------|-------|-------|-----------|--------|
| B | test_config_api.py | 9 | `write_config` holds an open fd for advisory `flock`, then `os.replace` over the same path; Windows refuses to rename over an open handle (WinError 5) | Applied existing `_skip_on_windows` mark |
| B | test_config_freeze.py | 5 | Same `write_config` path | Added `skipif(win)` |
| B | test_zero_touch.py | 7 | Same `write_config` path via HTTP endpoints (500) | Added `skipif(win)` |
| B | test_operating_mode.py | 11 | `set_mode` -> `_write_mode_atomic` does unconditional `import fcntl` + same flock/os.replace pattern; prod code itself documents it fails on Windows | Added `skipif(win)` |
| B | test_safety_hardening.py | 1 | Same `write_config` path | Added `skipif(win)` |
| B | test_rf_kismet_manager.py | 2 | `KismetManager.stop()` uses `os.getpgid`/`os.killpg` (POSIX-only); Kismet is a Linux-only RF tool | Added `skipif(win)` |
| C | test_topbar / test_topbar_order / test_safety_invariants / test_vocabulary | 17 | `Path.read_text()` with no encoding read UTF-8 templates as cp1252 on Windows -> UnicodeDecodeError | Pinned `encoding="utf-8"` |
| C | test_integration_wiring.py | 1 | `test_easter_script_tag_present` never set `morale_features_enabled`; `easter.js` is gated behind that flag, so the test only passed via global-state leak from sibling tests | Test now toggles the flag explicitly like its siblings |
| C | test_review.py | 3 | Export CLI tests fail because `review_export.main()` writes the report without `encoding="utf-8"` | Skipped on Windows (see bucket-A finding below) |

Bucket B = feature genuinely not Windows-applicable (honest skip, documents the platform constraint, mirrors the repo's existing `_skip_on_windows` precedent). Bucket C = non-portable test assumption, made portable.

## Bucket-A finding (NOT fixed in this PR — reported for a separate decision)

`hydra_detect/review_export.py` is **production code** with a portability defect:

- Line 505: `output_path.write_text(html_content)` — no `encoding`. The generated HTML report contains non-ASCII glyphs (e.g. U+2192 `->`). On a Windows host the default text encoding is cp1252, which cannot encode them, so the export CLI raises `UnicodeEncodeError` and exits non-zero.
- Lines 173 / 187: `open(path)` for reading JSONL/CSV logs — also no `encoding`, same family of latent non-portability.

Impact is low in practice because the export CLI's deployment target is the Linux Jetson, where the default encoding is UTF-8. But it is a real defect for anyone running the tool off-target. Per the task's hard rule (do not fix production code under cover of a test PR), it is **not patched here** — the 3 `test_review.py` CLI tests are skipped on Windows with a reason string that names the prod defect, so the skip is honest and points reviewers here. Recommend a small follow-up that pins `encoding="utf-8"` on those three `review_export.py` I/O calls.

Minor related observation (not a failure): `KismetManager.stop()` would raise `AttributeError` on Windows (the `os.getpgid` call is not wrapped by the `except` that catches `ProcessLookupError`/`PermissionError`). Unreachable in practice — Kismet cannot run on Windows at all — so not treated as a bug.

## Test plan

- [x] `python -m pytest -q --tb=short` on Windows: 54 failed -> 0 failed
- [x] All `skipif` markers are `sys.platform.startswith("win")`-gated — Linux CI sees no new skips
- [x] No production code modified — `git diff --stat` shows only `tests/*`