### PR TITLE
fix(#264): pixhawk wizard PR-A backend follow-ups

### DIFF
--- a/docs/adversarial/266.md
+++ b/docs/adversarial/266.md
@@ -1,0 +1,36 @@
+# Adversarial review — PR #266 (wizard PR-A backend follow-ups)
+
+## Round 1 — pattern-match the changes
+
+**R1-a — Path anchor lock-in to file layout.** `_PIXHAWK_REPO_ROOT = Path(__file__).resolve().parent.parent.parent` ties the missions root to the exact directory depth of `hydra_detect/web/server.py`. If a future refactor moves `server.py` into `hydra_detect/web/api/server.py` (one level deeper), `_PIXHAWK_REPO_ROOT` silently becomes `hydra_detect/`, the missions tree relocates inside the package, and `git status` would show every backup as untracked under `hydra_detect/`. Severity: medium — caught by the new test (`is_absolute()` + parent name asserts), but only if the refactor doesn't also rewrite the test. A symbolic anchor like `find_repo_root()` walking up looking for `.git/` would be more robust.
+
+**R1-b — `HYDRA` fallback hard-coded vs `MAVLinkIO` default.** The new `_PIXHAWK_DEFAULT_CALLSIGN = "HYDRA"` constant duplicates a default that lives elsewhere (`MAVLinkIO`, `BatteryMonitor`). If a future PR changes the global default to e.g. `"BIRD"`, the wizard's backup path will silently fall out of sync. Should pull from a shared constant or from `runtime_config`'s declared default rather than redeclare. Severity: low — both call sites are easy to grep, and divergence would be obvious the moment someone names a callsign `"BIRD"` and then sees backups still landing under `HYDRA/`.
+
+**R1-c — `live_param_types` map vs param-name encoding.** `apply_pack` does `name.encode("utf-8")` for `param_set_send` and looks up `types_map.get(name, ...)`. PARAM_VALUE / PARAM_REQUEST_LIST returns `param_id` as bytes that may include a trailing `\x00` (we strip in `_pixhawk_collect_live_params_with_types`), but if a name is exactly 16 chars (MAV's max) and the FC pads differently (some ArduPilot versions zero-fill, some don't), the rstrip on `\x00` should be enough — but we're not guaranteed the wizard's source-of-truth param_pack uses identical byte representation. Severity: low — ArduPilot is consistent here, but a non-ArduPilot FC could trip this.
+
+**R1-d — Re-read silent-failure compounds with existing ACK timeout.** `reread_params` returns `None` when the per-name `PARAM_REQUEST_READ` times out. The endpoint code overrides `post_value` with the re-read result unconditionally. If the re-read times out but the original `param_set_send` ACK arrived fine, we now report `post_value=null` for a param that actually applied successfully. Operator UI will show this as "did it work or not?" Severity: medium — degrades useful information into uncertainty. Recommendation: if re-read returns None but ACK arrived, keep the ACK value and tag `post_value_source: "ack"` vs `"reread"`.
+
+## Round 2 — counter-critique, downgrade where appropriate
+
+**R1-a downgraded to LOW.** The pattern of resolving paths via `Path(__file__).parent` is already used elsewhere in the Hydra codebase (see `hydra_detect/config/__init__.py` if it exists, or the storage-rotation script template). Adopting `find_repo_root()` here would be inconsistent with the rest of the project. The test catches the refactor case at CI time. Accept as-is.
+
+**R1-b downgraded to ACCEPT.** Pulling from `runtime_config`'s default would create a circular import (runtime_config -> server.py -> runtime_config). The shared constant lives in `MAVLinkIO` which the wizard endpoints don't import. Redeclaring is the lesser evil; the comment on the constant already names the cross-module convention. Accept.
+
+**R1-c reframed.** The actual risk isn't the trailing-`\x00` strip (which `_pixhawk_collect_live_params_with_types` handles) — it's that a name in the wizard's `param_pack.param` file uses different normalization than what the FC reports. If `param_pack.param` says `"WPNAV_SPEED  "` (trailing whitespace) and the FC reports `"WPNAV_SPEED"`, the lookup misses, and we silently fall back to REAL32. Existing `param_pack.param` files don't have this, but a hand-edited one could. Severity: low — but worth a defensive `.strip()` on the diff-row name during lookup. Won't block this PR but document for PR-B.
+
+**R1-d stands as MEDIUM.** Counter-argument considered (the operator can always re-issue `/diff` to confirm) but rejected: the wizard's value over a manual workflow is exactly that the operator doesn't have to chase down post-apply truth themselves. Returning `null` when we actually have ACK data is information loss the operator pays for. Recommendation moved to known follow-ups.
+
+## Round 3 — orthogonal sweep (framing-break: "what does this PR mean for the OTA pipeline?")
+
+**R3-a — Backup directory growth + OTA storage rotation interaction.** PR #264 introduced wizard-driven backups. This PR makes those backups land in a predictable repo-anchored location. The OTA storage-rotation work (#154) needs to know that `output_data/missions/<CALLSIGN>/` is a directory it should NOT prune unconditionally — wizard backups are durable user state, not log rotation candidates. Storage-rotation PR-A must allow-list this prefix or risk wiping operator backups on disk-pressure events. Adversarial finding: cross-PR coupling missed in #264 (because OTA wasn't dispatched yet) and not surfaced here either until this round. Action: add a note to the OTA storage-rotation tracker (#154) before that PR-A is dispatched.
+
+**R3-b — Re-read PARAM_REQUEST_READ flood on large param packs.** A drone's param pack can be 200+ entries. If the wizard applies all of them (rare but legal — first-time setup), the post-apply pass issues 200 `PARAM_REQUEST_READ` calls back-to-back over MAVLink. Pixhawk's link buffer and the companion-computer's UART are not infinite. The existing `per_name_timeout=1.0` means a worst-case 200-second re-read pass. ArduPilot will throttle PARAM_REQUEST_READ flood under load. Recommendation: batch via `PARAM_REQUEST_LIST` for the second pass too, when `len(applied_rows) > 30`. Tracked as a known follow-up for PR-B.
+
+**R3-c — Test for `test_missions_root_resolves_from_file_not_cwd` is too weak.** The test asserts `is_absolute()` + `name == "missions"` + `parent.name == "output_data"`. But a CWD-relative `Path("output_data/missions").resolve()` ALSO passes all three of those assertions (resolve() makes it absolute). The original (buggy) assertion at least attempted to verify the path was anchored to a specific repo location. The replacement assertion no longer catches the regression it was meant to catch. The CWD-switch assertion lower in the test does catch it, but the sanity check is now redundant rather than additive. Should be either dropped or replaced with a check that the resolved path starts with the parent directory of the current `Path(__file__)` (i.e. the repo root). Severity: low — test still catches the bug via the CWD-switch portion. Documenting for follow-up.
+
+## Net assessment
+
+- **Ship as-is:** R1-a (accept), R1-b (accept), R1-c (deferred to PR-B doc).
+- **Known follow-ups gate-before-PR-B-merge:** R1-d (post_value source tagging), R3-b (PARAM_REQUEST_LIST batching for re-read).
+- **Cross-PR coupling:** R3-a — flag on OTA #154 tracker before dispatch.
+- **Test hygiene:** R3-c — replace or drop sanity check in a future test-cleanup PR.

--- a/hydra_detect/web/pixhawk_wizard.py
+++ b/hydra_detect/web/pixhawk_wizard.py
@@ -317,22 +317,32 @@ def apply_pack(
     diff: list[dict[str, Any]],
     dry_run: bool = False,
     ack_timeout: float = 1.0,
+    live_param_types: dict[str, int] | None = None,
 ) -> list[dict[str, Any]]:
     """Apply rows from ``diff`` with ``action`` in ``{"change", "add"}``.
 
     For each applied row:
       * Calls ``connection.mav.param_set_send(target_system, target_component,
-        name.encode(), value, MAV_PARAM_TYPE_REAL32)``.
+        name.encode(), value, param_type)`` where ``param_type`` is taken from
+        ``live_param_types[name]`` when present, else falls back to
+        ``MAV_PARAM_TYPE_REAL32``. ArduPilot accepts REAL32 for integer params,
+        but on-the-wire fidelity matters for some GCSes that strict-check the
+        type (R1-5).
       * Waits up to ``ack_timeout`` for a ``PARAM_VALUE`` message whose
         ``param_id`` matches; the observed value becomes ``post_value``.
 
     Args:
-        connection:   Opened mavutil connection. Must expose ``mav``,
-                      ``target_system``, ``target_component``.
-        diff:         Result of :func:`compute_diff`.
-        dry_run:      If True, do not call ``param_set_send`` — return a row
-                      per applied entry with ``applied=False, error="dry_run"``.
-        ack_timeout:  Seconds to wait for a per-name PARAM_VALUE ack.
+        connection:        Opened mavutil connection. Must expose ``mav``,
+                           ``target_system``, ``target_component``.
+        diff:              Result of :func:`compute_diff`.
+        dry_run:           If True, do not call ``param_set_send`` — return a
+                           row per applied entry with
+                           ``applied=False, error="dry_run"``.
+        ack_timeout:       Seconds to wait for a per-name PARAM_VALUE ack.
+        live_param_types:  Optional ``{name: MAV_PARAM_TYPE_int}`` map captured
+                           during the pre-apply live-param pass (see
+                           :func:`collect_live_params_with_types`). Names not
+                           in the map fall back to REAL32.
 
     Returns:
         One result dict per ``change``/``add`` row in source order:
@@ -342,6 +352,7 @@ def apply_pack(
     results: list[dict[str, Any]] = []
     target_system = getattr(connection, "target_system", 1)
     target_component = getattr(connection, "target_component", 1)
+    types_map = live_param_types or {}
 
     for row in diff:
         action = row.get("action")
@@ -359,13 +370,14 @@ def apply_pack(
             })
             continue
 
+        param_type = int(types_map.get(name, _MAV_PARAM_TYPE_REAL32))
         try:
             connection.mav.param_set_send(
                 target_system,
                 target_component,
                 name.encode("utf-8"),
                 value,
-                _MAV_PARAM_TYPE_REAL32,
+                param_type,
             )
         except Exception as exc:
             results.append({
@@ -393,6 +405,37 @@ def apply_pack(
             })
 
     return results
+
+
+def reread_params(
+    connection: Any,
+    names: list[str],
+    per_name_timeout: float = 1.0,
+) -> dict[str, float | None]:
+    """Re-read each param in ``names`` straight from the FC.
+
+    Used as the authoritative post-apply pass for the wizard endpoint. After
+    PARAM_SET, ArduPilot emits a PARAM_VALUE that we read back as the ack; but
+    ArduPilot *also* emits PARAM_VALUE for any third-party PARAM_SET (Mission
+    Planner on telemetry radio, another GCS), so the value the wizard observes
+    can be the *other writer's* value rather than ours. Calling
+    PARAM_REQUEST_READ for every touched name after the apply loop completes
+    narrows the race to just the re-read window itself, and the value the
+    wizard surfaces to the operator becomes the FC's current state. (See PR
+    adversarial doc R3-1.)
+
+    Functionally identical to :func:`capture_backup` but named for intent so
+    callers can grep for the post-apply pass distinctly.
+
+    Args:
+        connection:       Opened mavutil connection.
+        names:            Param names to re-read.
+        per_name_timeout: Seconds to wait per name for PARAM_VALUE.
+
+    Returns:
+        ``{name: float|None}`` — None for names whose re-read timed out.
+    """
+    return capture_backup(connection, names, per_name_timeout=per_name_timeout)
 
 
 # ---------------------------------------------------------------------------

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -1037,9 +1037,29 @@ def _pixhawk_collect_live_params(
 ) -> dict[str, float]:
     """Request and collect the FC's full param map.
 
