### PR TITLE
fix(ci): install cryptography via pytak[with-crypto] extras

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ uvicorn[standard]>=0.24,<1.0
 jinja2>=3.1,<4.0
 requests>=2.31,<3.0
 ntplib>=0.4,<1.0
-pytak>=7.3,<8.0
+pytak[with-crypto]>=7.3,<8.0


### PR DESCRIPTION
Unblocks the test job on CI.

## Symptom

Every PR's test job fails during collection with:
\`\`\`
File pytak/crypto_functions.py:124: in <module>
    def _pkcs12_friendly_name(cert: Certificate) -> Optional[bytes]:
E   NameError: name 'Certificate' is not defined
\`\`\`

Aborts collection for 13 test files (test_adsb_codec, test_callsign_matcher, test_camera_loss, test_graceful_shutdown, test_mavlink_relay, test_pipeline_callbacks, test_safety_invariants, test_sitl_mode, test_tak, test_tak_input, test_tak_security, test_tak_unicast_manifest, test_vehicle_config).

## Cause

pytak 7.x references the cryptography ``Certificate`` type at module top-level (\`pytak/crypto_functions.py:124\`) without a conditional import guard. The cryptography package is declared optional by pytak (warned via \`UserWarning\`), but the unconditional type annotation makes the import fail at module load when cryptography is absent.

Confirmed pre-existing on main as of \`8811fa5\` (post-#218 merge); affects every queued PR until resolved.

## Fix

One-line change to \`requirements.txt\`: \`pytak>=7.3,<8.0\` -> \`pytak[with-crypto]>=7.3,<8.0\`. The \`with-crypto\` extra pulls in cryptography as a transitive dep, which provides the missing symbol at pytak import. Matches the upstream remediation hint in the warning text itself.

## Verification

Local: \`pytest --collect-only tests/test_adsb_codec.py tests/test_tak.py\` -> 46 tests collected cleanly. Cryptography is already present on the Jetson and dev workstations (transitive dep of other packages), which is why this regression is invisible outside CI.

## Closes

Doesn't close an issue (no tracker filed) but unblocks PR #260 and any future PRs.