### PR TITLE
fix(docker): pin numpy<2 last so the Jetson torch build works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rtl-sdr \
     && rm -rf /var/lib/apt/lists/*
 
+# torch on the l4t-pytorch base is built against numpy 1.x. The unpinned
+# scipy/matplotlib install above (and requirements-extra.txt) pull numpy 2.x
+# in transitively, which clobbers the numpy<2 pin from the filtered
+# requirements step and breaks torch.Tensor.numpy() at runtime
+# ("RuntimeError: Numpy is not available"). Pin numpy<2 last so it wins.
+# scipy 1.15 is compiled against the numpy 2.0 ABI but stays runtime-
+# compatible with numpy 1.x, so the downgrade does not break it.
+RUN pip3 install --no-cache-dir "numpy<2"
+
 # Copy application
 COPY hydra_detect/ ./hydra_detect/
 COPY config.ini .


### PR DESCRIPTION
## Problem

The `l4t-pytorch:r36.4.0` base image ships `torch` built against numpy 1.x.
The Dockerfile already filters `requirements.txt` to pin `numpy<2`, but the
later unpinned step --

```
pip3 install --no-cache-dir scipy polars ultralytics-thop defusedxml pyDeprecate matplotlib tqdm
```

-- plus `requirements-extra.txt` resolve current `scipy`/`matplotlib`, which
drag `numpy` 2.x back in. The built image ends up with `numpy 2.2.6`.

At runtime `torch.Tensor.numpy()` / `torch.from_numpy()` then fail with
`RuntimeError: Numpy is not available`. On a Jetson this crashes the detection
pipeline on the first frame, inside the YOLO predictor
(`ultralytics ... predictor.preprocess -> torch.from_numpy(im)`), and the
container crash-loops under systemd.

This is why a freshly built image (or the GHCR `hydra-detect:latest`
auto-build) will not run detection on the Jetsons.

## Fix

Add a final `RUN pip3 install --no-cache-dir "numpy<2"` after all other
installs so the numpy version has the last word. `scipy 1.15` is compiled
against the numpy 2.0 ABI but stays runtime-compatible with numpy 1.x, so the
downgrade does not break it.

One added layer, placed after the apt step and before the application COPYs,
so the expensive pip/apt layers stay cached on rebuild.

## Verification

Rebuilt on hydra-team-4 (Jetson Orin Nano Super 8GB, JetPack 6.2.1, L4T R36.4.7):

- `numpy 1.26.4`, `torch 2.4.0`
- `torch.Tensor.numpy()` and `torch.from_numpy()` both succeed
- `scipy 1.15.3`, `cv2 4.13.0`, `ultralytics` all import clean
- Detection pipeline runs end to end -- YOLO on GPU at roughly 8-10 fps,
  STATUSTEXT detection alerts reaching the GCS through the flight controller

## Notes

Root cause is `requirements.lock` carrying `numpy 2.2.6` and the unpinned
`scipy`/`matplotlib` install line. A follow-up could constrain numpy across
the whole dependency resolution (a pip constraints file) rather than
downgrading last, but the final-pin approach is minimal and verified on
hardware.