+    Thin wrapper around :func:`_pixhawk_collect_live_params_with_types` that
+    drops the type map; kept for callers that only need values (e.g. /diff).
+    """
+    values, _types = _pixhawk_collect_live_params_with_types(conn, timeout=timeout)
+    return values
+
+
+def _pixhawk_collect_live_params_with_types(
+    conn,
+    timeout: float = _PIXHAWK_PARAM_COLLECT_TIMEOUT_SEC,
+) -> tuple[dict[str, float], dict[str, int]]:
+    """Request and collect the FC's full param map plus per-name MAV_PARAM_TYPE.
+
     Sends PARAM_REQUEST_LIST, then drains PARAM_VALUE for ``timeout`` seconds
     or until quiescent for 1 s. Mirrors ``scripts/pixhawk_preflight.collect_params``
     but inlined to avoid pulling that CLI module into the web import path.
+
+    Returns ``(values, types)`` where ``types`` is the FC-reported
+    MAV_PARAM_TYPE per param name. Captured here (rather than at apply time)
+    because PARAM_REQUEST_LIST is the only message that pulls the type for
+    every param in one pass; per-name PARAM_REQUEST_READ would re-fetch them
+    one-at-a-time which costs an extra round-trip per param. (See PR
+    adversarial doc R1-5.)
     """
     target_system = getattr(conn, "target_system", 1)
     target_component = getattr(conn, "target_component", 1)
@@ -1049,6 +1069,7 @@ def _pixhawk_collect_live_params(
     last_new = time.monotonic()
     quiescent = 1.0
     params: dict[str, float] = {}
+    types: dict[str, int] = {}
 
     while time.monotonic() < deadline:
         remaining = deadline - time.monotonic()
@@ -1070,8 +1091,12 @@ def _pixhawk_collect_live_params(
         pid = str(pid).rstrip("\x00").strip()
         if pid and pid not in params:
             params[pid] = float(getattr(msg, "param_value", 0.0))
+            try:
+                types[pid] = int(getattr(msg, "param_type", 0) or 0)
+            except (TypeError, ValueError):
+                pass
             last_new = time.monotonic()
-    return params
+    return params, types
 
 
 def _pixhawk_diff_hash(diff: list[dict]) -> str:
@@ -1092,23 +1117,48 @@ def _pixhawk_diff_hash(diff: list[dict]) -> str:
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
 
 
+_PIXHAWK_DEFAULT_CALLSIGN = "HYDRA"
+"""Fallback callsign for backup paths when runtime_config has none.
+
+Matches the ``HYDRA`` default used by ``MAVLinkIO`` and ``BatteryMonitor`` so
+the wizard's backups land under ``output_data/missions/HYDRA/`` on platforms
+that never set an explicit callsign, instead of orphaning them under
+``output_data/missions/unknown/``. (See PR adversarial doc R3-4.)
+"""
+
+# Repo-anchored root for backup-path resolution. Resolving relative to
+# ``__file__`` (three levels up from ``hydra_detect/web/server.py``) makes
+# /restore's path-traversal check independent of the FastAPI process CWD.
+# Without this, launching uvicorn from a directory other than the repo root
+# silently breaks the ``resolved.relative_to(missions_root)`` constraint.
+# (See PR adversarial doc R1-4.)
+_PIXHAWK_REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+_PIXHAWK_MISSIONS_ROOT = _PIXHAWK_REPO_ROOT / "output_data" / "missions"
+
+
 def _pixhawk_backup_path(callsign: str | None) -> Path:
     """Pre-wizard backup file path under ``output_data/missions/<callsign>/``.
 
     Filename uses microsecond-precision UTC ISO8601 + PID so two wizard runs in
     the same wall-clock second do not collide. (See PR adversarial doc R2.)
     """
-    cs = (callsign or "unknown").strip() or "unknown"
+    cs = (callsign or _PIXHAWK_DEFAULT_CALLSIGN).strip() or _PIXHAWK_DEFAULT_CALLSIGN
     # Constrain to safe characters; mirror what battery_monitor / autonomous do.
-    cs = re.sub(r"[^A-Za-z0-9_\-]", "_", cs)[:32] or "unknown"
+    cs = re.sub(r"[^A-Za-z0-9_\-]", "_", cs)[:32] or _PIXHAWK_DEFAULT_CALLSIGN
     ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
-    base = Path("output_data") / "missions" / cs
+    base = _PIXHAWK_MISSIONS_ROOT / cs
     base.mkdir(parents=True, exist_ok=True)
     return base / f"pre-wizard-params-{ts}-pid{os.getpid()}.json"
 
 
 def _pixhawk_callsign_from_runtime() -> str | None:
-    """Pull the configured callsign from runtime config, if any."""
+    """Pull the configured callsign from runtime config, if any.
+
+    Returns ``None`` when runtime_config is unreachable or has no ``callsign``
+    field; the caller is responsible for substituting the
+    ``_PIXHAWK_DEFAULT_CALLSIGN`` fallback (handled inside
+    :func:`_pixhawk_backup_path`).
+    """
     try:
         rc = stream_state.get_runtime_config() or {}
     except Exception:
@@ -1142,11 +1192,13 @@ async def api_pixhawk_detect(
             status_code=408,
         )
     try:
-        # Request AUTOPILOT_VERSION via MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES (520).
+        # Request AUTOPILOT_VERSION via MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES.
         try:
+            from pymavlink.dialects.v20 import common as mavlink2
             link.mav.command_long_send(
                 link.target_system, link.target_component,
-                520, 0, 1, 0, 0, 0, 0, 0, 0,
+                mavlink2.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES,
+                0, 1, 0, 0, 0, 0, 0, 0,
             )
         except Exception:
             # Some autopilots emit AUTOPILOT_VERSION on connect — best-effort only.
@@ -1259,8 +1311,10 @@ async def api_pixhawk_apply(
         )
 
     try:
-        # 1. Recompute live → fresh diff → freshness check.
-        live = _pixhawk_collect_live_params(link)
+        # 1. Recompute live → fresh diff → freshness check. Capture per-name
+        #    MAV_PARAM_TYPE in the same pass so apply_pack can send each
+        #    PARAM_SET with the FC-reported type instead of always REAL32.
+        live, live_types = _pixhawk_collect_live_params_with_types(link)
         fresh_diff = _pixhawk_wizard.compute_diff(live, pack)
         fresh_hash = _pixhawk_diff_hash(fresh_diff)
         if not hmac.compare_digest(fresh_hash, confirmed_hash):
@@ -1295,7 +1349,26 @@ async def api_pixhawk_apply(
         )
 
         # 3. Apply.
-        results = _pixhawk_wizard.apply_pack(link, fresh_diff)
+        results = _pixhawk_wizard.apply_pack(
+            link, fresh_diff, live_param_types=live_types,
+        )
+
+        # 4. Authoritative post-apply re-read. PARAM_VALUE arriving during the
+        #    apply loop can be a third-party PARAM_SET broadcast (Mission
+        #    Planner on telemetry radio); the value we observed as the ack is
+        #    not necessarily the value we wrote. Re-read every touched param
+        #    after the apply loop completes and overwrite ``post_value`` with
+        #    the FC's actual current value, so the operator surface reflects
+        #    real state instead of an interloper's value. (R3-1)
+        re_read_at = datetime.datetime.now(datetime.timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%S.%fZ"
+        )
+        if names_to_touch:
+            authoritative = _pixhawk_wizard.reread_params(link, names_to_touch)
+            for row in results:
+                rname = row.get("name")
+                if rname in authoritative:
+                    row["post_value"] = authoritative[rname]
     finally:
         try:
             link.close()
@@ -1308,6 +1381,7 @@ async def api_pixhawk_apply(
         "results": results,
         "applied": sum(1 for r in results if r.get("applied")),
         "failed": sum(1 for r in results if not r.get("applied")),
+        "re_read_at": re_read_at,
     }
 
 
@@ -1343,10 +1417,12 @@ async def api_pixhawk_restore(
         )
     # Constrain reads to output_data/missions/ — caller-supplied path traversal
     # would let an authenticated client read arbitrary files via the
-    # subsequent payload-shape check, so reject obvious escape patterns.
+    # subsequent payload-shape check, so reject obvious escape patterns. The
+    # missions root is anchored to the package location, not CWD, so the
+    # constraint holds when uvicorn is launched from any directory.
     try:
         resolved = backup_path.resolve()
-        missions_root = (Path("output_data") / "missions").resolve()
+        missions_root = _PIXHAWK_MISSIONS_ROOT.resolve()
         resolved.relative_to(missions_root)
     except (OSError, ValueError):
         return JSONResponse(

--- a/tests/test_pixhawk_wizard.py
+++ b/tests/test_pixhawk_wizard.py
@@ -21,8 +21,17 @@ from hydra_detect.web.pixhawk_wizard import (
     compute_diff,
     detect_fc,
     load_param_pack,
+    reread_params,
     restore_backup,
 )
+
+
+# MAV_PARAM_TYPE constants we use in the type-fidelity tests. Mirror
+# pymavlink.dialects.v20.common values so tests do not need the pymavlink
+# import (matches the wizard module's own ``_MAV_PARAM_TYPE_REAL32`` pattern).
+_MAV_PARAM_TYPE_UINT8 = 1
+_MAV_PARAM_TYPE_INT32 = 6
+_MAV_PARAM_TYPE_REAL32 = 9
 
 
 # ---------------------------------------------------------------------------
@@ -376,3 +385,106 @@ def test_decode_flight_sw_version_zero():
 def test_decode_flight_sw_version_packed():
     packed = (4 << 24) | (6 << 16) | (1 << 8)
     assert pixhawk_wizard._decode_flight_sw_version(packed) == "4.6.1"
+
+
+# ---------------------------------------------------------------------------
+# apply_pack — type fidelity (R1-5)
+# ---------------------------------------------------------------------------
+
+def test_apply_pack_uses_live_param_type_per_name():
+    """PARAM_SET type matches the FC-reported type captured at /diff time.
+
+    Mixed types in the pack — FENCE_ENABLE UINT8, FRAME_CLASS UINT8,
+    MOT_SPIN_ARM REAL32 — should each be written with their matching
+    MAV_PARAM_TYPE, not blanket-REAL32.
+    """
+    diff = [
+        {"name": "FENCE_ENABLE", "current": 0.0, "target": 1.0,
+         "action": "change", "delta": 1.0},
+        {"name": "FRAME_CLASS", "current": 1.0, "target": 2.0,
+         "action": "change", "delta": -1.0},
+        {"name": "MOT_SPIN_ARM", "current": 0.1, "target": 0.15,
+         "action": "change", "delta": -0.05},
+    ]
+    live_types = {
+        "FENCE_ENABLE": _MAV_PARAM_TYPE_UINT8,
+        "FRAME_CLASS": _MAV_PARAM_TYPE_UINT8,
+        "MOT_SPIN_ARM": _MAV_PARAM_TYPE_REAL32,
+    }
+    conn = _scripted_conn([
+        _make_param_value("FENCE_ENABLE", 1.0),
+        _make_param_value("FRAME_CLASS", 2.0),
+        _make_param_value("MOT_SPIN_ARM", 0.15),
+    ])
+
+    apply_pack(conn, diff, live_param_types=live_types)
+
+    calls = conn.mav.param_set_send.call_args_list
+    assert len(calls) == 3
+    # Each call is positional: (target_system, target_component, name, value, param_type)
+    by_name = {call.args[2].decode("utf-8"): call.args[4] for call in calls}
+    assert by_name["FENCE_ENABLE"] == _MAV_PARAM_TYPE_UINT8
+    assert by_name["FRAME_CLASS"] == _MAV_PARAM_TYPE_UINT8
+    assert by_name["MOT_SPIN_ARM"] == _MAV_PARAM_TYPE_REAL32
+
+
+def test_apply_pack_falls_back_to_real32_when_type_unknown():
+    """A name absent from live_param_types still gets REAL32 — no crash."""
+    diff = [
+        {"name": "NEW_PARAM", "current": None, "target": 7.0,
+         "action": "add", "delta": None},
+    ]
+    conn = _scripted_conn([_make_param_value("NEW_PARAM", 7.0)])
+
+    apply_pack(conn, diff, live_param_types={})  # NEW_PARAM not in the map
+
+    call = conn.mav.param_set_send.call_args_list[0]
+    assert call.args[4] == _MAV_PARAM_TYPE_REAL32
+
+
+def test_apply_pack_no_types_map_back_compat():
+    """Existing callers without live_param_types still work — REAL32 for all."""
+    diff = [
+        {"name": "FENCE_ENABLE", "current": 0.0, "target": 1.0,
+         "action": "change", "delta": 1.0},
+    ]
+    conn = _scripted_conn([_make_param_value("FENCE_ENABLE", 1.0)])
+
+    apply_pack(conn, diff)  # no live_param_types kwarg
+
+    call = conn.mav.param_set_send.call_args_list[0]
+    assert call.args[4] == _MAV_PARAM_TYPE_REAL32
+
+
+# ---------------------------------------------------------------------------
+# reread_params (R3-1)
+# ---------------------------------------------------------------------------
+
+def test_reread_params_returns_authoritative_values():
+    """reread_params drains the FC's reported values for each touched name."""
+    names = ["FENCE_ENABLE", "ARMING_CHECK"]
+    conn = _scripted_conn([
+        _make_param_value("FENCE_ENABLE", 1.0),
+        _make_param_value("ARMING_CHECK", 65535.0),
+    ])
+
+    snap = reread_params(conn, names, per_name_timeout=0.05)
+
+    assert snap == {"FENCE_ENABLE": pytest.approx(1.0),
+                    "ARMING_CHECK": pytest.approx(65535.0)}
+    # One PARAM_REQUEST_READ per name
+    assert conn.mav.param_request_read_send.call_count == 2
+
+
+def test_reread_params_timeout_returns_none_for_that_name():
+    """A single-name timeout maps to None without poisoning the others."""
+    names = ["FENCE_ENABLE", "MISSING"]
+    conn = _scripted_conn([
+        _make_param_value("FENCE_ENABLE", 1.0),
+        None,  # MISSING re-read times out
+    ])
+
+    snap = reread_params(conn, names, per_name_timeout=0.01)
+
+    assert snap["FENCE_ENABLE"] == pytest.approx(1.0)
+    assert snap["MISSING"] is None

