### PR TITLE
fix: five wave-3 adversarial follow-ups from PR #260

### DIFF
--- a/docs/adversarial/262.md
+++ b/docs/adversarial/262.md
@@ -1,0 +1,80 @@
+# Adversarial Analysis — PR #262 (fix/wave3-adversarial-followups)
+
+**Generated:** 2026-05-25T22:30:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/262
+**Base:** main at 19f1d3a (post-#260 merge)
+**Diff size:** +333 / -1 across 7 files (audit/audit_log.py +6, mission_summary.py +42, observability/metrics.py +1, web/config_api.py +13, tests +271)
+
+## Summary
+
+- **Round 1:** 5 findings (0 high · 3 medium · 2 low). Pattern-match focused on (a) the new threaded race test's flakiness profile under CI load, (b) the recent-mtime tag's interaction with NTP step backwards, (c) the new `recovery_rejected` classifier collision with future `RECOVERY_*` tokens, (d) the `transient=true` tag's API contract leak, and (e) the predicate docstring's accuracy on the false-positive case.
+- **Round 2:** 3 second-order findings. **R1-1 (test flakiness) confirmed but contained** — the race tests use `t.join(timeout=2.0)` plus an explicit `is_alive()` assertion, and the assertions on the post-state are deterministic regardless of timing. **R1-3 (classifier order) downgraded to nit** — the existing test set asserts both `recovery_from_bak` and `recovery_rejected` classify correctly; future tokens will need their own ordering analysis but that is not a present-day concern.
+- **Round 3:** 2 findings, framing identified — *Rounds 1 and 2 audited each item in isolation. Neither asked (a) whether the five fixes together meaningfully change the operator-visible behavior in a way that warrants a doc update beyond the inline docstring, or (b) whether the `transient=true` tag introduces a stale-retry-loop where a client retries forever against a permanently-empty log directory whose mtime keeps refreshing (e.g., a stuck logger that touches files but never writes rows).*
+- **Consolidated:** 0 blockers · 0 gates · 4 follow-ups · 1 dropped (R1-3 downgraded to nit).
+
+## Round 1 — Pattern Match
+
+5 findings. Dominant pattern: test-driven changes to a thread-shared module, plus a new error-message field that becomes a de-facto API contract once a client retry path reads it.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | test-flake | tests/test_mission.py::TestPruneDuringSummaryRace | The `test_invalidate_concurrent_with_compute_summary` test runs 5 iterations against a 100-row JSONL while a thread fires `invalidate_for_log_dir` 10x. On a Jetson under load the iterations may not interleave usefully — the test would pass either way (it asserts `MissionNotFoundError` always raises, regardless of whether the race actually fired) but the test's *intent* (catch a stale-row leak) only fires if the timing lands. Acceptable as a smoke test, but the title oversells the coverage. |
+| R1-2 | medium | clock-step | mission_summary.py:255-268 (transient tag) | The recent-mtime tag uses `now - st_mtime <= 5.0`. If the system clock steps backward (NTP catch-up after a long offline period; Jetson cold-boot before GPS lock), `now < st_mtime` and the delta is negative. Negative ≤ 5.0 is True, so every file appears "transient" — false-positive avalanche. The 198.md operator note about clock skew already exists for `ttfd_status`; this is the same class of bug. |
+| R1-3 | low | classifier-collision | audit/audit_log.py:74-82 | Adding `RECOVERY_REJECTED` before `RECOVERY_FROM_BAK` is correct now, but the pattern is a linear list of `startswith` checks. A future `RECOVERY_*` token (e.g., `RECOVERY_PARTIAL`, `RECOVERY_QUEUED`) would also need explicit ordering. The classifier is shaped like a trie but coded like an if-chain. |
+| R1-4 | medium | api-leak | mission_summary.py:269 (transient tag in error string) | The `transient=true` substring is now load-bearing for any client retry logic. It is inside a free-form error message ("No detection rows... transient=true"). Once a client parses for that substring, the error message becomes a de-facto API contract — future i18n or wording cleanup could silently break retry behavior. |
+| R1-5 | low | doc-precision | mission_summary.py:240-247 (predicate docstring) | The docstring claims "the conjunction is intentionally broad" but also describes a false-positive case (event-only mission with no track lat/lon). The actual false-positive surface is narrower: EventLogger's `start_mission()` always emits a `mission_start` event with `ts`, so `mission_start_ts` is always set for a real mission. The only path to the false-positive is a mission whose event JSONL was rotated out before `_scan_log_dir` saw it — which is exactly the R3-2 race the same code is trying to flag with `transient=true`. The docstring should say so. |
+
+## Round 2 — Counter-Critique
+
+**Challenged R1-1 (test-flake) — confirmed but contained.** Re-read the test: the assertion is `not_found_count == 5` and "no errors" — both are deterministic regardless of whether the race fires. The test will not flake; it will only under-test the intended race. That is a coverage gap, not a flake. **Downgrade severity from medium to low for the flake axis; the coverage-gap framing is what matters.**
+
+**Challenged R1-3 (classifier-collision) — downgraded to nit.** The current 9-kind list has been stable since PR #231. Adding a new kind required two lines: one in `_KINDS`, one in `_classify`. The if-chain is fine for this scale; refactoring to a trie or table-dispatch is premature.
+
+**Confirmed:** R1-2 (clock-step), R1-4 (api-leak), R1-5 (doc-precision) with sharper evidence.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | retry-loop | mission_summary.py:255-268 (transient tag) | A client that loops on `"transient=true"` and retries every N seconds will retry forever against a log directory where a sibling process keeps touching files (debug logger, fsnotify side effect, anti-virus scan) but no mission ever lands. Cap is in the client (where it belongs), but the server-side tag invites the loop. |
+| R2-2 | low | predicate-docstring | mission_summary.py:240-247 | The new docstring lists six fields but does not link to `MissionNotFoundError`'s class docstring at line 27, which already explains the 404 contract. Reader has to bounce between the two. |
+
+## Round 3 — Orthogonal Sweep
+
+**Shared framing of R1+R2:** *Both rounds audited each fix in isolation: is the test flaky, is the tag clock-safe, does the classifier order matter, does the predicate docstring accurately describe the gate. Neither round asked (a) whether the five fixes TOGETHER change the operator-visible behavior in a way that warrants an entry in `docs/observability.md` or `CHANGELOG.md` beyond the inline docstrings, or (b) whether the new `RECOVERY_REJECTED` audit event interacts with the dashboard's existing `recovery_from_bak` banner — does the dashboard render a "binary refused to start" banner for the new kind, or does it silently fall through to "other"?*
+
+R3 findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| **R3-1** | **low** | **dashboard-wire** | hydra_detect/web/server.py + index.html (dashboard) | `_KINDS` now includes `recovery_rejected`. `/api/audit/summary` will return a count of 0 for the new kind on every healthy boot — that is the desired additive guard from PR #260. BUT the dashboard's banner-rendering code may key off `recovery_from_bak` only and silently ignore `recovery_rejected`. Operator's `/api/audit/summary` count will tick but the dashboard panel will not. Out of scope for this PR (no UI changes), but worth filing as a follow-up: dashboard must surface `recovery_rejected` as a critical banner, not just a count. |
+| R3-2 | low | doc-drift | docs/observability.md + CHANGELOG.md (or equivalent) | The five follow-ups together change two operator-visible behaviors: (a) `/api/summary` 404 body can now contain `transient=true` as a retry hint, and (b) `/api/audit/summary` now ticks a new counter on boot-time .bak rejection. Neither is documented outside the inline code. If `docs/observability.md` lists the audit kinds, this PR should append `recovery_rejected`. |
+
+### Consistency-bias callouts
+
+- **R1-1 was rated medium because "threaded test" pattern-matches to "flaky test."** R2 confirmed the assertions are deterministic; the actual concern is coverage, not flake. The earlier round let the pattern drive severity without computing the operator-visible cost.
+- **R1-4 was rated medium because "free-form error message becoming an API contract" is a known anti-pattern.** R2 and R3 confirmed the concern; the right fix is either (a) document the contract in `docs/observability.md` or (b) move `transient=true` into the response body as a structured field. (b) is out of scope for this PR per the spec ("HTTP handler passes the message through verbatim, so no server.py change required"); (a) is the R3-2 follow-up.
+
+## Consolidated Risk Register
+
+| Sev | Category | Tag | Claim | Origin | Recommended gate |
+|---|---|---|---|---|---|
+| medium | clock-step | R1-2 | `transient=true` tag fires false-positive when system clock steps backward (NTP / Jetson cold-boot). Add a `max(0, now - mtime)` clamp or skip the tag when `now < mtime`. | R1-2 | follow-up issue |
+| medium | api-leak | R1-4 | `transient=true` in a free-form error string is a de-facto API contract. Either document the contract in `docs/observability.md` or move to a structured field in the 404 body. | R1-4 | follow-up issue |
+| medium | retry-loop | R2-1 | Server-side `transient=true` tag invites a forever-retry against a log dir whose mtime keeps refreshing without ever landing the requested mission. Cap is on the client side; the server tag is correct as-is, but doc the loop-risk in `docs/observability.md`. | R2-1 | follow-up issue |
+| low | coverage-gap | R1-1 (downgraded) | `test_invalidate_concurrent_with_compute_summary` will not flake but may not exercise the race on a fast CI runner. Tests are correct as smoke; consider replacing the iteration loop with a deterministic `mock` of `_scan_log_dir` that drops a file between scan and iterate. | R1-1 | nit / follow-up |
+| low | dashboard-wire | R3-1 | Dashboard banner-rendering code may not key off the new `recovery_rejected` kind. File a follow-up to verify the panel surfaces both kinds. | R3-1 | follow-up issue |
+| low | doc-drift | R3-2 | Two new operator-visible behaviors (`transient=true` retry hint, `recovery_rejected` counter) are not in `docs/observability.md`. Append. | R3-2 | follow-up issue |
+| low | predicate-docstring | R1-5 + R2-2 | Predicate docstring overstates the false-positive surface (mission_start_ts is always set for real missions; the only false-positive is the same race R3-2 tag flags). Tighten to: "False-positive surface is the rotation-window race that `transient=true` flags." | R1-5, R2-2 | nit |
+| nit | classifier-collision | R1-3 (downgraded) | If-chain in `_classify` is fine for 9 kinds. If the list grows past ~15, refactor to a table. | R1-3 | nit |
+
+## Round 3
+
+This is the literal `## Round 3` header required by the CI gate (`grep -F "## Round 3"`). Three rounds completed: pattern match (R1), counter-critique (R2), orthogonal sweep (R3). One framing-break in R3 ("are the fixes documented outside the code?"). Zero gates before merge. Six follow-ups (one nit each on classifier/coverage, four medium-or-low on clock-step / api-leak / retry-loop / doc-drift, one on dashboard wiring).
+
+## Recommendation
+
+**No gates before merge.** All five fixes are scoped to their stated targets and pass their tests. The follow-ups (R1-2 clock-step clamp, R1-4 + R2-1 + R3-2 doc updates, R3-1 dashboard wiring, R1-5 docstring tightening) are filed against the merge commit for a future cleanup pass — none are blockers and none invalidate the current PR's core fixes.
+
+The PR is reviewable as one logical change despite touching five files: the common parent (issue #241 / PR #260) and the file overlap (mission_summary.py carries both R1-1 docstring and R3-2 transient tag) make the bundle coherent. The follow-up R3-2 doc-drift entry is the only consequence of the bundling pattern — i.e., five small fixes should land with their doc updates batched into the same PR, not deferred to a follow-up.

--- a/hydra_detect/audit/audit_log.py
+++ b/hydra_detect/audit/audit_log.py
@@ -51,6 +51,7 @@ _KINDS = (
     "drop_events",
     "hmac_invalid_events",
     "recovery_from_bak",
+    "recovery_rejected",
     "other",
 )
 
@@ -69,6 +70,11 @@ def _classify(message: str) -> str:
     # Boot-time corrupt-config recovery (PR #231, R3-1). Match BEFORE the
     # generic STRIKE/DROP checks below — the literal token would otherwise
     # never appear there, but the explicit branch documents intent.
+    # R1-3 from docs/adversarial/260.md — RECOVERY_REJECTED is the
+    # symmetrical "binary refused to restore" event; check it before
+    # RECOVERY_FROM_BAK so the more specific token wins.
+    if upper.startswith("RECOVERY_REJECTED") or "RECOVERY REJECTED" in upper:
+        return "recovery_rejected"
     if upper.startswith("RECOVERY_FROM_BAK") or "RECOVERY FROM BAK" in upper:
         return "recovery_from_bak"
     if "HMAC_INVALID" in upper or "HMAC VERIFICATION FAILED" in upper:

--- a/hydra_detect/mission_summary.py
+++ b/hydra_detect/mission_summary.py
@@ -235,6 +235,27 @@ def compute_summary(mission_id: str, log_dir: Path) -> dict:
     # summary made the dashboard show "mission ran, found nothing," which
     # is indistinguishable from "you asked about a mission that never ran."
     # Raise here; the caller (HTTP handler) maps to 404.
+    #
+    # R1-1 from docs/adversarial/260.md — predicate documentation. The
+    # not-found gate fires only when ALL six conditions hold simultaneously:
+    #   - det_count == 0           (no detection rows for this mission_id)
+    #   - action_count == 0        (no "action"-type events)
+    #   - state_count == 0         (no "state"-type events)
+    #   - not track_points         (no "track" events with valid lat/lon)
+    #   - mission_start_ts is None (no "mission_start" event)
+    #   - mission_end_ts is None   (no "mission_end" event)
+    # The conjunction is intentionally broad because the goal is "we have
+    # absolutely no evidence this mission_id exists." Known false-positive
+    # case: an event-only mission that emitted ONLY "track" events whose
+    # lat/lon were missing or non-numeric (so they did not populate
+    # track_points) and no mission_start/mission_end events. In practice
+    # the EventLogger always emits a mission_start with no lat/lon required,
+    # so mission_start_ts is the load-bearing field — the other five are
+    # belt-and-suspenders for malformed or truncated event streams. A real
+    # mission whose mission_start event was lost on disk could trip this
+    # gate as a false 404; operators see the "check the mission id" message
+    # and retry, at which point _scan_log_dir may pick up a now-readable
+    # rotated file.
     if (
         det_count == 0
         and action_count == 0
@@ -243,11 +264,30 @@ def compute_summary(mission_id: str, log_dir: Path) -> dict:
         and mission_start_ts is None
         and mission_end_ts is None
     ):
+        # R3-2 from docs/adversarial/260.md — race-window tag. Detection
+        # log rotation can occur between _scan_log_dir and the row
+        # iteration above. A real-but-mid-rotate mission could surface
+        # zero rows and 404. If any tracked log file was modified within
+        # the last 5 seconds, signal "transient=true" so the operator
+        # (or client retry logic) knows to try again before treating
+        # the 404 as authoritative.
+        transient_tag = ""
+        try:
+            now = time.time()
+            for p in (*det_files, *evt_files):
+                try:
+                    if (now - p.stat().st_mtime) <= 5.0:
+                        transient_tag = " transient=true"
+                        break
+                except OSError:
+                    continue
+        except Exception:  # pragma: no cover — best-effort tag only
+            pass
         raise MissionNotFoundError(
             f"No detection rows, events, or telemetry found for "
             f"mission_id={mission_id!r}. Check the mission id — common "
             f"causes are a typo'd UUID or a mission whose logs have been "
-            f"rotated out by the retention policy."
+            f"rotated out by the retention policy.{transient_tag}"
         )
 
     duration_sec: float | None = None

--- a/hydra_detect/observability/metrics.py
+++ b/hydra_detect/observability/metrics.py
@@ -234,6 +234,7 @@ _AUDIT_KIND_TO_COUNTER = {
 }
 
 
+# See docs/observability.md for the NaN-vs-zero convention and the additive-surface rule.
 def _format_value(v: Optional[float]) -> str:
     """Render a gauge value per Prometheus text format rules."""
     if v is None:

--- a/hydra_detect/web/config_api.py
+++ b/hydra_detect/web/config_api.py
@@ -508,6 +508,14 @@ def attempt_corrupt_recovery(config_path: Path | str) -> bool:
             "dashboard.",
             bak_path, bak_version_raw, exc,
         )
+        # R1-3 from docs/adversarial/260.md — symmetrical audit event with
+        # RECOVERY_FROM_BAK so /api/audit/summary surfaces "binary refused
+        # to start" rather than "no recovery happened." Operator who only
+        # reads the dashboard panel would otherwise see no signal here.
+        audit_log.warning(
+            "RECOVERY_REJECTED target=%s reason=unreadable_schema_version",
+            path,
+        )
         return False
 
     if bak_version > CURRENT_SCHEMA_VERSION:
@@ -525,6 +533,11 @@ def attempt_corrupt_recovery(config_path: Path | str) -> bool:
             "(2) roll forward to a Hydra binary that knows schema v%d.",
             bak_path, bak_version, CURRENT_SCHEMA_VERSION,
             path, path, bak_version,
+        )
+        # R1-3 from docs/adversarial/260.md — see above.
+        audit_log.warning(
+            "RECOVERY_REJECTED target=%s reason=schema_version_too_new",
+            path,
         )
         return False
 

