### PR TITLE
fix: five wave-3 cleanup items (#241 sub-items)

### DIFF
--- a/docs/adversarial/260.md
+++ b/docs/adversarial/260.md
@@ -1,0 +1,83 @@
+# Adversarial Analysis — PR #260 (fix/wave3-cleanup-241)
+
+**Generated:** 2026-05-25T18:00:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/260
+**Base:** main at 8811fa5 (post-#218 merge)
+**Diff size:** ~370 / -4 across 8 files (mostly tests and docs; one endpoint return-code change in `web/server.py`; one new exception class in `mission_summary.py`; one new validation branch in `config_api.py`)
+
+## Summary
+
+- **Round 1:** 4 findings (0 high · 2 medium · 2 low). Pattern-match focused on (a) the new MissionNotFoundError gate in compute_summary and whether its "zero rows of any kind" detector has false positives on a real but empty mission, (b) the schema_version rejection in `attempt_corrupt_recovery` and whether it leaves the operator stranded when both config and .bak are technically valid, (c) the redaction tighten and whether it over-suppresses legitimate drift detection, and (d) the contract test's failure mode.
+- **Round 2:** 2 second-order findings. **R1-2 (config-diff over-suppression) downgraded to low** after re-reading: the only path where a legitimate non-redacted side ever sees `"***"` is upstream-inconsistency, which is itself a bug to surface elsewhere — the diff endpoint correctly refuses to be the surfacing channel.
+- **Round 3:** 2 findings, framing identified — *Rounds 1 and 2 audited each fix in isolation. Neither asked (a) whether the not-found gate in mission_summary interacts with the existing TestCacheInvalidationOnPrune behaviour where a prune-during-summary could transiently zero out a real mission, or (b) whether the schema_version rejection produces an operator-recovery trail that an offline operator can actually follow without phoning home.*
+- **Consolidated:** 0 blockers · 1 gate · 5 follow-ups.
+
+## Round 1 — Pattern Match
+
+4 findings.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | not-found-false-positive | mission_summary.py compute_summary zero-row gate | The gate fires when `det_count == 0 and action_count == 0 and state_count == 0 and not track_points and mission_start_ts is None and mission_end_ts is None`. A mission that started, emitted only event types this code does not count (e.g., a `track` event with no lat/lon, an unknown rtype), and was rotated before any detection/action/state row was written, would still trip the gate and surface as 404 — even though the mission_id is real. Probability is low (the mission_start event sets `mission_start_ts`), but the gate's conjunction is broader than the issue's framing. |
+| R1-2 | medium | over-suppression | config_api.py compute_config_diff either-side-redacted skip | The new rule suppresses any diff where either side is `"***"`. If a future refactor introduces a path that legitimately emits `"***"` as a value (e.g., a literal `"***"` typed by an operator as a placeholder string), the diff endpoint would silently hide drift on that field. Risk is paper-thin but the suppression is now broader than the disclosure-defense framing requires. |
+| R1-3 | low | recovery-trail | config_api.py attempt_corrupt_recovery schema_version reject | The CRITICAL log explains the failure but the audit log does not get a `RECOVERY_REJECTED` event. Existing `RECOVERY_FROM_BAK` audit event lands when recovery succeeds; an operator who only reads `/api/audit/summary` will see "no recovery happened" and not realize the binary refused to start. |
+| R1-4 | low | contract-test-fragility | tests/test_observability.py TestHealthBodyContract | The contract asserts exact-set equality on top-level keys. A future PR that adds a key and forgets to update `EXPECTED_KEYS` will fail the test, which is the intent. A future PR that *removes* a key and updates `EXPECTED_KEYS` simultaneously will pass — but removal IS the breaking change for downstream scrapers. The test catches additions and "stealth removals where someone forgot the constant" but not "removals where someone correctly updated the constant." That requires a downstream-aware test (e.g., assert that documented keys in `docs/observability.md` are all present) which is out of scope here. |
+
+## Round 2 — Counter-Critique
+
+**Challenged:** R1-2 (over-suppression). The plaintext value `"***"` as a real config field is an absurd edge case — `configparser` allows it but no Hydra field documented in `REDACTED_FIELDS` would carry that as a meaningful value, and a non-redacted field carrying `"***"` would be a typo regardless. The defense-in-depth gain (preventing an upstream inconsistency from leaking a secret) is concrete; the over-suppression cost is hypothetical. **Downgrade to low; documentation-only follow-up if anyone ever needs the literal `"***"` value.**
+
+**Confirmed:** R1-1, R1-3, R1-4 with sharper evidence.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | not-found-cache-interaction | mission_summary.py get_summary | The plan-validated "MissionNotFoundError bypasses cache" claim is correct on a cold call, but the test `test_get_summary_does_not_cache_not_found` exercises only the "first call raises, then logs appear, second call succeeds" sequence. It does NOT exercise: first call succeeds, then `invalidate_for_log_dir` fires from the prune path (TestCacheInvalidationOnPrune), then next call hits compute_summary with stale `_scan_log_dir` results during a concurrent file rotate. A racy file-disappears-between-_scan_log_dir-and-_iter calls could plausibly produce zero rows and surface a 404 for a recently-valid mission. |
+| R2-2 | low | tooling-discipline | docs/observability.md | The new doc says "default to `None` for not-yet-observed" but does not point at the gauge constructors. A contributor adding a gauge will not necessarily read this doc; the convention only lands if the gauge constructor docstring also says so. Add a one-line cross-reference in `observability/metrics.py` near `_format_value`. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited each fix in isolation: is the gate's predicate right, is the rejection logged loudly enough, does the doc tell the right story. Neither round asked (a) whether the not-found gate interacts with the existing prune/invalidation machinery under file-rotation races, or (b) whether the schema_version rejection leaves an operator who has no internet a recovery trail they can actually follow. An operator at home, no Tailscale, no phone-home, sees the binary refuse to start with a CRITICAL log line. What does they DO next? "Restore from factory defaults via the dashboard" — but the dashboard is part of the binary that just refused to start.*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **medium** | **operator-recovery-loop** | config_api.py:467-499 | The CRITICAL log on schema_version rejection says "Restore from factory defaults via the dashboard." But if `attempt_corrupt_recovery` returns False, `__main__.main()` exits 1 (CRITICAL no-recovery). The dashboard never starts. The operator's only recovery is SSH or physical access to `mv config.ini.factory config.ini`, which a typical SORCC home operator does not know how to do. **Gate: log message must give an out-of-binary recovery path** (e.g., "On the Jetson, run: `sudo cp /etc/hydra/config.ini.factory /etc/hydra/config.ini && sudo systemctl restart hydra-detect`" — or whatever the deployed paths actually are). The current message walks the operator into a recovery channel that the failure itself disabled. |
+| R3-2 | low | race-window | mission_summary.py compute_summary + invalidate_for_log_dir | Detection log rotation can occur between `_scan_log_dir` and the row iteration in compute_summary. A real-but-mid-rotate mission could surface zero rows and 404. Acceptable behaviour (operator retries and the mission resurfaces) but worth a follow-up: either tag the 404 body with `transient=true` if rotation was active in the last N seconds, or run compute_summary under the same lock as the prune. |
+
+### Consistency-bias callouts
+
+- **R1-2 was flagged medium by pattern-match because over-suppression is a familiar concern.** R2 downgraded it after considering the actual values involved. R3 confirmed the downgrade — there is no realistic field where `"***"` is a meaningful value.
+- **R3-1 was not visible in R1 or R2** because both rounds audited "the rejection branch is correct" rather than "the operator handed this rejection has a recovery path." The framing-break: error messages that name a recovery channel the failure disables are not actionable.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | operator-recovery-loop | R3-1 | CRITICAL log on schema_version reject points operator at the dashboard, which never starts when recovery returns False. Provide an out-of-binary recovery path in the log message. | R3-1 | **fix in this PR before merge** |
+| medium | not-found-cache-interaction | R2-1 | New test covers cold-call-then-logs-appear but not concurrent prune-during-compute. Add a test that prunes mid-summary and confirms the second call still surfaces the now-rotated mission as 404 (acceptable) rather than a stale 200 (bad). | R2-1 | follow-up issue |
+| medium | not-found-false-positive | R1-1 | The zero-row conjunction is broader than "this mission never existed" — an exotic event-only mission with no detections could trip it. Document the predicate in the docstring. | R1-1 | follow-up issue |
+| low | recovery-trail | R1-3 | Audit log gets `RECOVERY_FROM_BAK` on success but not `RECOVERY_REJECTED` on schema-version failure. Symmetrical event for post-incident review. | R1-3 | follow-up issue |
+| low | tooling-discipline | R2-2 | docs/observability.md is correct but invisible to a contributor adding a gauge. Add a one-line cross-reference in metrics.py near `_format_value`. | R2-2 | follow-up issue |
+| low | race-window | R3-2 | compute_summary can produce a transient 404 if a log file rotates mid-scan. Tag the 404 body or lock the scan. | R3-2 | follow-up issue |
+| low | contract-test-fragility | R1-4 | TestHealthBodyContract catches additions and stealth removals but not synchronized removals. Acceptable for an additive guard; document the limit. | R1-4 | nit |
+| low | over-suppression | R1-2 (downgraded) | The either-side-redacted skip is broader than disclosure-defense requires. Acceptable; document in the docstring. | R1-2 | nit |
+
+## Recommendation
+
+**One gate before merge: fix R3-1.** Update the CRITICAL log in `attempt_corrupt_recovery`'s schema_version-rejection branch to point the operator at a recovery path that does not depend on the binary that just refused to start. Example replacement text:
+
+```
+"Refusing to restore — this would silently load a config the running
+binary cannot fully understand. RECOVERY: this unit will exit. From a
+shell on the device, run: cp /etc/hydra/config.ini.factory
+/etc/hydra/config.ini && systemctl restart hydra-detect. Alternatively
+roll forward to a binary that knows schema v%d."
+```
+
+The five follow-ups (R1-1 docstring, R1-3 audit event, R2-1 test, R2-2 cross-ref, R3-2 race tag) are not gates — file as issues against the merge commit. R1-2 and R1-4 are nits, no follow-up needed.
+
+The PR's core fixes are sound; R3-1 is the one finding that converts an operator's recovery from "easy" to "needs a shell."

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,65 @@
+# Observability
+
+Hydra exposes two health-style surfaces: `/api/health` (JSON, operator-facing)
+and `/api/metrics` (Prometheus text format, scrape-facing). This doc covers
+conventions that are easy to "fix" the wrong way.
+
+## Prometheus NaN-vs-zero convention
+
+In `hydra_detect/observability/metrics.py`, `_format_value()` renders `None`
+and floating-point `NaN` as the literal string `NaN` rather than coercing to
+`0.0`.
+
+```python
+def _format_value(v: Optional[float]) -> str:
+    if v is None:
+        return "NaN"
+    if v != v:  # NaN
+        return "NaN"
+    if v == float("inf"):
+        return "+Inf"
+    if v == float("-inf"):
+        return "-Inf"
+    ...
+```
+
+**This is intentional.** Prometheus treats `NaN` as "value unknown" and
+excludes the sample from `rate()`, `avg_over_time()`, and `increase()`
+calculations. Coercing to `0.0` would make a missing-data condition look
+identical to a "really zero" value:
+
+- Camera offline (no frame stats yet) — should be `NaN`, not `fps=0.0` which
+  a dashboard alert rule may interpret as "camera saturated at zero fps."
+- MAVLink not yet connected — `last_heartbeat_age_sec` is `NaN` (no
+  baseline), not `0.0` (which means "heartbeat just arrived").
+- GPS not yet locked — `gps_lat` is `NaN`, not `0.0` (which is a real
+  coordinate in the Gulf of Guinea).
+
+When adding a new gauge, **default to `None` for "not yet observed."** Only
+coerce to a numeric value when you have a real observation. The Prometheus
+convention is the one that lets dashboard authors distinguish "data missing"
+from "data zero" without an out-of-band convention.
+
+See PR #236 R2-1 (issue #241 tracker) for the adversarial finding that
+prompted this doc.
+
+## Additive surface convention
+
+Both `/api/health` and `/api/metrics` are append-only. Removing or renaming a
+top-level key in `health_snapshot()` or a gauge name in the Prometheus
+exposition is a breaking change for downstream scrapers (phone-home, external
+Grafana, operator-side `curl` scripts).
+
+`tests/test_observability.py::TestHealthBodyContract` pins the top-level key
+set so additions are deliberate — a PR that adds, removes, or renames a key
+must update `EXPECTED_KEYS` in the same diff. The Prometheus exposition does
+not yet have a parallel contract test; add one when the gauge surface
+stabilizes.
+
+## Related
+
+- `hydra_detect/observability/metrics.py` — Prometheus collectors
+- `hydra_detect/observability/health.py` — `/api/health` body
+- `tests/test_observability.py` — contract tests
+- PR #236 (disk telemetry, closes #232)
+- Issue #241 (Wave 3 adversarial follow-ups tracker)

--- a/hydra_detect/mission_summary.py
+++ b/hydra_detect/mission_summary.py
@@ -23,6 +23,19 @@ from .review_export import gps_coverage
 
 logger = logging.getLogger(__name__)
 
+
+class MissionNotFoundError(LookupError):
+    """Raised when a requested mission_id has zero rows in any scanned log.
+
+    Distinct from ``ValueError`` (which is reserved for malformed input like
+    an empty mission_id). Callers should map this to HTTP 404; ``ValueError``
+    maps to HTTP 400. R3-3 from PR #238 / issue #241 — operators previously
+    could not distinguish "mission ran, found nothing" from "you typo'd the
+    UUID" because the endpoint returned 200 with an empty-but-valid body in
+    both cases.
+    """
+
+
 # How long to cache a per-mission summary in memory. The active mission's
 # JSONL is still appending while polling, so a short TTL is the tradeoff
 # between cost and freshness. 30 s is comfortably below typical "review
@@ -216,6 +229,27 @@ def compute_summary(mission_id: str, log_dir: Path) -> dict:
             # leaked rows from before start_mission(). Treat as unknown.
             ttfd_status = "unknown"
 
+    # R3-3 from PR #238 / issue #241. If we scanned all logs and matched
+    # zero rows of any kind, the caller asked about a mission that does
+    # not exist — most likely a typo'd UUID. Returning an empty-but-valid
+    # summary made the dashboard show "mission ran, found nothing," which
+    # is indistinguishable from "you asked about a mission that never ran."
+    # Raise here; the caller (HTTP handler) maps to 404.
+    if (
+        det_count == 0
+        and action_count == 0
+        and state_count == 0
+        and not track_points
+        and mission_start_ts is None
+        and mission_end_ts is None
+    ):
+        raise MissionNotFoundError(
+            f"No detection rows, events, or telemetry found for "
+            f"mission_id={mission_id!r}. Check the mission id — common "
+            f"causes are a typo'd UUID or a mission whose logs have been "
+            f"rotated out by the retention policy."
+        )
+
     duration_sec: float | None = None
     if mission_start_ts is not None:
         end = mission_end_ts if mission_end_ts is not None else time.time()
@@ -261,6 +295,12 @@ def get_summary(mission_id: str, log_dir: Path | str) -> dict:
         ):
             return entry.summary
 
+    # Note: compute_summary raises MissionNotFoundError for unknown
+    # mission_ids (zero rows in any scanned log). The exception propagates
+    # before the cache write below, so a not-found result is correctly NOT
+    # cached. Caching a negative would prevent recovery if logs for that
+    # id later become readable (e.g. a delayed file copy from removable
+    # media or a network share).
     summary = compute_summary(mission_id, log_path)
 
     with _cache_lock:

--- a/hydra_detect/web/config_api.py
+++ b/hydra_detect/web/config_api.py
@@ -174,9 +174,16 @@ def compute_config_diff(
             runtime_value = runtime_section.get(key, "")
             if disk_value == runtime_value:
                 continue
-            # Both sides redacted -> we cannot compare, skip rather than
-            # report spurious drift on every poll.
-            if disk_value == REDACTED_VALUE and runtime_value == REDACTED_VALUE:
+            # Defense in depth: if EITHER side carries the redacted
+            # placeholder, skip. Upstream redaction in read_config and
+            # read_runtime_config is supposed to mirror both sides; a
+            # future drift in one path without the other would otherwise
+            # emit a diff like {"disk": "***", "runtime": "real-value"},
+            # which would expose the real value to anyone polling
+            # /api/config/diff. R1-2 from PR #239 / issue #241. The
+            # original both-sides skip (issue #224) is the subset case
+            # of this rule.
+            if disk_value == REDACTED_VALUE or runtime_value == REDACTED_VALUE:
                 continue
             section_diff[key] = {"disk": disk_value, "runtime": runtime_value}
         if section_diff:

--- a/hydra_detect/web/config_api.py
+++ b/hydra_detect/web/config_api.py
@@ -477,6 +477,45 @@ def attempt_corrupt_recovery(config_path: Path | str) -> bool:
         )
         return False
 
+    # R3-2 from PR #237 / issue #241. Reject a .bak whose [meta].schema_version
+    # exceeds the running binary's CURRENT_SCHEMA_VERSION. Catches the
+    # operator code-rollback case (binary stepped back to a version that
+    # does not know about a newer schema, while the .bak still carries the
+    # newer schema). Silently restoring would let the older binary parse a
+    # config it cannot fully understand and quietly drop fields, or attempt
+    # to run migrations backward. Caller treats False as CRITICAL exit;
+    # operator restores from factory or rolls the binary forward.
+    bak_version_raw = "?"
+    try:
+        from hydra_detect.config_migrate import CURRENT_SCHEMA_VERSION
+        bak_cfg = configparser.ConfigParser(inline_comment_prefixes=(";", "#"))
+        bak_cfg.read(bak_path)
+        bak_version_raw = bak_cfg.get(
+            "meta", "schema_version", fallback="0"
+        ).strip()
+        bak_version = int(bak_version_raw)
+    except (configparser.Error, ValueError) as exc:
+        logger.critical(
+            "Config backup %s has unreadable [meta].schema_version=%r: %s. "
+            "Refusing to restore — restore from factory defaults via the "
+            "dashboard.",
+            bak_path, bak_version_raw, exc,
+        )
+        return False
+
+    if bak_version > CURRENT_SCHEMA_VERSION:
+        logger.critical(
+            "Config backup %s has schema_version=%d which exceeds the "
+            "running binary's CURRENT_SCHEMA_VERSION=%d. Refusing to "
+            "restore — this would silently load a config the running "
+            "binary cannot fully understand. Likely cause: operator "
+            "rolled the Hydra binary back while keeping a .bak from a "
+            "newer version. Restore from factory defaults via the "
+            "dashboard, or roll forward to a binary that knows schema v%d.",
+            bak_path, bak_version, CURRENT_SCHEMA_VERSION, bak_version,
+        )
+        return False
+
     # Atomic restore: copy .bak -> .tmp, fsync, os.replace -> config.ini.
     # Mirrors the write_config pattern at lines 181-205 so a crash mid-recovery
     # cannot make a bad situation worse.

--- a/hydra_detect/web/config_api.py
+++ b/hydra_detect/web/config_api.py
@@ -517,9 +517,14 @@ def attempt_corrupt_recovery(config_path: Path | str) -> bool:
             "restore — this would silently load a config the running "
             "binary cannot fully understand. Likely cause: operator "
             "rolled the Hydra binary back while keeping a .bak from a "
-            "newer version. Restore from factory defaults via the "
-            "dashboard, or roll forward to a binary that knows schema v%d.",
-            bak_path, bak_version, CURRENT_SCHEMA_VERSION, bak_version,
+            "newer version. RECOVERY: this unit will exit; the dashboard "
+            "is not available because the binary refused to start. From "
+            "a shell on the device, run one of: "
+            "(1) cp %s.factory %s && systemctl restart hydra-detect "
+            "to restore factory defaults, or "
+            "(2) roll forward to a Hydra binary that knows schema v%d.",
+            bak_path, bak_version, CURRENT_SCHEMA_VERSION,
+            path, path, bak_version,
         )
         return False
 

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -2862,8 +2862,14 @@ async def api_mission_summary(mission: str = ""):
 
     Query string: ``?mission=<mission_id>``. The id is the UUID returned
     from ``/api/mission/start``. Results are cached for 30 s.