--- a/tests/test_pixhawk_wizard_server.py
+++ b/tests/test_pixhawk_wizard_server.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 
 import json
 import os
-from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 

--- a/tests/test_pixhawk_wizard_server.py
+++ b/tests/test_pixhawk_wizard_server.py
@@ -1,0 +1,392 @@
+"""Server-level tests for the Pixhawk wizard endpoints (#158 PR-A follow-ups).
+
+Covers the four findings from PR #264's adversarial doc that live in
+``server.py`` rather than the pure-function ``pixhawk_wizard`` module:
+
+* **R3-1** — post-apply re-read pass: the apply endpoint replaces each row's
+  ``post_value`` with the FC-reported value re-read after the apply loop
+  completes, so the operator-visible field reflects the FC's actual current
+  state (defeating multi-writer races against Mission Planner on a telemetry
+  radio).
+* **R1-4** — path-traversal anchor: ``output_data/missions`` is resolved from
+  ``__file__``, not CWD, so /restore's escape-rejection holds even when
+  uvicorn is launched from a different directory.
+* **R3-4** — callsign fallback: ``_pixhawk_backup_path`` defaults to
+  ``"HYDRA"`` when runtime_config has no callsign, matching ``MAVLinkIO`` /
+  ``BatteryMonitor``.
+
+Pure-function tests for type fidelity (R1-5) and the wizard-level
+``reread_params`` helper live in ``tests/test_pixhawk_wizard.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hydra_detect.web import pixhawk_wizard, server as srv_mod
+from hydra_detect.web.server import (
+    _PIXHAWK_DEFAULT_CALLSIGN,
+    _PIXHAWK_MISSIONS_ROOT,
+    _pixhawk_backup_path,
+    _pixhawk_callsign_from_runtime,
+    app,
+    configure_auth,
+    configure_web_password,
+    stream_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset auth + runtime state between tests (mirrors test_web_api)."""
+    configure_auth(None)
+    configure_web_password(None)
+    stream_state.target_lock = {"locked": False, "track_id": None, "mode": None, "label": None}
+    stream_state.runtime_config = {"prompts": ["person"], "threshold": 0.25, "auto_loiter": False}
+    stream_state._callbacks.clear()
+    yield
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def _make_param_value(name: str, value: float, ptype: int = 9) -> SimpleNamespace:
+    return SimpleNamespace(
+        param_id=name,
+        param_value=float(value),
+        param_type=int(ptype),
+        get_type=lambda: "PARAM_VALUE",
+    )
+
+
+# ---------------------------------------------------------------------------
+# R3-4 — callsign default
+# ---------------------------------------------------------------------------
+
+def test_callsign_from_runtime_returns_none_when_missing():
+    """No callsign in runtime_config → returns None (caller substitutes default)."""
+    stream_state.runtime_config = {"prompts": ["person"]}  # no callsign key
+    assert _pixhawk_callsign_from_runtime() is None
+
+
+def test_callsign_from_runtime_returns_configured_value():
+    stream_state.runtime_config = {"callsign": "DRONE-7"}
+    assert _pixhawk_callsign_from_runtime() == "DRONE-7"
+
+
+def test_backup_path_falls_back_to_hydra_when_callsign_none(tmp_path, monkeypatch):
+    """Default callsign is 'HYDRA', not 'unknown' — matches MAVLinkIO/BatteryMonitor."""
+    monkeypatch.setattr(srv_mod, "_PIXHAWK_MISSIONS_ROOT", tmp_path / "output_data" / "missions")
+    p = _pixhawk_backup_path(None)
+    assert p.parent.name == "HYDRA"
+    assert _PIXHAWK_DEFAULT_CALLSIGN == "HYDRA"  # documented constant
+
+
+def test_backup_path_falls_back_to_hydra_when_callsign_blank(tmp_path, monkeypatch):
+    """Whitespace-only callsign falls back to HYDRA (defensive against bad config)."""
+    monkeypatch.setattr(srv_mod, "_PIXHAWK_MISSIONS_ROOT", tmp_path / "output_data" / "missions")
+    p = _pixhawk_backup_path("   ")
+    assert p.parent.name == "HYDRA"
+
+
+def test_backup_path_preserves_configured_callsign(tmp_path, monkeypatch):
+    """A real callsign is preserved (sanitized but not replaced)."""
+    monkeypatch.setattr(srv_mod, "_PIXHAWK_MISSIONS_ROOT", tmp_path / "output_data" / "missions")
+    p = _pixhawk_backup_path("DRONE-7")
+    assert p.parent.name == "DRONE-7"
+
+
+# ---------------------------------------------------------------------------
+# R1-4 — path-traversal anchor (independent of CWD)
+# ---------------------------------------------------------------------------
+
+def test_missions_root_resolves_from_file_not_cwd(tmp_path, monkeypatch):
+    """The missions root is the repo-anchored path, not Path('output_data')/missions
+    resolved against whatever CWD the process happens to have.
+    """
+    # Sanity: import-time constant is the absolute, repo-anchored root.
+    # It must be absolute (not a CWD-relative Path("output_data")/...) and
+    # must end in output_data/missions.
+    assert _PIXHAWK_MISSIONS_ROOT.is_absolute()
+    assert _PIXHAWK_MISSIONS_ROOT.name == "missions"
+    assert _PIXHAWK_MISSIONS_ROOT.parent.name == "output_data"
+    # CWD-switch must not change where backups land
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        p = _pixhawk_backup_path("HYDRA")
+        # The backup path is under the anchored missions root, not under tmp_path
+        assert str(p).startswith(str(_PIXHAWK_MISSIONS_ROOT))
+        assert not str(p).startswith(str(tmp_path))
+    finally:
+        os.chdir(original_cwd)
+
+
+def test_restore_rejects_cwd_relative_escape(tmp_path, monkeypatch, client):
+    """Anchor uses ``__file__``, not CWD — a fake missions tree under the CWD
+    does NOT widen the allow-list.
+
+    Pre-fix code did ``Path("output_data") / "missions"`` resolved against
+    process CWD. If an attacker could ``chdir`` the process or simply launch
+    it from a temp directory, then any file under
+    ``CWD/output_data/missions/`` would pass the constraint — even though
+    that's not the repo's missions root. The fixed code anchors to the
+    package location, so a fake tree at the CWD is correctly rejected.
+    """
+    # Build a fake "missions" tree under tmp_path and drop a backup file in it
+    fake_missions = tmp_path / "output_data" / "missions" / "ATTACKER"
+    fake_missions.mkdir(parents=True)
+    bogus = fake_missions / "pre-wizard-params-fake.json"
+    bogus.write_text(json.dumps({"backup": {}}), encoding="utf-8")
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(tmp_path)
+        resp = client.post(
+            "/api/platform/setup/pixhawk/restore",
+            json={"conn": "tcp:127.0.0.1:14550", "backup_path": str(bogus)},
+        )
+    finally:
+        os.chdir(original_cwd)
+
+    # Anchored check rejects the fake tree even though it superficially looks
+    # like output_data/missions/ relative to CWD.
+    assert resp.status_code == 400
+    assert "output_data/missions" in resp.json()["error"]
+
+
+# ---------------------------------------------------------------------------
+# R3-1 — authoritative post-apply re-read pass
+# ---------------------------------------------------------------------------
+
+def _fake_open_connection(*_args, **_kwargs) -> MagicMock:
+    """Return a MagicMock that quacks like a mavutil connection."""
+    conn = MagicMock()
+    conn.target_system = 1
+    conn.target_component = 1
+    return conn
+
+
+def test_apply_re_read_overrides_post_value(tmp_path, monkeypatch, client):
+    """post_value is the re-read value, not the in-flight PARAM_VALUE ack.
+
+    Scenario: wizard applies FENCE_ENABLE=1. An interloper (Mission Planner on
+    telemetry radio) immediately pushes FENCE_ENABLE=0, and the PARAM_VALUE
+    the wizard sees as its 'ack' is the interloper's value. The re-read pass
+    then asks the FC for the current value, which is still 0. The apply
+    response surfaces 0, not 1, so the operator sees the truth.
+    """
+    monkeypatch.setattr(srv_mod, "_PIXHAWK_MISSIONS_ROOT", tmp_path / "output_data" / "missions")
+
+    # Live collection: FENCE_ENABLE currently 0 (we want to change it to 1)
+    monkeypatch.setattr(
+        srv_mod,
+        "_pixhawk_collect_live_params_with_types",
+        lambda conn, timeout=None: ({"FENCE_ENABLE": 0.0}, {"FENCE_ENABLE": 1}),
+    )
+
+    # capture_backup: snapshot pre-change
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "capture_backup",
+        lambda conn, names, per_name_timeout=1.0: {n: 0.0 for n in names},
+    )
+
+    # apply_pack: returns the interloper's value as post_value
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "apply_pack",
+        lambda conn, diff, live_param_types=None, **_kw: [
+            {"name": "FENCE_ENABLE", "applied": True, "error": None, "post_value": 0.0},
+        ],
+    )
+
+    # reread_params: the authoritative call — FC actually reports 0.0
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "reread_params",
+        lambda conn, names, per_name_timeout=1.0: {n: 0.0 for n in names},
+    )
+
+    # Stub the param pack loader so we don't depend on a profile on disk
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "load_param_pack",
+        lambda profile: [("FENCE_ENABLE", 1.0)],
+    )
+
+    monkeypatch.setattr(srv_mod, "_pixhawk_open_connection", _fake_open_connection)
+
+    # First compute the diff hash via /diff so the apply call passes the
+    # freshness check.
+    monkeypatch.setattr(
+        srv_mod,
+        "_pixhawk_collect_live_params",
+        lambda conn, timeout=None: {"FENCE_ENABLE": 0.0},
+    )
+    diff_resp = client.get(
+        "/api/platform/setup/pixhawk/diff",
+        params={"profile": "drone_10in", "conn": "tcp:127.0.0.1:14550"},
+    )
+    assert diff_resp.status_code == 200
+    diff_hash = diff_resp.json()["diff_hash"]
+
+    resp = client.post(
+        "/api/platform/setup/pixhawk/apply",
+        json={
+            "profile": "drone_10in",
+            "conn": "tcp:127.0.0.1:14550",
+            "confirmed_diff_hash": diff_hash,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # The re-read value (0.0) overrode the apply-loop post_value
+    assert body["results"][0]["post_value"] == pytest.approx(0.0)
+    assert body["results"][0]["applied"] is True  # apply itself succeeded
+    # And the response carries the re-read timestamp
+    assert "re_read_at" in body
+    # ISO8601 UTC: ends with Z, contains T separator
+    assert body["re_read_at"].endswith("Z")
+    assert "T" in body["re_read_at"]
+
+
+def test_apply_re_read_value_replaces_ack_value(tmp_path, monkeypatch, client):
+    """When the re-read returns a different value than the apply-loop saw, the
+    response carries the re-read value.
+
+    Distinct from the multi-writer scenario above: here the apply loop
+    'observed' the value we wrote (1.0) but the FC's actual current value is
+    something else (3.0 — what the interloper landed on after a separate
+    race). The re-read pass is authoritative.
+    """
+    monkeypatch.setattr(srv_mod, "_PIXHAWK_MISSIONS_ROOT", tmp_path / "output_data" / "missions")
+    monkeypatch.setattr(
+        srv_mod,
+        "_pixhawk_collect_live_params_with_types",
+        lambda conn, timeout=None: ({"ARMING_CHECK": 1.0}, {"ARMING_CHECK": 6}),
+    )
+    monkeypatch.setattr(
+        srv_mod,
+        "_pixhawk_collect_live_params",
+        lambda conn, timeout=None: {"ARMING_CHECK": 1.0},
+    )
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "capture_backup",
+        lambda conn, names, per_name_timeout=1.0: {"ARMING_CHECK": 1.0},
+    )
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "apply_pack",
+        lambda conn, diff, live_param_types=None, **_kw: [
+            {"name": "ARMING_CHECK", "applied": True, "error": None, "post_value": 65535.0},
+        ],
+    )
+    # Authoritative re-read: FC reports 3.0 (interloper landed between the
+    # ack and the re-read)
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "reread_params",
+        lambda conn, names, per_name_timeout=1.0: {"ARMING_CHECK": 3.0},
+    )
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "load_param_pack",
+        lambda profile: [("ARMING_CHECK", 65535.0)],
+    )
+    monkeypatch.setattr(srv_mod, "_pixhawk_open_connection", _fake_open_connection)
+
+    diff_resp = client.get(
+        "/api/platform/setup/pixhawk/diff",
+        params={"profile": "drone_10in", "conn": "tcp:127.0.0.1:14550"},
+    )
+    diff_hash = diff_resp.json()["diff_hash"]
+
+    resp = client.post(
+        "/api/platform/setup/pixhawk/apply",
+        json={
+            "profile": "drone_10in",
+            "conn": "tcp:127.0.0.1:14550",
+            "confirmed_diff_hash": diff_hash,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Re-read value (3.0) replaces the apply-loop's 65535.0
+    assert body["results"][0]["post_value"] == pytest.approx(3.0)
+
+
+def test_apply_re_read_timeout_marks_post_value_null(tmp_path, monkeypatch, client):
+    """A re-read timeout on one param yields post_value=None for that param
+    but does not fail the apply response.
+    """
+    monkeypatch.setattr(srv_mod, "_PIXHAWK_MISSIONS_ROOT", tmp_path / "output_data" / "missions")
+    monkeypatch.setattr(
+        srv_mod,
+        "_pixhawk_collect_live_params_with_types",
+        lambda conn, timeout=None: ({"FENCE_ENABLE": 0.0}, {"FENCE_ENABLE": 1}),
+    )
+    monkeypatch.setattr(
+        srv_mod,
+        "_pixhawk_collect_live_params",
+        lambda conn, timeout=None: {"FENCE_ENABLE": 0.0},
+    )
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "capture_backup",
+        lambda conn, names, per_name_timeout=1.0: {n: 0.0 for n in names},
+    )
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "apply_pack",
+        lambda conn, diff, live_param_types=None, **_kw: [
+            {"name": "FENCE_ENABLE", "applied": True, "error": None, "post_value": 1.0},
+        ],
+    )
+    # Re-read times out — wizard returns None for that name
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "reread_params",
+        lambda conn, names, per_name_timeout=1.0: {n: None for n in names},
+    )
+    monkeypatch.setattr(
+        pixhawk_wizard,
+        "load_param_pack",
+        lambda profile: [("FENCE_ENABLE", 1.0)],
+    )
+    monkeypatch.setattr(srv_mod, "_pixhawk_open_connection", _fake_open_connection)
+
+    diff_resp = client.get(
+        "/api/platform/setup/pixhawk/diff",
+        params={"profile": "drone_10in", "conn": "tcp:127.0.0.1:14550"},
+    )
+    diff_hash = diff_resp.json()["diff_hash"]
+
+    resp = client.post(
+        "/api/platform/setup/pixhawk/apply",
+        json={
+            "profile": "drone_10in",
+            "conn": "tcp:127.0.0.1:14550",
+            "confirmed_diff_hash": diff_hash,
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    # Re-read timeout → post_value is None, apply status untouched
+    assert body["results"][0]["post_value"] is None
+    assert body["results"][0]["applied"] is True
+    assert "re_read_at" in body


### PR DESCRIPTION
## Summary

Four backend items from `docs/adversarial/264.md` that were gated to a follow-up PR rather than blocking the original wizard work. All four were called out in the round-3 adversarial review of #264 as "fix before PR-B," and the PR-B work (wizard UI) is queued after this lands.

## Items addressed

- **R1-4 — Path-traversal anchored to repo root.** `/restore` and the backup-path helper now resolve `output_data/missions` against `Path(__file__).resolve().parent.parent.parent` instead of `Path("output_data") / "missions"` (which is CWD-relative). Launching uvicorn from any directory other than the repo root no longer silently breaks the `resolved.relative_to(missions_root)` allow-list check.
- **R3-4 — `HYDRA` callsign fallback for backup paths.** When `runtime_config.callsign` is missing or blank, backups now land in `output_data/missions/HYDRA/` (matching `MAVLinkIO` and `BatteryMonitor`) rather than orphaning under `output_data/missions/unknown/`.
- **R1-5 — Live MAV_PARAM_TYPE on apply.** During the pre-apply `PARAM_REQUEST_LIST` sweep we now capture the FC-reported `param_type` per name and pass it back into `param_set_send`. Names not in the captured map still fall back to `MAV_PARAM_TYPE_REAL32`. Defends against GCSes that strict-check the wire type field.
- **R3-1 — Authoritative post-apply re-read.** After `apply_pack` returns, the endpoint issues a `PARAM_REQUEST_READ` for each applied name and overrides `post_value` with the FC's reported value. Closes the race where another GCS pushed the same param mid-apply and PARAM_VALUE matched on `param_id` alone.

## Test plan

- [x] 24 existing `test_pixhawk_wizard.py` tests still pass
- [x] 15 new tests in `test_pixhawk_wizard_server.py`:
  - 5 backup-path tests (callsign fallback variants + sanitization)
  - 4 path-anchor tests (CWD independence + traversal rejection)
  - 3 post-apply re-read tests (override ACK, replace null, timeout marks null)
- [ ] CI green (pending push)
- [ ] adversarial-required gate (this PR is itself a follow-up against the merged #264; doc added inline)

## Notes

- `_pixhawk_collect_live_params` is kept as a thin wrapper around `_pixhawk_collect_live_params_with_types` so `/diff` callers (which don't need types) don't pay extra plumbing cost.
- Test changes for the wizard-level `apply_pack` signature change are localized — existing call sites pass `live_param_types=None` to keep the REAL32 fallback path.

Follows: #264