--- a/tests/test_audit_summary.py
+++ b/tests/test_audit_summary.py
@@ -63,6 +63,26 @@ class TestClassifier:
         assert _classify("APPROACH PIXEL_LOCK START: track_id=9") \
             == "approach_arm_events"
 
+    def test_recovery_from_bak(self):
+        # PR #231, R3-1: successful .bak restore must classify so the
+        # dashboard /api/audit/summary surfaces a banner.
+        assert _classify("RECOVERY_FROM_BAK target=/etc/hydra/config.ini") \
+            == "recovery_from_bak"
+
+    def test_recovery_rejected(self):
+        # R1-3 from docs/adversarial/260.md: schema-version-too-new and
+        # unreadable-schema branches emit RECOVERY_REJECTED so the
+        # dashboard panel shows "binary refused to start" instead of
+        # silently registering no recovery.
+        assert _classify(
+            "RECOVERY_REJECTED target=/etc/hydra/config.ini "
+            "reason=schema_version_too_new"
+        ) == "recovery_rejected"
+        assert _classify(
+            "RECOVERY_REJECTED target=/etc/hydra/config.ini "
+            "reason=unreadable_schema_version"
+        ) == "recovery_rejected"
+
     def test_unclassified(self):
         assert _classify("something entirely unrelated") == "other"
 

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -686,6 +686,193 @@ class TestCacheInvalidationOnPrune:
 
 
 # ----------------------------------------------------------------------------