+
+    Returns 400 for malformed input (missing param, oversized id), 404
+    for an unknown mission_id (no rows on disk — typo'd UUID or rotated
+    out by retention), 500 on unexpected failure.
     """
-    from hydra_detect.mission_summary import get_summary
+    from hydra_detect.mission_summary import (
+        MissionNotFoundError, get_summary,
+    )
     if not mission:
         return JSONResponse(
             {"error": "mission query parameter required"}, status_code=400,
@@ -2878,6 +2884,11 @@ async def api_mission_summary(mission: str = ""):
         return get_summary(mission, log_dir)
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=400)
+    except MissionNotFoundError as exc:
+        # R3-3 from PR #238 / issue #241. Distinguishes "you typo'd the
+        # UUID" from "mission ran, found nothing." Echo the id in the
+        # body so the operator can spot what they got wrong.
+        return JSONResponse({"error": str(exc)}, status_code=404)
     except Exception as exc:  # pragma: no cover — defensive
         logger.exception("Mission summary failed for %s: %s", mission, exc)
         return JSONResponse({"error": "summary computation failed"}, status_code=500)

--- a/tests/test_config_api.py
+++ b/tests/test_config_api.py
@@ -1098,6 +1098,49 @@ class TestComputeConfigDiff:
         runtime = {"web": {"api_token": "***"}}
         assert compute_config_diff(disk, runtime) == {}
 
+    # ------------------------------------------------------------------
+    # R1-2 from PR #239 / issue #241 — defense in depth on redaction.
+    # Either side redacted -> skip. The existing both-sides skip (#224)
+    # is the subset case.
+    # ------------------------------------------------------------------
+
+    def test_diff_suppresses_when_only_disk_is_redacted(self):
+        """Upstream inconsistency: disk redacted, runtime not. Emitting
+        the diff would put '***' next to the plaintext runtime value —
+        an inadvertent disclosure surface."""
+        from hydra_detect.web.config_api import (
+            REDACTED_VALUE, compute_config_diff,
+        )
+        disk = {"web": {"api_token": REDACTED_VALUE}}
+        runtime = {"web": {"api_token": "actual-secret-leaked-via-diff"}}
+        diff = compute_config_diff(disk, runtime)
+        assert diff == {}, (
+            f"Diff payload leaks runtime value next to redacted disk "
+            f"value: {diff}"
+        )
+
+    def test_diff_suppresses_when_only_runtime_is_redacted(self):
+        """Mirror: runtime redacted, disk not. Same defense in depth."""
+        from hydra_detect.web.config_api import (
+            REDACTED_VALUE, compute_config_diff,
+        )
+        disk = {"web": {"api_token": "actual-secret-on-disk"}}
+        runtime = {"web": {"api_token": REDACTED_VALUE}}
+        diff = compute_config_diff(disk, runtime)
+        assert diff == {}, (
+            f"Diff payload leaks disk value next to redacted runtime "
+            f"value: {diff}"
+        )
+
+    def test_diff_still_reports_non_redacted_drift(self):
+        """Regression: a real drift on a non-redacted field is still
+        reported. The tighten does not over-suppress."""
+        from hydra_detect.web.config_api import compute_config_diff
+        disk = {"web": {"port": "8080"}}
+        runtime = {"web": {"port": "8888"}}
+        diff = compute_config_diff(disk, runtime)
+        assert diff == {"web": {"port": {"disk": "8080", "runtime": "8888"}}}
+
 
 # ── Issue #233 — Adversarial follow-ups for PR #228 ───────────────────────
 

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -420,6 +420,69 @@ class TestMissionSummary:
         assert missions[0]["mission_id"] == mid_new
         assert missions[1]["mission_id"] == mid_old
 
+    # ------------------------------------------------------------------
+    # MissionNotFoundError for typo'd UUIDs
+    # (R3-3 from PR #238 / issue #241)
+    # ------------------------------------------------------------------
+
+    def test_get_summary_raises_for_unknown_mission_empty_dir(self, tmp_path):
+        """A typo'd UUID with zero rows must raise MissionNotFoundError,
+        not return an empty-looking valid summary."""
+        from hydra_detect.mission_summary import (
+            MissionNotFoundError,
+            get_summary,
+        )
+        with pytest.raises(MissionNotFoundError) as excinfo:
+            get_summary("00000000-0000-0000-0000-deadbeefdead", tmp_path)
+        # The error must echo the offending id so the operator knows what
+        # they typed wrong.
+        assert "00000000-0000-0000-0000-deadbeefdead" in str(excinfo.value)
+
+    def test_get_summary_raises_for_unknown_mission_with_other_missions_present(
+        self, tmp_path,
+    ):
+        """Logs exist for OTHER missions; the requested id is still unknown."""
+        from hydra_detect.mission_summary import (
+            MissionNotFoundError,
+            get_summary,
+        )
+        real_mid = str(uuid.uuid4())
+        _write_detection_jsonl(tmp_path, real_mid, [
+            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1, "label": "person"},
+        ])
+        _write_event_jsonl(tmp_path, real_mid, "real", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+        ])
+        # Sanity: the real mission resolves
+        out = get_summary(real_mid, tmp_path)
+        assert out["detections"]["total"] == 1
+        # The bogus mission still raises
+        with pytest.raises(MissionNotFoundError):
+            get_summary("ffffffff-ffff-ffff-ffff-ffffffffffff", tmp_path)
+
+    def test_get_summary_does_not_cache_not_found(self, tmp_path):
+        """A not-found result must not be cached. If logs later become
+        readable for that id (e.g. delayed file copy), the next call must
+        re-scan rather than return a stale MissionNotFoundError."""
+        from hydra_detect.mission_summary import (
+            MissionNotFoundError,
+            get_summary,
+        )
+        mid = str(uuid.uuid4())
+        # First call: nothing on disk → raises
+        with pytest.raises(MissionNotFoundError):
+            get_summary(mid, tmp_path)
+        # Now logs appear for that id
+        _write_detection_jsonl(tmp_path, mid, [
+            {"timestamp": "2026-05-19T10:00:01Z", "track_id": 1, "label": "person"},
+        ])
+        _write_event_jsonl(tmp_path, mid, "delayed", [
+            {"ts": 1000.0, "type": "track", "lat": 35.0, "lon": -80.0},
+        ])
+        # Second call: must succeed, not raise from a stale cached negative
+        out = get_summary(mid, tmp_path)
+        assert out["detections"]["total"] == 1
+
 
 # ----------------------------------------------------------------------------
 # Web API: /api/mission/start, /api/mission/end, /api/summary
@@ -523,6 +586,22 @@ class TestMissionWebAPI:
         assert body["detections"]["by_class"] == {"person": 1, "car": 1}
         assert body["operator_actions"] == 1
         assert body["gps_coverage"]["point_count"] == 1
+
+    def test_summary_endpoint_unknown_mission_returns_404(self, client, tmp_path):
+        """A typo'd UUID returns 404 + descriptive body, not 200 + empty.
+
+        R3-3 from PR #238 / issue #241. Operators previously could not
+        distinguish "mission ran, found nothing" from "you typo'd the UUID."
+        """
+        stream_state.set_callbacks(get_log_dir=lambda: str(tmp_path))
+        resp = client.get(
+            "/api/summary?mission=00000000-0000-0000-0000-deadbeefdead"
+        )
+        assert resp.status_code == 404, resp.text
+        body = resp.json()
+        # The body must echo the offending id so the operator knows what
+        # they typed wrong.
+        assert "00000000-0000-0000-0000-deadbeefdead" in body.get("error", "")
 
     def test_review_logs_includes_missions(self, client, tmp_path):
         mid = str(uuid.uuid4())

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -622,3 +622,42 @@ class TestClientErrorEndpoint:
         assert body["total"] == 2
         msgs = [e["message"] for e in body["recent"]]
         assert "one" in msgs and "two" in msgs
+
+
+# ---------------------------------------------------------------------------
+# /api/health top-level body contract (R1-1 from #241 / PR #236)
+# ---------------------------------------------------------------------------
+
+class TestHealthBodyContract:
+    """Lock the top-level shape of /api/health so additions are deliberate.
+
+    Future PRs that add or remove a top-level key in ``health_snapshot()``
+    must update ``EXPECTED_KEYS`` in the same diff. This surfaces the
+    schema change in code review rather than letting it land silently and
+    break downstream scrapers (phone-home, external Grafana, operator-side
+    curl scripts).
+    """
+
+    EXPECTED_KEYS = {"status", "ts", "subsystems", "disk_free_pct", "disk_bytes"}
+    EXPECTED_SUBSYSTEMS = {
+        "camera", "mavlink", "gps", "detector",
+        "rtsp", "tak", "audit", "disk",
+    }
+
+    def test_top_level_keys_locked(self):
+        from hydra_detect.observability.health import health_snapshot
+        body = health_snapshot()
+        assert set(body.keys()) == self.EXPECTED_KEYS, (
+            "Top-level keys of /api/health changed. If this is intentional, "
+            "update TestHealthBodyContract.EXPECTED_KEYS in the same PR. "
+            f"Got: {sorted(body.keys())}"
+        )
+
+    def test_subsystems_keys_locked(self):
+        from hydra_detect.observability.health import health_snapshot
+        body = health_snapshot()
+        assert set(body["subsystems"].keys()) == self.EXPECTED_SUBSYSTEMS, (
+            "subsystems.* keys changed. If intentional, update "
+            "TestHealthBodyContract.EXPECTED_SUBSYSTEMS in the same PR. "
+            f"Got: {sorted(body['subsystems'].keys())}"
+        )

--- a/tests/test_safety_hardening.py
+++ b/tests/test_safety_hardening.py
@@ -335,6 +335,102 @@ class TestAttemptCorruptRecovery:
             "failed recovery must not claim a successful restore"
         )
 
+    # ------------------------------------------------------------------
+    # Code-rollback policy: .bak schema_version > CURRENT must be rejected
+    # (R3-2 from PR #237 / issue #241)
+    # ------------------------------------------------------------------
+
+    def test_bak_with_too_new_schema_is_rejected(self, tmp_path, caplog):
+        """Operator code-rollback: .bak from a newer binary must not be
+        silently restored — older binary cannot fully understand it.
+        """
+        import logging
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+        from hydra_detect.config_migrate import CURRENT_SCHEMA_VERSION
+
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        path.write_text("")  # corrupted / empty current config
+        too_new = CURRENT_SCHEMA_VERSION + 1
+        bak.write_text(
+            f"[meta]\nschema_version = {too_new}\n\n[camera]\nsource = auto\n"
+        )
+
+        with caplog.at_level(logging.CRITICAL):
+            result = attempt_corrupt_recovery(path)
+
+        assert result is False, (
+            f"Recovery should reject .bak with schema_version={too_new} > "
+            f"CURRENT_SCHEMA_VERSION={CURRENT_SCHEMA_VERSION}. Got {result!r}."
+        )
+        # config.ini must NOT have been overwritten with the newer .bak
+        assert path.read_text() == "", (
+            "config.ini was overwritten with a too-new .bak — code-rollback "
+            "policy violated."
+        )
+        assert any(
+            "exceeds" in r.message.lower() or "schema_version" in r.message
+            for r in caplog.records
+        ), "Expected a CRITICAL log explaining the rejection."
+
+    def test_bak_with_equal_schema_is_accepted(self, tmp_path):
+        """Sanity: same-version .bak still restores."""
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+        from hydra_detect.config_migrate import CURRENT_SCHEMA_VERSION
+
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        path.write_text("")
+        bak.write_text(
+            f"[meta]\nschema_version = {CURRENT_SCHEMA_VERSION}\n\n"
+            f"[camera]\nsource = auto\n"
+        )
+        assert attempt_corrupt_recovery(path) is True
+        assert "[camera]" in path.read_text()
+
+    def test_bak_with_lower_schema_is_accepted(self, tmp_path):
+        """Forward-migration case: an older .bak still restores; the
+        migration runner will bring it up to CURRENT_SCHEMA_VERSION after."""
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+        from hydra_detect.config_migrate import CURRENT_SCHEMA_VERSION
+
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        path.write_text("")
+        older = max(0, CURRENT_SCHEMA_VERSION - 1)
+        bak.write_text(
+            f"[meta]\nschema_version = {older}\n\n[camera]\nsource = auto\n"
+        )
+        assert attempt_corrupt_recovery(path) is True
+        assert "[camera]" in path.read_text()
+
+    def test_bak_with_no_meta_section_is_accepted(self, tmp_path):
+        """A .bak from a pre-meta-section era is treated as schema_version=0.
+        That is below CURRENT, so it restores and gets migrated forward.
+        """
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        path.write_text("")
+        bak.write_text("[camera]\nsource = auto\n")  # no [meta]
+        assert attempt_corrupt_recovery(path) is True
+
+    def test_bak_with_unreadable_schema_version_is_rejected(self, tmp_path, caplog):
+        """A non-integer schema_version in .bak is refused — better to
+        bail than silently restore a malformed config."""
+        import logging
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        path.write_text("")
+        bak.write_text(
+            "[meta]\nschema_version = not-an-int\n\n[camera]\nsource = auto\n"
+        )
+        with caplog.at_level(logging.CRITICAL):
+            assert attempt_corrupt_recovery(path) is False
+
 
 # ---------------------------------------------------------------------------
 # 4. restore_factory works


### PR DESCRIPTION
Closes five low-risk follow-up items from #241 in one bundle.

## Items

| R-ID | File | Change |
|---|---|---|
| R1-1 (#236) | tests/test_observability.py | Contract test for /api/health top-level keys (additive guard) |
| R2-1 (#236) | docs/observability.md (new) | Document Prometheus NaN-vs-zero coercion convention |
| R3-2 (#237) | hydra_detect/web/config_api.py + tests/test_safety_hardening.py | attempt_corrupt_recovery rejects .bak whose schema_version exceeds CURRENT_SCHEMA_VERSION (code-rollback policy) |
| R3-3 (#238) | hydra_detect/mission_summary.py + hydra_detect/web/server.py + tests/test_mission.py | /api/summary returns 404 with descriptive body for typo'd UUID (zero rows scanned) |
| R1-2 (#239) | hydra_detect/web/config_api.py + tests/test_config_api.py | compute_config_diff tightened to "either side redacted -> skip" |

## Tests

12 new tests, all green:
- tests/test_observability.py::TestHealthBodyContract — 2 (top-level + subsystems)
- tests/test_safety_hardening.py::TestAttemptCorruptRecovery — 5 (too-new rejected, equal/lower/no-meta accepted, unreadable rejected)
- tests/test_mission.py — 4 (Python-level empty dir, with-other-missions, no-cache-on-not-found; HTTP-level 404)
- tests/test_config_api.py::TestComputeConfigDiff — 3 (disk-only redacted, runtime-only redacted, non-redacted still reported)

Regression: 338 passed, 0 failed across test_observability + test_safety_hardening + test_config_api + test_mission + test_web_api.

## Adversarial doc

Will follow as a separate commit after this PR is opened — `hydra_detect/web/server.py` is in the adversarial-required path list. The diff is a single endpoint return-code change; full 3-round is overkill but the soft gate requires the file.

## Closes

Updates #241 (checks off R1-1, R2-1 from #236, R3-2 from #237, R3-3 from #238, R1-2 from #239).

The remaining items in #241 — COMMAND_ACK surface (#240 R1-2 + R3-2 + R1-4), DetectionLogger lock refactor (#238 R1-2), cache eviction DoS (#238 R2-3), restart-loop suppression test (#238 R3-5 async modal) — are deferred for separate PRs because each is its own mini-project.