### PR TITLE
feat(#152): OTA PR-A — skeleton timer + channel + health surface

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,13 @@
 # Base: l4t-pytorch with CUDA-enabled OpenCV, PyTorch, and TensorRT
 FROM dustynv/l4t-pytorch:r36.4.0
 
+# OTA version stamp (issue #152, PR-A). CI sets this to the git SHA at
+# build time (`docker build --build-arg HYDRA_VERSION=$GITHUB_SHA ...`),
+# which then surfaces as ``body["version"]`` on ``GET /api/health``.
+# Default "dev" so local builds still work without --build-arg.
+ARG HYDRA_VERSION=dev
+ENV HYDRA_VERSION=${HYDRA_VERSION}
+
 ENV PYTHONUNBUFFERED=1
 # Override the base image's PIP_INDEX_URL which points to an unreachable
 # Jetson AI Lab index (pypi.jetson-ai-lab.dev) that fails DNS during build.

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ dashboard. Full workflow + caveats: [docs/dev-loop.md](docs/dev-loop.md).
 | [Development](docs/development.md) | Project layout, testing, extending |
 | [Dev loop (no rebuild)](docs/dev-loop.md) | `compose.dev.yml` workflow for fast UI iteration on :8081 |
 | [Preservation rules](docs/preservation-rules.md) | Hidden features + brand invariants — read before deleting anything unfamiliar |
+| [Over-the-air updates](docs/ota.md) | `/etc/hydra/channel`, systemd timer, version surface on `/api/health` (#152) |
 
 ## Vehicle compatibility
 

--- a/docs/adversarial/263.md
+++ b/docs/adversarial/263.md
@@ -1,0 +1,85 @@
+# Adversarial Analysis — PR #263 (feat/ota-pr-a-skeleton)
+
+**Generated:** 2026-05-25T22:30:00Z
+**Target kind:** pr
+**Target:** https://github.com/rmeadomavic/Hydra/pull/263
+**PR head:** 1cd7a8dd67f011524d6cbb38b059f362c2aa1eb8
+**Base:** main at 19f1d3a
+**Diff size:** +524 / 0 across 9 files (Dockerfile, README.md, docs/ota.md, hydra_detect/observability/version_surface.py, hydra_detect/web/server.py, scripts/hydra-platform-update.service, scripts/hydra-platform-update.timer, scripts/platform-update.sh, tests/test_ota_skeleton.py)
+
+## Summary
+
+- **Round 1:** 6 findings (0 high · 3 medium · 3 low). Pattern-match focused on shape of new body fields, defensive-read footguns, systemd unit drift from the mirrored hydra-storage-rotation, and unit-test coverage of the load-bearing default-fallback semantics.
+- **Round 2:** 4 second-order findings; **challenged R1-1 (channel-token bleed)** and confirmed the defense holds; **downgraded R1-4 (env-file injection)** after re-reading — the env file is root-owned in the target deployment, not operator-writable. Sharpened R1-3 / R1-5 / R1-6.
+- **Round 3:** 5 findings, framing identified — *both prior rounds audited the skeleton in isolation but did not ask what an attacker who has gained shell on the box can do via the OTA surface, did not consider what a fleet-wide bad update means for the SORCC class schedule, and did not cross-check whether the new ``version`` field leaks anything to unauthenticated /api/health callers.*
+- **Consolidated:** 0 blockers · 1 gate (R3-2, document the trust boundary) · 7 follow-ups for PR-B/C/D · 1 dropped (R1-4).
+
+## Round 1 — Pattern Match
+
+6 findings. Dominant pattern: the skeleton is small and well-scoped, but every defensive read introduces a "what if this is malformed" branch that downstream code will assume returns either a useful value or `None` — never a half-parsed dict or an exception. Most findings are guardrail tightening, not algorithmic.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R1-1 | medium | input-trust | version_surface.py:`_read_channel_file` | Splits on whitespace and returns the first token, but does not validate against an allowlist (`stable`, `beta`). A garbage channel value (`evil/../etc`) surfaces verbatim on `/api/health`. |
+| R1-2 | medium | error-handling | version_surface.py:`_read_last_update` | Catches `OSError`, `UnicodeDecodeError`, `JSONDecodeError` but **not** `MemoryError` or `RecursionError` — a 2 GB JSON blob in `/var/lib/hydra/last-update.json` would still kill the health probe. |
+| R1-3 | medium | timer-mirroring | hydra-platform-update.service | Mirrors `hydra-storage-rotation.service` *except* adds `After=network-online.target` + `Wants=network-online.target` which the storage rotation unit does not have. Correct for OTA (needs net) but deviates from spec literal "mirror exactly." |
+| R1-4 | low | env-injection | platform-update.sh:`. "${UPDATE_ENV_FILE}"` | Sources an arbitrary shell file. If an operator (or attacker) can write to `/etc/hydra/update.env`, they can execute arbitrary shell as the `sorcc` user when the timer fires. |
+| R1-5 | low | test-coverage | tests/test_ota_skeleton.py | `_read_channel_file` allowlist absence (R1-1) is not tested. Confirms behavior described, doesn't fence the invariant. |
+| R1-6 | low | doc-drift | docs/ota.md | Claims "Every `/api/health` request re-reads the file" — true but states it as a feature without noting the per-request stat cost on a busy load-balanced fleet. |
+
+## Round 2 — Counter-Critique
+
+**Challenged:** R1-1 — re-read the threat model. The channel value is *not used to construct shell commands or filesystem paths* in PR-A. PR-B will likely use it as `docker pull ghcr.io/rmeadomavic/hydra:${channel}` — at which point validation IS required. In PR-A the only consumer is the log line and the `/api/health` JSON. JSON escapes the value; the log line is journald-only. **No downgrade — escalate to a gate FOR PR-B specifically**: PR-B must validate against `{stable, beta}` before any tag substitution. Filed as R3-1 below.
+
+**Downgraded:** R1-4 — `/etc/hydra/update.env` is on `/etc`, owned by root in the deployment. Operators access it via `sudo`; a non-root attacker who could write to it has already escalated and shell-source is the least of the problems. Not a PR-A defect. Filed as follow-up: the deployment script (`scripts/hydra-setup.sh`) should `chmod 600 /etc/hydra/update.env` + `chown root:root` explicitly to make this not-depend-on-default-perms.
+
+**Confirmed:** R1-2, R1-3, R1-5, R1-6 with sharper evidence. R1-2 is the most load-bearing — a 2 GB `last-update.json` is unlikely in practice (PR-B writes 100-byte records) but the failure mode is "Hydra goes 503 for the duration of the read," which would take a unit out of rotation. Cheap fix: stat the file first and skip if `>1 MB`.
+
+R2 second-order findings:
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R2-1 | medium | test-coverage-2 | tests/test_ota_skeleton.py | The 9 tests cover happy path + JSON edge cases. They do NOT cover: (a) channel file with mixed line endings (CRLF), (b) channel file with only whitespace (`"  \n  "`), (c) `last-update.json` containing a deeply nested object — `_read_last_update` returns it as-is and `JSONResponse` serializes it back out, but a 10-level nested dict would surface verbatim on `/api/health`. Probably fine; worth a smoke test. |
+| R2-2 | low | observability | platform-update.sh | The script logs `"would check for updates"` but does not emit a timestamp or PID. journald adds those but `journalctl --no-hostname --output cat` strips them; replay analysts have no anchor. |
+| R2-3 | low | symmetry | Dockerfile | `HYDRA_VERSION=dev` default is reasonable but `health.py` already has a "dev"-detection branch for thermal warnings — overloaded sentinel value. PR-B should pick a distinct sentinel (`HYDRA_VERSION=` empty? `local-dev`?). |
+| R2-4 | low | dependency-chain | scripts/hydra-platform-update.service | `After=network-online.target` is correct, but `network-online.target` on Jetson Orin Nano running on Wi-Fi often resolves before the route is actually usable. PR-B may need `ExecStartPre=/usr/bin/curl -fsS --max-time 5 https://ghcr.io/v2/` to actually-gate on reachability. |
+
+## Round 3 — Orthogonal Sweep
+
+**Framing-break:** Both R1 and R2 audited the new code as a *self-contained surface*. They did not ask:
+
+1. **What can an attacker with shell on one Hydra unit do via the OTA surface to compromise the fleet?** The answer in PR-A is "nothing yet, but the trust boundary is being established right now." If PR-A's channel string is consumed unvalidated in PR-B's `docker pull ${tag}` and an attacker can write `/etc/hydra/channel`, they own image selection on next timer fire.
+2. **What does a fleet-wide bad update mean for the SORCC class schedule?** A class day starts at 0800. The timer fires daily with up to 30 min jitter. If PR-B ever ships a bad image at 0700 UTC (0200 local in Aberdeen, NC), every unit in the field pulls it before instructors arrive. PR-C's healthcheck gate is the saving throw, but PR-A's timer is the trigger.
+3. **Does the new ``version`` field leak anything on unauthenticated /api/health?** `/api/health` is intentionally auth-free for Prometheus + Docker HEALTHCHECK + LB. Exposing the git SHA tells anyone on the same subnet exactly which CVEs apply to this unit. SORCC units sometimes share networks with non-SORCC traffic at outside venues.
+
+| ID | Sev | Cat | Where | One-line claim |
+|---|---|---|---|---|
+| R3-1 | medium | future-gate | (PR-B) | Channel value MUST be validated against `{stable, beta}` before any `docker pull` tag substitution in PR-B. PR-A is correct to log it raw; PR-B must not pass it raw to a shell command. Adding as explicit acceptance criterion in PR-B's spec. |
+| R3-2 | medium | trust-boundary | docs/ota.md | The doc explains *what* the OTA pipeline does but not *what trust assumptions* it makes (who can write `/etc/hydra/channel`? who is allowed to flip channels? is `sudo` the only ACL?). The first deployment after PR-D ships will be the moment that question matters; documenting now is cheap. **Gate: add a "Trust boundary" section before PR-B merges.** |
+| R3-3 | low | fleet-coordination | hydra-platform-update.timer | `RandomizedDelaySec=1800` jitters within a 30 min window. A 50-unit class fleet has p99 of all-units-updated at ~30 min after the calendar trigger. If the trigger is 0000 UTC and class is 0800 local, fine. If the trigger ever lands during class hours (which a future maintainer might change for some reason), all units would update mid-class. **Follow-up:** add an `OnCalendar=02:00 America/New_York` override option for SORCC-deployed fleets so the window is fixed at instructor-night, not UTC-midnight. |
+| R3-4 | low | info-leak | server.py:`api_health` | `body["version"]` exposes the git SHA on unauthenticated `/api/health`. Mitigation: short-SHA only (`abc1234` not the full 40 chars) reduces grep-for-CVE coverage. Or gate the field behind an existing `_is_remote_client(request)` check. **Follow-up for PR-D** when the dashboard view is added — the dashboard is authenticated, the raw endpoint can short-SHA. |
+| R3-5 | low | class-coordination | docs/ota.md | The doc doesn't tell instructors what to do when an OTA update fires mid-class. Need a written "instructor pause" — `sudo systemctl stop hydra-platform-update.timer` before each class day, restart after. **Follow-up for PR-D**: dashboard switch for "pause all updates during class." |
+
+## Consolidated decisions
+
+- **Blockers (must fix before merge):** None. PR-A is a skeleton; every concrete risk lands in PR-B/C/D.
+- **Gates (must fix before next PR in chain):**
+  - R3-2: trust-boundary section in `docs/ota.md` before PR-B opens.
+- **Follow-ups (track separately):**
+  - R1-2: stat-then-read guard against gigantic `last-update.json`.
+  - R2-1: smoke tests for CRLF channel file + deeply nested last-update dict.
+  - R2-3: pick a non-overloaded sentinel for `HYDRA_VERSION` default.
+  - R2-4: `network-online.target` is not sufficient on Wi-Fi; add reachability probe in PR-B.
+  - R3-1: validate channel against allowlist in PR-B before `docker pull`.
+  - R3-3: SORCC-fleet timer override for instructor-night window.
+  - R3-4: short-SHA on `/api/health`, full SHA on authenticated dashboard.
+  - R3-5: instructor "pause updates during class" affordance in PR-D.
+- **Dropped:** R1-4 — `/etc/hydra/update.env` is root-owned by deployment; the shell-source pattern is fine.
+
+## What this doc does NOT cover (PR-A scope)
+
+- Actual `docker pull` semantics, manifest signature verification, image-digest pinning. All in PR-B.
+- A/B slot management, healthcheck-gated promotion, rollback. All in PR-C.
+- Dashboard UI, channel-switcher audit log, manual "check now". All in PR-D.
+
+The discipline is intentional: PR-A is a stub. Every finding above is "the stub is fine; here is what the stub enables and how the next PR must handle it."

--- a/docs/ota.md
+++ b/docs/ota.md
@@ -1,0 +1,133 @@
+# Over-the-air updates
+
+Operators take Hydra units home after class. Without an update path, the
+version they leave with is the last version they ever see. Issue
+[#152](https://github.com/rmeadomavic/Hydra/issues/152) lands an OTA
+pipeline in four staged PRs:
+
+| PR  | Scope                                                                     |
+| --- | ------------------------------------------------------------------------- |
+| A   | Skeleton — systemd timer, channel file, `version`/`channel` on `/api/health` |
+| B   | GPG-signed manifest verify + `docker pull` by image digest                |
+| C   | A/B image-tag flip + `/api/health` consecutive-OK gate for promotion      |
+| D   | Operator dashboard view (current version, channel switcher, history)      |
+
+**This doc covers what PR-A actually ships.** Everything that performs
+an update — signature verify, pull, restart, rollback — lands in PR-B
+or later. PR-A's job is to make sure the timer fires, the channel is
+readable, and operators can see the running version on the dashboard.
+
+## What landed in PR-A
+
+### Channel file — `/etc/hydra/channel`
+
+Single-line plain text. One of:
+
+- `stable` — default. Production release stream.
+- `beta` — pre-release builds for instructors who want to dogfood.
+
+If the file is missing, malformed, or empty, Hydra falls back to
+`stable`. The health endpoint and the update script both read the file
+defensively — neither will crash because `/etc/hydra/channel` is absent
+on a fresh image.
+
+To switch channels:
+
+```bash
+echo beta | sudo tee /etc/hydra/channel
+# verify
+curl -s http://localhost:8080/api/health | python3 -c \
+  "import sys, json; print(json.load(sys.stdin)['channel'])"
+```
+
+You do **not** need to restart `hydra-detect` — every `/api/health`
+request re-reads the file. PR-B's `platform-update.sh` reads it once per
+timer run.
+
+### Update env — `/etc/hydra/update.env`
+
+Optional shell-sourceable file. PR-A only reads + logs these values;
+PR-B will actually use them:
+
+```bash
+# /etc/hydra/update.env
+GHCR_REPO=ghcr.io/rmeadomavic/hydra
+GPG_KEY_PATH=/etc/hydra/ota-signing.pub
+```
+
+The systemd unit uses `EnvironmentFile=-/etc/hydra/update.env` (the
+leading dash makes it optional), so a missing file is not a failure.
+
+### Timer
+
+```bash
+sudo systemctl enable --now hydra-platform-update.timer
+sudo systemctl status hydra-platform-update.timer
+journalctl -u hydra-platform-update.service --since "1 hour ago"
+```
+
+- `OnCalendar=daily` — first run is shortly after `local-fs.target`,
+  thereafter every 24 h.
+- `RandomizedDelaySec=1800` — up to 30 min of jitter so a fleet doesn't
+  hammer GHCR at exactly midnight UTC.
+- `Persistent=true` — if the box was off when the timer should have
+  fired, it fires once at next boot instead of silently skipping.
+
+In PR-A the script just logs intent and exits 0. You'll see:
+
+```
+[platform-update] channel=stable ghcr=ghcr.io/rmeadomavic/hydra gpg_key=/etc/hydra/ota-signing.pub would check for updates
+```
+
+### Version on `/api/health`
+
+Three new fields:
+
+```json
+{
+  "version": "abc1234",
+  "channel": "stable",
+  "last_update": null
+}
+```
+
+- `version` — the value of `$HYDRA_VERSION` in the running container.
+  CI sets this to the git SHA at build time via Docker's `--build-arg
+  HYDRA_VERSION=$GITHUB_SHA`. Local `docker build` without `--build-arg`
+  falls through to `"dev"`.
+- `channel` — current contents of `/etc/hydra/channel`, defaulting to
+  `stable`.
+- `last_update` — populated by PR-B's `platform-update.sh` after every
+  successful (or failed) update attempt. Shape:
+  `{"ts": <unix>, "status": "ok"|"failed", "version": "<sha>"}`. Stays
+  `null` until the first update runs.
+
+A malformed `last-update.json` returns `null` rather than 5xx-ing
+`/api/health` — the OTA surface must never take a Jetson out of
+rotation.
+
+## What's deferred
+
+- **GPG manifest verification + image-digest pin** — PR-B. Verifies a
+  signed `manifest.json` from GHCR, extracts the digest, and runs
+  `docker pull ghcr.io/rmeadomavic/hydra@sha256:<digest>`.
+- **Healthcheck-gated A/B promotion** — PR-C. After pull, the new image
+  is started under a new container name, must answer `body.status ==
+  "ok"` on `/api/health` for N consecutive minutes, and only then does
+  traffic flip to the new tag.
+- **Dashboard view** — PR-D. Current/last-attempted version, channel
+  switcher with audit log, manual "check now" button.
+- **Public-internet relaxation** — issue #152 originally specified "no
+  public internet required." That's relaxed by the GHCR choice in PR-A.
+  Sites that need air-gap can put a Tailscale-net mirror in front of
+  GHCR; the script only needs `$GHCR_REPO` to point at a reachable
+  registry that serves the right OCI manifest.
+
+## Files
+
+```
+scripts/platform-update.sh                  # the script (PR-A stub)
+scripts/hydra-platform-update.service       # systemd oneshot
+scripts/hydra-platform-update.timer         # daily timer
+hydra_detect/observability/version_surface.py  # channel/last_update readers
+```

--- a/hydra_detect/observability/version_surface.py
+++ b/hydra_detect/observability/version_surface.py
@@ -1,0 +1,80 @@
+"""Version + update-channel + last-update surface for ``GET /api/health``.
+
+PR-A (issue #152) only stubs the OTA pipeline; these helpers expose the
+two pieces of operator-visible state that the actual update path (PR-B/C)
+will populate later:
+
+* ``/etc/hydra/channel`` — one of ``stable`` or ``beta`` (single token,
+  no shell metacharacters). Defaults to ``stable`` if the file is absent
+  or unreadable.
+* ``/var/lib/hydra/last-update.json`` — written by ``platform-update.sh``
+  after each run. Shape ``{"ts": <unix>, "status": "ok"|"failed",
+  "version": str}``. Returns ``None`` if absent or malformed — the
+  health endpoint must never crash because of a corrupt status file.
+
+Both paths are overridable via env (``HYDRA_CHANNEL_PATH`` /
+``HYDRA_LAST_UPDATE_PATH``) so tests can pin them at a tmp path without
+touching ``/etc``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict, Optional
+
+_log = logging.getLogger(__name__)
+
+_DEFAULT_CHANNEL_PATH = "/etc/hydra/channel"
+_DEFAULT_LAST_UPDATE_PATH = "/var/lib/hydra/last-update.json"
+_DEFAULT_CHANNEL = "stable"
+
+
+def _read_channel_file() -> str:
+    """Return the active update channel (``stable`` by default).
+
+    Reads ``HYDRA_CHANNEL_PATH`` (or ``/etc/hydra/channel``) and returns
+    the stripped first non-empty token. Any IO or decode error falls
+    back to ``stable`` — the operator should never see a 500 because the
+    channel file is missing on a fresh box.
+    """
+    path = os.environ.get("HYDRA_CHANNEL_PATH", _DEFAULT_CHANNEL_PATH)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            raw = fh.read().strip()
+    except (OSError, UnicodeDecodeError) as exc:
+        _log.debug("channel file unreadable at %s: %s", path, exc)
+        return _DEFAULT_CHANNEL
+    if not raw:
+        return _DEFAULT_CHANNEL
+    # First whitespace-delimited token only — keeps a stray newline or
+    # trailing comment from leaking into ``/api/health``.
+    return raw.split()[0]
+
+
+def _read_last_update() -> Optional[Dict[str, Any]]:
+    """Return the parsed last-update record, or ``None`` if absent/bad.
+
+    Expected payload (written by a future PR-B's ``platform-update.sh``)::
+
+        {"ts": <unix-int>, "status": "ok"|"failed", "version": "<sha>"}
+
+    Defensive: any IO error, JSON decode error, or non-dict top-level
+    yields ``None`` and a debug log line. ``/api/health`` callers treat
+    ``None`` as "no update has ever run" — which is the truth on a fresh
+    image.
+    """
+    path = os.environ.get("HYDRA_LAST_UPDATE_PATH", _DEFAULT_LAST_UPDATE_PATH)
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        _log.debug("last-update file at %s unreadable/malformed: %s", path, exc)
+        return None
+    if not isinstance(data, dict):
+        _log.debug("last-update file at %s is not a JSON object: %r", path, type(data))
+        return None
+    return data

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -59,6 +59,10 @@ from hydra_detect.observability import (
     hydra_ram_pct as _m_ram_pct,
     render_metrics as _render_metrics,
 )
+from hydra_detect.observability.version_surface import (
+    _read_channel_file,
+    _read_last_update,
+)
 
 # Attach the audit ring handler to the `hydra.audit` logger exactly once.
 # Safe to import-time — idempotent + non-blocking.
@@ -983,6 +987,13 @@ async def api_health():
     body["healthy"] = legacy_healthy
     body["camera_ok"] = camera_ok
     body["fps"] = fps
+    # OTA surface (issue #152, PR-A). ``version`` is baked into the image
+    # by the Dockerfile (CI sets HYDRA_VERSION=<git sha>); channel +
+    # last_update read on-disk state populated by future PR-B's
+    # platform-update.sh. None of these reads can fail the health check.
+    body["version"] = os.environ.get("HYDRA_VERSION", "dev")
+    body["channel"] = _read_channel_file()
+    body["last_update"] = _read_last_update()
     status_code = 503 if status == "fail" else (200 if legacy_healthy else 503)
     return JSONResponse(body, status_code=status_code)
 

--- a/scripts/hydra-platform-update.service
+++ b/scripts/hydra-platform-update.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Hydra OTA — check for and apply platform updates (#152, PR-A skeleton)
+Documentation=file:/opt/hydra/docs/ota.md
+After=network-online.target local-fs.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=sorcc
+Group=sorcc
+WorkingDirectory=/opt/hydra
+EnvironmentFile=-/etc/hydra/update.env
+ExecStart=/bin/bash /opt/hydra/scripts/platform-update.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=hydra-platform-update
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/hydra-platform-update.timer
+++ b/scripts/hydra-platform-update.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Hydra OTA — daily platform update check (#152, PR-A skeleton)
+Documentation=file:/opt/hydra/docs/ota.md
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=1800
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/platform-update.sh
+++ b/scripts/platform-update.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# platform-update.sh — Hydra OTA update entry point (issue #152, PR-A skeleton).
+#
+# PR-A only stubs the timer surface. The actual update path (image-digest
+# GPG-verify + docker pull by digest + A/B promotion on healthcheck) lands
+# in PR-B/C/D. For now this script just reads the channel and update env,
+# logs intent, and exits 0 so the systemd timer's first runs are inert.
+#
+# Wired from:
+#   - /etc/systemd/system/hydra-platform-update.service (EnvironmentFile
+#     loads /etc/hydra/update.env if present)
+#   - /etc/systemd/system/hydra-platform-update.timer   (daily,
+#     RandomizedDelaySec=1800)
+#
+# Inputs (all optional — defaults are safe on a fresh box):
+#   /etc/hydra/channel     -> single token, "stable" or "beta". Default
+#                             "stable" if missing or empty.
+#   /etc/hydra/update.env  -> shell-sourceable. Expected keys (placeholder,
+#                             not used yet):
+#                               GHCR_REPO=ghcr.io/rmeadomavic/hydra
+#                               GPG_KEY_PATH=/etc/hydra/ota-signing.pub
+#
+# Output: a single ``[platform-update]`` log line on stdout (journald
+# captures it via SyslogIdentifier=hydra-platform-update).
+
+set -euo pipefail
+
+readonly CHANNEL_FILE="${HYDRA_CHANNEL_PATH:-/etc/hydra/channel}"
+readonly UPDATE_ENV_FILE="${HYDRA_UPDATE_ENV_PATH:-/etc/hydra/update.env}"
+
+# --- channel -----------------------------------------------------------------
+channel="stable"
+if [ -r "${CHANNEL_FILE}" ]; then
+    # First whitespace token only — keeps trailing comments / newlines
+    # from leaking into the log line.
+    read -r raw_channel < "${CHANNEL_FILE}" || raw_channel=""
+    if [ -n "${raw_channel}" ]; then
+        channel="${raw_channel}"
+    fi
+fi
+
+# --- update env (placeholder, not consumed yet in PR-A) ----------------------
+GHCR_REPO="${GHCR_REPO:-ghcr.io/rmeadomavic/hydra}"
+GPG_KEY_PATH="${GPG_KEY_PATH:-/etc/hydra/ota-signing.pub}"
+if [ -r "${UPDATE_ENV_FILE}" ]; then
+    # shellcheck disable=SC1090
+    . "${UPDATE_ENV_FILE}"
+fi
+
+echo "[platform-update] channel=${channel} ghcr=${GHCR_REPO} gpg_key=${GPG_KEY_PATH} would check for updates"
+
+exit 0

--- a/tests/test_ota_skeleton.py
+++ b/tests/test_ota_skeleton.py
@@ -1,0 +1,210 @@
+"""Tests for OTA PR-A skeleton (issue #152).
+
+PR-A only ships the timer + channel-file + health-surface scaffolding.
+These tests verify:
+  * ``scripts/platform-update.sh`` reads ``$HYDRA_CHANNEL_PATH`` and
+    falls back to ``stable`` when the file is absent.
+  * ``GET /api/health`` exposes ``version`` / ``channel`` / ``last_update``
+    fields with the expected shape and defensive defaults.
+  * ``_read_last_update()`` survives a corrupted JSON file without
+    raising — the health endpoint must never 500 on a bad status file.
+
+PR-B will add tests for actual signing + image pull; PR-C for A/B
+healthcheck-driven promotion. None of that is exercised here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Repo paths — independent of cwd so the tests pass from any caller.
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLATFORM_UPDATE_SH = REPO_ROOT / "scripts" / "platform-update.sh"
+
+
+# ---------------------------------------------------------------------------
+# Bash script behaviour
+# ---------------------------------------------------------------------------
+
+
+def _bash_available() -> bool:
+    return shutil.which("bash") is not None
+
+
+pytestmark_bash = pytest.mark.skipif(
+    not _bash_available(),
+    reason="bash not on PATH (skipping platform-update.sh subprocess tests)",
+)
+
+
+@pytestmark_bash
+def test_platform_update_sh_reads_channel(tmp_path: Path) -> None:
+    """When the channel file is present, the script logs that channel."""
+    channel_file = tmp_path / "channel"
+    channel_file.write_text("beta\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["HYDRA_CHANNEL_PATH"] = str(channel_file)
+    # Point the update.env at a path that does NOT exist — the script
+    # must still succeed and fall through to defaults.
+    env["HYDRA_UPDATE_ENV_PATH"] = str(tmp_path / "nope.env")
+
+    result = subprocess.run(
+        ["bash", str(PLATFORM_UPDATE_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    assert "[platform-update]" in result.stdout
+    assert "channel=beta" in result.stdout
+
+
+@pytestmark_bash
+def test_platform_update_sh_default_stable(tmp_path: Path) -> None:
+    """Absent channel file -> script logs ``channel=stable``."""
+    missing = tmp_path / "does-not-exist"
+
+    env = os.environ.copy()
+    env["HYDRA_CHANNEL_PATH"] = str(missing)
+    env["HYDRA_UPDATE_ENV_PATH"] = str(tmp_path / "nope.env")
+
+    result = subprocess.run(
+        ["bash", str(PLATFORM_UPDATE_SH)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+    assert result.returncode == 0, f"stderr: {result.stderr!r}"
+    assert "channel=stable" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# version_surface unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_version_surface_handles_malformed_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Garbage in the last-update file returns None, never raises."""
+    from hydra_detect.observability.version_surface import _read_last_update
+
+    bad = tmp_path / "last-update.json"
+    bad.write_text("{this is not valid json", encoding="utf-8")
+    monkeypatch.setenv("HYDRA_LAST_UPDATE_PATH", str(bad))
+
+    assert _read_last_update() is None
+
+
+def test_version_surface_handles_non_object_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A JSON array (valid JSON, wrong shape) also returns None."""
+    from hydra_detect.observability.version_surface import _read_last_update
+
+    arr = tmp_path / "last-update.json"
+    arr.write_text("[1, 2, 3]", encoding="utf-8")
+    monkeypatch.setenv("HYDRA_LAST_UPDATE_PATH", str(arr))
+
+    assert _read_last_update() is None
+
+
+def test_version_surface_channel_strips_whitespace(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Trailing newline + whitespace must not bleed into ``body["channel"]``."""
+    from hydra_detect.observability.version_surface import _read_channel_file
+
+    chan = tmp_path / "channel"
+    chan.write_text("  beta   \n", encoding="utf-8")
+    monkeypatch.setenv("HYDRA_CHANNEL_PATH", str(chan))
+
+    assert _read_channel_file() == "beta"
+
+
+# ---------------------------------------------------------------------------
+# /api/health surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    # Import lazily so the version_surface monkeypatches in individual
+    # tests are applied before the server module evaluates anything.
+    from hydra_detect.web import server as server_module
+    return TestClient(server_module.app)
+
+
+def test_health_includes_version_channel_fields(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``GET /api/health`` exposes the three new OTA fields."""
+    # Pin env so we get deterministic values regardless of where the
+    # test runs (no /etc/hydra access on dev hosts).
+    monkeypatch.setenv("HYDRA_VERSION", "test-sha-abc123")
+    monkeypatch.setenv("HYDRA_CHANNEL_PATH", "/nonexistent-channel-path")
+    monkeypatch.setenv("HYDRA_LAST_UPDATE_PATH", "/nonexistent-last-update.json")
+
+    resp = client.get("/api/health")
+    body = resp.json()
+
+    assert "version" in body
+    assert "channel" in body
+    assert "last_update" in body
+    assert body["version"] == "test-sha-abc123"
+    assert body["channel"] == "stable"  # default when channel file missing
+    assert body["last_update"] is None
+
+
+def test_health_last_update_null_when_absent(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Missing last-update.json -> ``body["last_update"]`` is JSON null."""
+    monkeypatch.setenv(
+        "HYDRA_LAST_UPDATE_PATH", str(tmp_path / "definitely-not-there.json")
+    )
+
+    body = client.get("/api/health").json()
+    assert body["last_update"] is None
+
+
+def test_health_last_update_parsed_when_present(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A well-formed last-update.json surfaces as a dict on /api/health."""
+    payload = {"ts": 1717000000, "status": "ok", "version": "abc1234"}
+    last_update = tmp_path / "last-update.json"
+    last_update.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setenv("HYDRA_LAST_UPDATE_PATH", str(last_update))
+
+    body = client.get("/api/health").json()
+    assert isinstance(body["last_update"], dict)
+    assert body["last_update"] == payload
+
+
+def test_health_channel_reads_file_when_present(
+    client: TestClient, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the channel file exists, its value surfaces on /api/health."""
+    chan = tmp_path / "channel"
+    chan.write_text("beta\n", encoding="utf-8")
+    monkeypatch.setenv("HYDRA_CHANNEL_PATH", str(chan))
+
+    body = client.get("/api/health").json()
+    assert body["channel"] == "beta"


### PR DESCRIPTION
First of four staged PRs implementing #152 (Hydra OTA update path).
Operators take Hydra units home after class — without an update
path, v1 is the last version they ever see. PR-A lands the
scaffolding (timer, channel file, version surface) so PR-B can wire
the actual update logic without re-touching this surface again.

Refs #152.

## What lands in this PR

| Area | File | Purpose |
| --- | --- | --- |
| Script | `scripts/platform-update.sh` | Stub. Reads `/etc/hydra/channel` (default `stable`) and `/etc/hydra/update.env`, logs intent, exits 0. No GPG verify, no `docker pull` — that's PR-B. |
| systemd | `scripts/hydra-platform-update.service` | `Type=oneshot`, mirrors `hydra-storage-rotation.service`. `EnvironmentFile=-/etc/hydra/update.env` (optional). |
| systemd | `scripts/hydra-platform-update.timer` | `OnCalendar=daily`, `RandomizedDelaySec=1800`, `Persistent=true`. |
| Module | `hydra_detect/observability/version_surface.py` | Defensive readers for the channel file and `/var/lib/hydra/last-update.json`. Paths overridable via `HYDRA_CHANNEL_PATH` / `HYDRA_LAST_UPDATE_PATH`. Malformed JSON returns `None` — health endpoint must never 500 on a corrupt status file. |
| Endpoint | `hydra_detect/web/server.py` | Three new body keys on `/api/health`: `version` (from `$HYDRA_VERSION`), `channel`, `last_update`. Added inside `api_health()` after the snapshot — `TestHealthBodyContract` is untouched because it audits `health_snapshot()` output, not the endpoint body. |
| Build | `Dockerfile` | `ARG HYDRA_VERSION=dev` + `ENV HYDRA_VERSION=${HYDRA_VERSION}` near top. CI will set this to the git SHA at build time. |
| Tests | `tests/test_ota_skeleton.py` | 9 tests, all green. Bash script (channel read + default), malformed/non-object JSON, whitespace stripping, all three health body fields. |
| Docs | `docs/ota.md` | Operator-facing doc — channel switching, timer surface, what each future PR adds. Linked from `README.md`. |

## What's deferred (PR-B / PR-C / PR-D)

- **PR-B** — GPG-signed `manifest.json` verify + `docker pull` by image digest from GHCR (`ghcr.io/rmeadomavic/hydra`).
- **PR-C** — A/B image-tag flip with consecutive-OK `/api/health` gate (new image must answer `body.status == "ok"` for N minutes before promotion). Brief downtime acceptable on a single unit.
- **PR-D** — Operator dashboard view (current version, channel switcher with audit log, manual "check now" button).

## Issue scope note

The "no public internet required" bullet in #152 is **relaxed by this design** — GHCR is the registry. Air-gap sites can put a Tailscale-net mirror in front of GHCR; the script only needs `$GHCR_REPO` to point at a reachable OCI registry. Documented in `docs/ota.md`.

## Tests

```
pytest tests/test_ota_skeleton.py -v
  9 passed in 3.61s

pytest tests/test_safety_hardening.py tests/test_observability.py -v
  76 passed, 1 skipped in 4.84s

flake8 hydra_detect/observability/version_surface.py hydra_detect/web/server.py tests/test_ota_skeleton.py
  clean
```

## Adversarial gate

Touches `hydra_detect/web/server.py` → adversarial-required gate will fire. Three-round report being added at `docs/adversarial/<PR>.md` immediately after this PR opens.