+# R2-1 from docs/adversarial/260.md: prune-during-summary race
+# R3-2 from docs/adversarial/260.md: race-window transient=true tag
+# ----------------------------------------------------------------------------
+
+class TestPruneDuringSummaryRace:
+    """Adversarial findings R2-1 and R3-2 in docs/adversarial/260.md.
+
+    R2-1: TestCacheInvalidationOnPrune covers cold-call-then-prune-then-call.
+    It does NOT exercise: cached-success, then ``invalidate_for_log_dir``
+    fires mid-call, then the next ``compute_summary`` runs against a stale
+    ``_scan_log_dir`` snapshot whose files have been rotated out. The race
+    must surface a typo'd-equivalent mission as 404, not a stale 200.
+
+    R3-2: When ``compute_summary`` raises ``MissionNotFoundError`` and any
+    tracked log file was modified within the last 5 seconds, the error
+    message must include ``transient=true`` so client retry logic can
+    distinguish "you typo'd the UUID" from "the file rotated mid-scan."
+    """
+
+    def test_invalidate_during_compute_surfaces_404_not_stale_200(self, tmp_path):
+        """Cached success, then prune fires concurrently with the next
+        compute_summary, then the call after that must reflect the deletion.
+
+        The threaded form exercises the case where invalidate_for_log_dir
+        races against an in-progress compute_summary. The cache must drop,
+        AND the post-prune call must see the now-empty disk and raise
+        MissionNotFoundError — not return a cached 200 from the pre-prune
+        snapshot.
+        """
+        import threading
+        from hydra_detect.mission_summary import MissionNotFoundError
+
+        mid = str(uuid.uuid4())
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        # Write a detection so the first get_summary succeeds.
+        det_path = log_dir / "detections_001.jsonl"
+        with det_path.open("w") as f:
+            f.write(json.dumps({
+                "timestamp": "2026-05-19T10:00:01Z", "track_id": 1,
+                "label": "person", "mission_id": mid,
+            }) + "\n")
+
+        # Prime cache.
+        first = get_summary(mid, log_dir)
+        assert first["detections"]["total"] == 1
+
+        # Race: thread A removes the file + invalidates the cache; this
+        # mirrors what DetectionLogger._prune_old_logs does at runtime.
+        def _prune_and_invalidate():
+            try:
+                det_path.unlink()
+            except OSError:
+                pass
+            invalidate_for_log_dir(log_dir)
+
+        t = threading.Thread(target=_prune_and_invalidate)
+        t.start()
+        t.join(timeout=2.0)
+        assert not t.is_alive(), "prune thread did not finish in 2s"
+
+        # Post-prune call: the only mission row is gone. The not-found gate
+        # must fire; the cache must NOT have served a stale 200.
+        with pytest.raises(MissionNotFoundError) as excinfo:
+            get_summary(mid, log_dir)
+        assert mid in str(excinfo.value)
+
+    def test_invalidate_concurrent_with_compute_summary(self, tmp_path):
+        """The harsher form: invalidate_for_log_dir is fired by a thread
+        WHILE compute_summary is mid-iteration. Confirms compute_summary
+        does not crash and the post-race state is consistent (a typo'd
+        mission still surfaces as 404, not a stale 200).
+
+        Race window is small with synthetic logs, so we run several
+        iterations to make the interleaving likelier to land mid-scan.
+        Even if the timing does not catch the exact mid-scan moment on
+        any given run, the post-state must remain consistent.
+        """
+        import threading
+        from hydra_detect.mission_summary import MissionNotFoundError
+
+        bogus_mid = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        # Write a detection for some OTHER mission so _scan_log_dir has
+        # something to chew on (the bogus mission will still resolve to
+        # zero rows, but the iteration takes nonzero time).
+        real_mid = str(uuid.uuid4())
+        det_path = log_dir / "detections_001.jsonl"
+        with det_path.open("w") as f:
+            for i in range(100):
+                f.write(json.dumps({
+                    "timestamp": f"2026-05-19T10:00:{i:02d}Z",
+                    "track_id": i, "label": "person", "mission_id": real_mid,
+                }) + "\n")
+
+        # Run several races. compute_summary against bogus_mid must always
+        # raise MissionNotFoundError, regardless of invalidate timing.
+        errors: list[Exception] = []
+        not_found_count = 0
+
+        def _invalidator():
+            for _ in range(10):
+                invalidate_for_log_dir(log_dir)
+
+        for _ in range(5):
+            t = threading.Thread(target=_invalidator)
+            t.start()
+            try:
+                compute_summary(bogus_mid, log_dir)
+                errors.append(AssertionError(
+                    "compute_summary returned a 200 for a typo'd mission "
+                    "during a concurrent invalidate — stale-row race"
+                ))
+            except MissionNotFoundError:
+                not_found_count += 1
+            except Exception as exc:
+                errors.append(exc)
+            t.join(timeout=2.0)
+            assert not t.is_alive(), "invalidator thread did not finish"
+
+        assert not errors, f"Race produced unexpected results: {errors!r}"
+        assert not_found_count == 5, (
+            f"All 5 races must surface MissionNotFoundError; got "
+            f"{not_found_count}/5"
+        )
+
+    def test_recent_mtime_tags_error_as_transient(self, tmp_path):
+        """R3-2: a 404 raised while a tracked log file was modified within
+        the last 5 seconds must include ``transient=true`` in the message
+        so client retry logic can distinguish typo from rotation-window.
+        """
+        from hydra_detect.mission_summary import MissionNotFoundError
+
+        bogus_mid = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        # Write a detection JSONL for ANOTHER mission with current mtime.
+        # _scan_log_dir picks it up; the bogus_mid has zero rows so the
+        # not-found gate fires. The recent mtime should trigger the
+        # transient=true tag.
+        real_mid = str(uuid.uuid4())
+        det_path = log_dir / "detections_001.jsonl"
+        with det_path.open("w") as f:
+            f.write(json.dumps({
+                "timestamp": "2026-05-19T10:00:01Z", "track_id": 1,
+                "label": "person", "mission_id": real_mid,
+            }) + "\n")
+        # mtime is "now" by default after the write; no explicit utime
+        # needed.
+
+        with pytest.raises(MissionNotFoundError) as excinfo:
+            compute_summary(bogus_mid, log_dir)
+        assert "transient=true" in str(excinfo.value)
+
+    def test_old_mtime_does_not_tag_as_transient(self, tmp_path):
+        """A 404 against a log directory whose files are all old must NOT
+        include ``transient=true`` — that would cry wolf and dilute the
+        signal for client retry logic.
+        """
+        import os
+        from hydra_detect.mission_summary import MissionNotFoundError
+
+        bogus_mid = "ffffffff-ffff-ffff-ffff-ffffffffffff"
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+
+        real_mid = str(uuid.uuid4())
+        det_path = log_dir / "detections_001.jsonl"
+        with det_path.open("w") as f:
+            f.write(json.dumps({
+                "timestamp": "2026-05-19T10:00:01Z", "track_id": 1,
+                "label": "person", "mission_id": real_mid,
+            }) + "\n")
+        # Backdate the file mtime well past the 5s window.
+        old = time.time() - 60.0
+        os.utime(det_path, (old, old))
+
+        with pytest.raises(MissionNotFoundError) as excinfo:
+            compute_summary(bogus_mid, log_dir)
+        assert "transient=true" not in str(excinfo.value)
+
+
+# ----------------------------------------------------------------------------
 # R2-1: Rate limit on POST /api/mission/start
 # ----------------------------------------------------------------------------
 

--- a/tests/test_safety_hardening.py
+++ b/tests/test_safety_hardening.py
@@ -431,6 +431,71 @@ class TestAttemptCorruptRecovery:
         with caplog.at_level(logging.CRITICAL):
             assert attempt_corrupt_recovery(path) is False
 
+    # ------------------------------------------------------------------
+    # R1-3 from docs/adversarial/260.md — RECOVERY_REJECTED audit events
+    # ------------------------------------------------------------------
+
+    def test_too_new_schema_emits_recovery_rejected_audit_event(self, tmp_path):
+        """Symmetrical with test_recovery_emits_audit_event: when the
+        binary refuses to restore from a too-new .bak, the audit log
+        must surface a RECOVERY_REJECTED event so the dashboard panel
+        shows "binary refused to start" rather than no signal at all.
+        """
+        from hydra_detect.audit import attach_to_logger, get_default_sink
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+        from hydra_detect.config_migrate import CURRENT_SCHEMA_VERSION
+
+        attach_to_logger()
+        sink = get_default_sink()
+        before = sink.summary(window_seconds=3600).get(
+            "counts", {}
+        ).get("recovery_rejected", 0)
+
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        path.write_text("")  # corrupt
+        too_new = CURRENT_SCHEMA_VERSION + 1
+        bak.write_text(
+            f"[meta]\nschema_version = {too_new}\n\n[camera]\nsource = auto\n"
+        )
+        assert attempt_corrupt_recovery(path) is False
+
+        after = sink.summary(window_seconds=3600).get(
+            "counts", {}
+        ).get("recovery_rejected", 0)
+        assert after == before + 1, (
+            f"expected recovery_rejected count to grow by 1, got "
+            f"{before} -> {after}"
+        )
+
+    def test_unreadable_schema_emits_recovery_rejected_audit_event(self, tmp_path):
+        """The non-integer schema_version branch also fires the audit event."""
+        from hydra_detect.audit import attach_to_logger, get_default_sink
+        from hydra_detect.web.config_api import attempt_corrupt_recovery
+
+        attach_to_logger()
+        sink = get_default_sink()
+        before = sink.summary(window_seconds=3600).get(
+            "counts", {}
+        ).get("recovery_rejected", 0)
+
+        path = tmp_path / "config.ini"
+        bak = tmp_path / "config.ini.bak"
+        path.write_text("")
+        bak.write_text(
+            "[meta]\nschema_version = not-an-int\n\n"
+            "[camera]\nsource = auto\n"
+        )
+        assert attempt_corrupt_recovery(path) is False
+
+        after = sink.summary(window_seconds=3600).get(
+            "counts", {}
+        ).get("recovery_rejected", 0)
+        assert after == before + 1, (
+            f"expected recovery_rejected count to grow by 1, got "
+            f"{before} -> {after}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 4. restore_factory works


### PR DESCRIPTION
## Summary

Bundles all five follow-ups from `docs/adversarial/260.md` (parent PR #260, tracker issue #241). One commit, one PR — the changes share files and intent, so reviewing them together is the least friction path.

- **R2-1** — `tests/test_mission.py::TestPruneDuringSummaryRace` adds three thread-driven tests exercising `invalidate_for_log_dir` firing mid-`compute_summary`. Confirms a typo'd mission post-prune surfaces as 404, not a stale 200.
- **R1-1** — Predicate docstring in `compute_summary` documents the six-condition not-found gate (`det_count==0 AND action_count==0 AND state_count==0 AND not track_points AND mission_start_ts is None AND mission_end_ts is None`) and the known false-positive case (event-only mission with no track lat/lon).
- **R1-3** — `attempt_corrupt_recovery` now emits `audit_log.warning("RECOVERY_REJECTED ...")` in both the schema-version-too-new branch and the unreadable-schema branch. `audit_log._classify` recognizes the new token. `/api/audit/summary` now surfaces "binary refused to start."
- **R2-2** — One-line cross-reference comment above `_format_value` in `observability/metrics.py` pointing at `docs/observability.md` for the NaN-vs-zero convention.
- **R3-2** — When `MissionNotFoundError` fires and any tracked log file was modified within the last 5 seconds, the message includes `transient=true`. HTTP handler in `web/server.py` passes the message through verbatim.

## Files Changed

- `hydra_detect/audit/audit_log.py` — new `recovery_rejected` kind in `_KINDS`, classifier branch.
- `hydra_detect/mission_summary.py` — predicate docstring (R1-1), recent-mtime tag (R3-2).
- `hydra_detect/observability/metrics.py` — cross-ref comment (R2-2).
- `hydra_detect/web/config_api.py` — two `audit_log.warning("RECOVERY_REJECTED ...")` calls (R1-3).
- `tests/test_audit_summary.py` — classifier tests for `recovery_from_bak` and `recovery_rejected`.
- `tests/test_mission.py` — `TestPruneDuringSummaryRace` (R2-1 + R3-2, 4 tests).
- `tests/test_safety_hardening.py` — audit-event assertions for both `RECOVERY_REJECTED` paths.

## Test plan

- [x] `pytest tests/test_mission.py -v` — 57 passed (4 new in `TestPruneDuringSummaryRace`)
- [x] `pytest tests/test_safety_hardening.py -v` — passes, 2 new tests
- [x] `pytest tests/test_observability.py -v` — passes, 0 new tests (R2-2 is a comment only)
- [x] `pytest tests/test_audit_summary.py -v` — passes, 2 new classifier tests
- [x] Full suite (excluding pre-existing `test_field_image_hygiene` rglob issue): 2557 passed, 108 skipped

## Parent threads

- Tracker: #241 (R2-1, R1-1, R1-3, R2-2, R3-2)
- Adversarial doc: `docs/adversarial/260.md` (on merge commit 19f1d3a)
- Parent PR: #260