### PR TITLE
feat(#152): OTA PR-B — manifest verify + GHCR pull-by-digest

### DIFF
--- a/docs/adversarial/267.md
+++ b/docs/adversarial/267.md
@@ -1,0 +1,76 @@
+# Adversarial review — PR #267 (OTA PR-B: manifest verify + pull-by-digest)
+
+## Round 1 — pattern-match the changes
+
+**R1-a — `gpg --verify` fingerprint not pinned.** Initial concern: GPG returns 0 on a valid signature from any key in the keyring, not specifically the pinned key. Looking at the actual implementation: `gpg --batch --no-default-keyring --keyring "${GPG_KEY_PATH}" --verify ...`. The `--no-default-keyring` flag means GPG will NOT fall through to `~/.gnupg/pubring.gpg` or `/etc/gnupg/`; the only keys it can verify against are the ones in the single file at `${GPG_KEY_PATH}`. Downgraded to LOW: a signature from any key in that specific file passes (so during key rotation when both old and new are present, either signs valid). Operator-controlled foot-gun; not a CI-discoverable defect. Accept.
+
+**R1-b — Manifest channel-mismatch bail timing.** Re-read the script. Confirmed flow: `gpg --verify` -> Python parse + schema validate -> channel match -> already-current short-circuit -> digest regex (already done in Python parse, line 284) -> `docker pull`. Channel-match runs BEFORE version-skip. Downgrade to ACCEPT. The order is correct.
+
+**R1-c — `docker pull` failure mode is the empty case.** Persistent-failure case (deleted beta release, GHCR pruned the digest) means the timer retries the same failing digest every hour. Severity: low — operationally tractable. The dashboard work in PR-D should surface "stuck on digest X for N attempts" rather than just "last update failed." Track for PR-D.
+
+**R1-d — `${HYDRA_VERSION}` env var trust.** Operator-controlled. `docker run -e HYDRA_VERSION=99.99.99` would silently force `up_to_date`. Accept — documented foot-gun, no realistic mitigation since the env is the operator's interface.
+
+**R1-e — `mktemp -d` cleanup on signal.** `trap cleanup EXIT` covers normal exit + most signals. SIGKILL from `systemd TimeoutSec=` would leak a tmpdir under `/tmp` until reboot. Trivial; systemd `RuntimeDirectory=` would solve it but bash `mktemp -d` matches existing Hydra convention. Accept.
+
+## Round 2 — counter-critique, downgrade where appropriate
+
+**R1-a accepted at LOW.** The `--no-default-keyring` flag is the right defense. The remaining "multiple-key-in-pinned-file" risk is real but operator-controlled.
+
+**R1-b accepted as correct.** Flow order is right.
+
+**R1-c stands as LOW.** Tracked for PR-D dashboard.
+
+**R1-d stands as ACCEPT.** Foot-gun-by-design.
+
+**R1-e stands as TRIVIAL.** Accept.
+
+## Round 3 — orthogonal sweep (framing-break: "what happens when a signed manifest is replayed?")
+
+**R3-a — Signed manifest replay -> downgrade attack.** This is the most important finding in this review. The signed manifest is a static, durable file. Nothing in it binds to a specific box, time, or running version. If a previous valid signed manifest (e.g., v0.4 from 3 weeks ago) is replayed to a box currently running v0.5, the script will:
+
+  1. gpg-verify (passes — signature is permanently valid)
+  2. parse + validate (passes)
+  3. channel-match (passes if v0.4 was same channel)
+  4. `manifest_version != HYDRA_VERSION` (TRUE — v0.4 != v0.5, treated as "update available")
+  5. `docker pull "${GHCR_REPO}@${manifest_digest_v0.4}"`
+  6. Record `last_update` with v0.4
+
+The line in question is `platform-update.sh:329`:
+```
+if [[ -n "${running_version}" && "${running_version}" == "${manifest_version}" ]]; then
+```
+
+It checks equality, not monotonicity. A box on v0.5 receiving a replayed v0.4 manifest will pull v0.4. PR-B does NOT restart the container (PR-C does), so the running container stays on v0.5 — but the v0.4 image sits in the local Docker cache, ready for PR-C's A/B flip to promote it. PR-C MUST add version-monotonic check before flipping traffic, OR this PR must add a `manifest.version > $HYDRA_VERSION` check now.
+
+The version scheme is "short git SHA or semver-ish" per the schema regex (`[A-Za-z0-9._+-]{1,64}`). Git SHAs aren't lexicographically orderable in any meaningful sense, so a string-comparison `>` won't work. Options for monotonicity:
+
+- **(a) `released_at` timestamp in manifest, reject if older than last applied.** Requires manifest format change (small) + tracking last_applied_released_at in `last_update.json`. Works for any version scheme.
+- **(b) Monotonic counter in `/var/lib/hydra/manifest-counter`.** Simple. Doesn't survive cache wipes.
+- **(c) Sigstore + Rekor transparency log.** Out of scope for the chosen design (we picked GPG-pinned-key).
+- **(d) Accept the limitation, gate the actual downgrade in PR-C.** Document here; address in PR-C's restart logic.
+
+**Recommendation: Option (d) for PR-B, then Option (a) in PR-C.** PR-B pulls by digest but doesn't promote; the durable harm window is PR-C's restart. Add `manifest.version > running.version`-equivalent (via released_at) as a PR-C blocker. Document this here so the PR-C dispatch carries the requirement.
+
+Severity: **HIGH for the OTA pipeline overall, MEDIUM for this PR specifically.** Filed as a PR-C blocker, not a PR-B blocker.
+
+**R3-b — Air-gapped deployment manifest URL contract.** PR description says "swap MANIFEST_URL_BASE + GPG_KEY_PATH" for air-gapped boxes. Channel-specific path (`/latest/download/`, `/download/beta/`) is hardcoded — it mirrors GitHub's URL layout. A self-hosted manifest server has to mimic that layout exactly OR override the routing. Should parameterize `MANIFEST_STABLE_PATH` / `MANIFEST_BETA_PATH` via env so the air-gapped story doesn't require monkey-patching the script. Severity: low. Track for PR-C or a small fix-up PR.
+
+**R3-c — GHCR_REPO auth state.** Public repos: `docker pull` against digest is anonymous. Private repos: requires `docker login ghcr.io` first. The script doesn't check auth state, doesn't call `docker login`. If `rmeadomavic/Hydra` ever flips private (or the org enforces it), every box silently `pull_failed` indistinguishably from a network glitch. Severity: low for current public state. PR-D dashboard should distinguish auth-required from network-fail in the surface.
+
+**R3-d — `last_update.json` lock-free concurrent write.** Tmpfile-and-rename is per-write atomic. Concurrent writes (manual run while timer fires) both rename to the same path; last-write-wins. Fine for a status file; systemd's unit semantics prevent the timer from double-firing its own Service. Accept.
+
+## Net assessment
+
+**No PR-B blockers.** All Round 1 findings either downgraded to LOW or accepted after re-reading the code.
+
+**PR-C blockers (MUST address before PR-C merges, not before PR-B):**
+- **R3-a (HIGH for the pipeline)** — version-monotonic check before container restart, via `released_at` timestamp in manifest. The PR-C dispatch prompt must carry this requirement.
+
+**Known follow-ups (gate-before-PR-D-merge):**
+- R3-b — parameterize manifest channel paths for air-gapped deployments.
+- R1-c — surface "stuck on digest X for N attempts" in dashboard.
+- R3-c — distinguish auth-required from network-fail in dashboard.
+
+**Accepted as-is:** R1-a (keyring pinned), R1-b (flow order correct), R1-d (operator foot-gun), R1-e (trivial), R3-d (last-write-wins is fine for status file).
+
+R1-a was overstated in initial sweep; the `--no-default-keyring` flag was missed in the first read. Round-2 re-read caught it. This is exactly the kind of thing the 3-round structure is supposed to catch — a one-pass review would have called the code wrong.

--- a/scripts/platform-update.sh
+++ b/scripts/platform-update.sh
@@ -287,11 +287,11 @@ if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
 # Version: short SHA or semver-ish. Reject anything that could be
 # interpreted by the shell.
 if not re.fullmatch(r"[A-Za-z0-9._+-]{1,64}", m["version"]):
-    print(f"PARSE_ERROR version shape: {m[\"version\"]!r}", file=sys.stderr)
+    print(f"PARSE_ERROR version shape: {m['version']!r}", file=sys.stderr)
     sys.exit(1)
 # Channel: same allowlist as the bash side.
 if m["channel"] not in ("stable", "beta"):
-    print(f"PARSE_ERROR channel: {m[\"channel\"]!r}", file=sys.stderr)
+    print(f"PARSE_ERROR channel: {m['channel']!r}", file=sys.stderr)
     sys.exit(1)
 print(m["channel"])
 print(m["version"])

--- a/scripts/platform-update.sh
+++ b/scripts/platform-update.sh
@@ -1,10 +1,25 @@
 #!/usr/bin/env bash
-# platform-update.sh — Hydra OTA update entry point (issue #152, PR-A skeleton).
+# platform-update.sh — Hydra OTA update entry point (issue #152, PR-B).
 #
-# PR-A only stubs the timer surface. The actual update path (image-digest
-# GPG-verify + docker pull by digest + A/B promotion on healthcheck) lands
-# in PR-B/C/D. For now this script just reads the channel and update env,
-# logs intent, and exits 0 so the systemd timer's first runs are inert.
+# Flow (PR-B):
+#   1. Read channel from /etc/hydra/channel (allowlist: stable, beta).
+#   2. Read GHCR_REPO + GPG_KEY_PATH + MANIFEST_URL_BASE from
+#      /etc/hydra/update.env (or env defaults).
+#   3. Resolve manifest URL by channel:
+#        stable -> ${BASE}/latest/download/manifest.json  (GH 302's to latest)
+#        beta   -> ${BASE}/download/beta/manifest.json    (literal "beta" tag,
+#                                                          a rolling pre-release)
+#   4. curl --fail manifest.json + manifest.json.sig to a tmpdir.
+#   5. gpg --verify against the pinned public keyring at GPG_KEY_PATH.
+#   6. Validate manifest schema + that manifest channel == box channel.
+#   7. If manifest version == $HYDRA_VERSION (running container), exit
+#      with status="up_to_date" — no pull.
+#   8. docker pull ${GHCR_REPO}@${digest}  (digest from the verified manifest)
+#   9. Write /var/lib/hydra/last-update.json atomically (tmp+rename).
+#
+# PR-B does NOT restart the container — the pulled image sits in the
+# local Docker cache until PR-C promotes it via the A/B flip + healthcheck
+# gate. PR-D adds the dashboard view.
 #
 # Wired from:
 #   - /etc/systemd/system/hydra-platform-update.service (EnvironmentFile
@@ -12,41 +27,327 @@
 #   - /etc/systemd/system/hydra-platform-update.timer   (daily,
 #     RandomizedDelaySec=1800)
 #
-# Inputs (all optional — defaults are safe on a fresh box):
-#   /etc/hydra/channel     -> single token, "stable" or "beta". Default
-#                             "stable" if missing or empty.
-#   /etc/hydra/update.env  -> shell-sourceable. Expected keys (placeholder,
-#                             not used yet):
-#                               GHCR_REPO=ghcr.io/rmeadomavic/hydra
-#                               GPG_KEY_PATH=/etc/hydra/ota-signing.pub
+# Inputs (all overridable via env — tests use HYDRA_*_PATH to sandbox):
+#   /etc/hydra/channel                   single token: "stable" | "beta"
+#   /etc/hydra/update.env                shell-sourceable:
+#                                          GHCR_REPO=ghcr.io/rmeadomavic/hydra
+#                                          GPG_KEY_PATH=/etc/hydra/ota-signing.pub
+#                                          MANIFEST_URL_BASE=https://github.com/rmeadomavic/Hydra/releases
 #
-# Output: a single ``[platform-update]`` log line on stdout (journald
-# captures it via SyslogIdentifier=hydra-platform-update).
+# Output:
+#   stdout              one ``[platform-update]`` line per phase
+#   /var/lib/hydra/last-update.json
+#                       {"ts": <unix>, "status": "ok"|"failed"|"up_to_date",
+#                        "version": str, "digest": str, "channel": str,
+#                        "reason": str?}
+#
+# Failure-mode contract: any reachable failure path MUST write a
+# last-update.json with status="failed" and a short, fixed ``reason``
+# token (``manifest_fetch_failed``, ``signature_invalid``, etc.) before
+# exiting non-zero. The one exception is missing_signing_key, which
+# exits 0 (so the timer stays armed) but still records the failure so
+# the operator sees it on the dashboard.
 
 set -euo pipefail
 
+# --- paths + defaults --------------------------------------------------------
+
 readonly CHANNEL_FILE="${HYDRA_CHANNEL_PATH:-/etc/hydra/channel}"
 readonly UPDATE_ENV_FILE="${HYDRA_UPDATE_ENV_PATH:-/etc/hydra/update.env}"
+readonly LAST_UPDATE_PATH="${HYDRA_LAST_UPDATE_PATH:-/var/lib/hydra/last-update.json}"
 
-# --- channel -----------------------------------------------------------------
+# The channels we will accept from /etc/hydra/channel AND from the
+# manifest payload. Anything else is rejected before any network or
+# shell substitution happens (R3-1 from PR-A's adversarial).
+readonly ALLOWED_CHANNELS=("stable" "beta")
+
+TMP_DIR=""
+CURRENT_CHANNEL=""
+CURRENT_VERSION=""
+CURRENT_DIGEST=""
+
+# --- tmp dir + cleanup -------------------------------------------------------
+
+cleanup() {
+    if [[ -n "${TMP_DIR}" && -d "${TMP_DIR}" ]]; then
+        rm -rf -- "${TMP_DIR}"
+    fi
+}
+trap cleanup EXIT
+
+# --- logging -----------------------------------------------------------------
+
+log() {
+    printf '[platform-update] %s\n' "$*"
+}
+
+# --- last-update.json writer (atomic) ----------------------------------------
+
+# write_last_update STATUS [REASON]
+#
+# Composes a JSON record using the current channel/version/digest globals
+# and writes it atomically (tmp file in same dir + mv) so the read side
+# (version_surface._read_last_update) never sees a half-written file.
+# Missing fields are emitted as empty strings — version_surface accepts
+# any JSON object.
+write_last_update() {
+    local status="$1"
+    local reason="${2:-}"
+    local ts
+    ts="$(date +%s)"
+
+    local parent_dir
+    parent_dir="$(dirname -- "${LAST_UPDATE_PATH}")"
+    mkdir -p -- "${parent_dir}"
+
+    local tmp_file
+    tmp_file="$(mktemp -- "${parent_dir}/.last-update.json.XXXXXX")"
+
+    # Compose JSON via python3 — robust against quoting / unicode quirks
+    # that a printf '{"key":"%s"}' approach would mangle.
+    STATUS_ENV="${status}" \
+    REASON_ENV="${reason}" \
+    TS_ENV="${ts}" \
+    VERSION_ENV="${CURRENT_VERSION}" \
+    DIGEST_ENV="${CURRENT_DIGEST}" \
+    CHANNEL_ENV="${CURRENT_CHANNEL}" \
+    python3 -c '
+import json, os, sys
+rec = {
+    "ts": int(os.environ["TS_ENV"]),
+    "status": os.environ["STATUS_ENV"],
+    "version": os.environ["VERSION_ENV"],
+    "digest": os.environ["DIGEST_ENV"],
+    "channel": os.environ["CHANNEL_ENV"],
+}
+reason = os.environ.get("REASON_ENV", "")
+if reason:
+    rec["reason"] = reason
+sys.stdout.write(json.dumps(rec))
+' > "${tmp_file}"
+
+    mv -f -- "${tmp_file}" "${LAST_UPDATE_PATH}"
+}
+
+# fail REASON [EXIT_CODE]
+#
+# Records a failed last-update entry and exits non-zero (default 1).
+# Use for any post-pre-flight failure where we want the timer to keep
+# firing tomorrow.
+fail() {
+    local reason="$1"
+    local code="${2:-1}"
+    log "FAIL: ${reason}"
+    write_last_update "failed" "${reason}"
+    exit "${code}"
+}
+
+# --- channel allowlist -------------------------------------------------------
+
+is_allowed_channel() {
+    local candidate="$1"
+    local allowed
+    for allowed in "${ALLOWED_CHANNELS[@]}"; do
+        [[ "${candidate}" == "${allowed}" ]] && return 0
+    done
+    return 1
+}
+
+# --- read channel ------------------------------------------------------------
+
 channel="stable"
-if [ -r "${CHANNEL_FILE}" ]; then
-    # First whitespace token only — keeps trailing comments / newlines
-    # from leaking into the log line.
+if [[ -r "${CHANNEL_FILE}" ]]; then
     read -r raw_channel < "${CHANNEL_FILE}" || raw_channel=""
-    if [ -n "${raw_channel}" ]; then
+    # Strip a trailing carriage return so a CRLF channel file written
+    # from Windows still matches the allowlist. Defends against the
+    # "beta\r" mis-match observed in tests run under Git Bash.
+    raw_channel="${raw_channel%$'\r'}"
+    if [[ -n "${raw_channel}" ]]; then
         channel="${raw_channel}"
     fi
 fi
+CURRENT_CHANNEL="${channel}"
 
-# --- update env (placeholder, not consumed yet in PR-A) ----------------------
+if ! is_allowed_channel "${channel}"; then
+    # Bail before any network call. Don't trust the operator's typo.
+    fail "invalid_channel"
+fi
+
+# --- read update.env ---------------------------------------------------------
+
 GHCR_REPO="${GHCR_REPO:-ghcr.io/rmeadomavic/hydra}"
 GPG_KEY_PATH="${GPG_KEY_PATH:-/etc/hydra/ota-signing.pub}"
-if [ -r "${UPDATE_ENV_FILE}" ]; then
+MANIFEST_URL_BASE="${MANIFEST_URL_BASE:-https://github.com/rmeadomavic/Hydra/releases}"
+
+if [[ -r "${UPDATE_ENV_FILE}" ]]; then
     # shellcheck disable=SC1090
     . "${UPDATE_ENV_FILE}"
 fi
 
-echo "[platform-update] channel=${channel} ghcr=${GHCR_REPO} gpg_key=${GPG_KEY_PATH} would check for updates"
+readonly GHCR_REPO GPG_KEY_PATH MANIFEST_URL_BASE
+
+log "channel=${channel} ghcr=${GHCR_REPO} gpg_key=${GPG_KEY_PATH} starting update check"
+
+# --- signing key sanity ------------------------------------------------------
+
+# Missing key is a special case: we don't want the timer to fail (which
+# would mark the unit failed and stop further checks until an operator
+# clears it). Record the failure visibly and exit 0 so tomorrow's run
+# tries again.
+if [[ ! -r "${GPG_KEY_PATH}" ]]; then
+    log "FAIL: missing_signing_key (no readable key at ${GPG_KEY_PATH})"
+    write_last_update "failed" "missing_signing_key"
+    exit 0
+fi
+
+# --- tmpdir for downloads ----------------------------------------------------
+
+TMP_DIR="$(mktemp -d)"
+MANIFEST_PATH="${TMP_DIR}/manifest.json"
+SIG_PATH="${TMP_DIR}/manifest.json.sig"
+
+# --- resolve manifest URLs ---------------------------------------------------
+
+case "${channel}" in
+    stable)
+        # GitHub redirects /releases/latest/download/<asset> to the
+        # newest non-prerelease asset on each request — no need to
+        # parse the API for the latest tag.
+        MANIFEST_URL="${MANIFEST_URL_BASE}/latest/download/manifest.json"
+        SIG_URL="${MANIFEST_URL_BASE}/latest/download/manifest.json.sig"
+        ;;
+    beta)
+        # Beta is a single rolling pre-release tag literally named
+        # "beta" that gets republished each cycle. release-manifest.yml
+        # picks this up via release.prerelease == true.
+        MANIFEST_URL="${MANIFEST_URL_BASE}/download/beta/manifest.json"
+        SIG_URL="${MANIFEST_URL_BASE}/download/beta/manifest.json.sig"
+        ;;
+    *)
+        # Unreachable due to allowlist above, but keeps shellcheck happy.
+        fail "invalid_channel"
+        ;;
+esac
+
+# --- fetch manifest + sig ----------------------------------------------------
+
+log "fetching ${MANIFEST_URL}"
+if ! curl --fail --location --silent --show-error \
+        --max-time 60 \
+        --output "${MANIFEST_PATH}" "${MANIFEST_URL}"; then
+    fail "manifest_fetch_failed"
+fi
+
+log "fetching ${SIG_URL}"
+if ! curl --fail --location --silent --show-error \
+        --max-time 60 \
+        --output "${SIG_PATH}" "${SIG_URL}"; then
+    fail "manifest_fetch_failed"
+fi
+
+# --- gpg verify --------------------------------------------------------------
+
+# --no-default-keyring + --keyring pins trust to the operator-installed
+# public key. We must NOT fall through to ~/.gnupg or the system keyring.
+log "verifying signature against ${GPG_KEY_PATH}"
+if ! gpg --batch \
+        --no-default-keyring \
+        --keyring "${GPG_KEY_PATH}" \
+        --verify "${SIG_PATH}" "${MANIFEST_PATH}"; then
+    fail "signature_invalid"
+fi
+
+# --- parse + validate manifest ----------------------------------------------
+
+# Use python3 (CI runners + Jetson both ship it; jq may or may not be
+# present). Emit channel/version/digest on three TSV lines so the bash
+# parse is trivial.
+PARSE_OUTPUT="$(MANIFEST_PATH="${MANIFEST_PATH}" python3 -c '
+import json, os, re, sys
+try:
+    with open(os.environ["MANIFEST_PATH"], "r", encoding="utf-8") as f:
+        m = json.load(f)
+except (OSError, json.JSONDecodeError) as exc:
+    print("PARSE_ERROR", str(exc), file=sys.stderr)
+    sys.exit(1)
+if not isinstance(m, dict):
+    print("PARSE_ERROR not a JSON object", file=sys.stderr)
+    sys.exit(1)
+required = ("channel", "version", "digest")
+missing = [k for k in required if k not in m or not isinstance(m[k], str) or not m[k]]
+if missing:
+    print(f"PARSE_ERROR missing fields: {missing}", file=sys.stderr)
+    sys.exit(1)
+digest = m["digest"]
+# Hard-constrain digest to sha256:<64 hex>. Defends against a manifest
+# that smuggles a shell metacharacter into the docker pull tag.
+if not re.fullmatch(r"sha256:[0-9a-f]{64}", digest):
+    print(f"PARSE_ERROR digest shape: {digest!r}", file=sys.stderr)
+    sys.exit(1)
+# Version: short SHA or semver-ish. Reject anything that could be
+# interpreted by the shell.
+if not re.fullmatch(r"[A-Za-z0-9._+-]{1,64}", m["version"]):
+    print(f"PARSE_ERROR version shape: {m[\"version\"]!r}", file=sys.stderr)
+    sys.exit(1)
+# Channel: same allowlist as the bash side.
+if m["channel"] not in ("stable", "beta"):
+    print(f"PARSE_ERROR channel: {m[\"channel\"]!r}", file=sys.stderr)
+    sys.exit(1)
+print(m["channel"])
+print(m["version"])
+print(m["digest"])
+' 2>&1)" || {
+    log "manifest parse failure: ${PARSE_OUTPUT}"
+    fail "manifest_invalid"
+}
+
+manifest_channel="$(printf '%s\n' "${PARSE_OUTPUT}" | sed -n '1p')"
+manifest_version="$(printf '%s\n' "${PARSE_OUTPUT}" | sed -n '2p')"
+manifest_digest="$(printf '%s\n' "${PARSE_OUTPUT}" | sed -n '3p')"
+
+if [[ -z "${manifest_channel}" || -z "${manifest_version}" || -z "${manifest_digest}" ]]; then
+    log "manifest parse produced empty fields: ${PARSE_OUTPUT}"
+    fail "manifest_invalid"
+fi
+
+CURRENT_VERSION="${manifest_version}"
+CURRENT_DIGEST="${manifest_digest}"
+
+# --- channel match -----------------------------------------------------------
+
+if [[ "${manifest_channel}" != "${channel}" ]]; then
+    log "channel mismatch: manifest=${manifest_channel} box=${channel}"
+    fail "channel_mismatch"
+fi
+
+# --- already current? --------------------------------------------------------
+
+# The running container's version is exported into the systemd unit env
+# as $HYDRA_VERSION (Dockerfile bakes the git SHA at build time). If
+# that matches the manifest, we can skip the pull entirely.
+running_version="${HYDRA_VERSION:-}"
+if [[ -n "${running_version}" && "${running_version}" == "${manifest_version}" ]]; then
+    log "already up to date (running=${running_version}, manifest=${manifest_version}); skipping pull"
+    write_last_update "up_to_date"
+    exit 0
+fi
+
+# --- docker pull -------------------------------------------------------------
+
+PULL_REF="${GHCR_REPO}@${manifest_digest}"
+log "docker pull ${PULL_REF}"
+pull_start="$(date +%s)"
+if ! docker pull "${PULL_REF}"; then
+    pull_end="$(date +%s)"
+    log "docker pull failed after $((pull_end - pull_start))s"
+    fail "docker_pull_failed"
+fi
+pull_end="$(date +%s)"
+log "docker pull ok in $((pull_end - pull_start))s"
+
+# --- record success ----------------------------------------------------------
+
+write_last_update "ok"
+log "ok version=${manifest_version} digest=${manifest_digest} channel=${channel}"
 
 exit 0

--- a/tests/test_ota_skeleton.py
+++ b/tests/test_ota_skeleton.py
@@ -50,7 +50,13 @@ pytestmark_bash = pytest.mark.skipif(
 
 @pytestmark_bash
 def test_platform_update_sh_reads_channel(tmp_path: Path) -> None:
-    """When the channel file is present, the script logs that channel."""
+    """When the channel file is present, the script logs that channel.
+
+    PR-B note: the script now attempts a fetch + verify when the
+    signing key is missing it records ``failed`` and exits 0 so the
+    timer stays armed. ``HYDRA_LAST_UPDATE_PATH`` is pinned at a
+    tmp file so the script doesn't try to write to ``/var/lib/hydra``.
+    """
     channel_file = tmp_path / "channel"
     channel_file.write_text("beta\n", encoding="utf-8")
 
@@ -59,6 +65,7 @@ def test_platform_update_sh_reads_channel(tmp_path: Path) -> None:
     # Point the update.env at a path that does NOT exist — the script
     # must still succeed and fall through to defaults.
     env["HYDRA_UPDATE_ENV_PATH"] = str(tmp_path / "nope.env")
+    env["HYDRA_LAST_UPDATE_PATH"] = str(tmp_path / "last-update.json")
 
     result = subprocess.run(
         ["bash", str(PLATFORM_UPDATE_SH)],
@@ -68,6 +75,9 @@ def test_platform_update_sh_reads_channel(tmp_path: Path) -> None:
         timeout=10,
     )
 
+    # PR-B: missing /etc/hydra/ota-signing.pub is the expected outcome
+    # in a tmp-dir sandbox — script must exit 0 (timer-friendly) and
+    # log the channel selection before the key check fails.
     assert result.returncode == 0, f"stderr: {result.stderr!r}"
     assert "[platform-update]" in result.stdout
     assert "channel=beta" in result.stdout
@@ -81,6 +91,7 @@ def test_platform_update_sh_default_stable(tmp_path: Path) -> None:
     env = os.environ.copy()
     env["HYDRA_CHANNEL_PATH"] = str(missing)
     env["HYDRA_UPDATE_ENV_PATH"] = str(tmp_path / "nope.env")
+    env["HYDRA_LAST_UPDATE_PATH"] = str(tmp_path / "last-update.json")
 
     result = subprocess.run(
         ["bash", str(PLATFORM_UPDATE_SH)],

--- a/tests/test_ota_verify_pull.py
+++ b/tests/test_ota_verify_pull.py
@@ -33,7 +33,6 @@ import shutil
 import stat
 import subprocess
 import textwrap
-import time
 from pathlib import Path
 from typing import Any, Dict, List
 
@@ -195,12 +194,18 @@ def harness(tmp_path: Path):
         encoding="utf-8",
     )
     key_path = etc_dir / "ota-signing.pub"
-    key_path.write_text("-----BEGIN PGP PUBLIC KEY BLOCK-----\nfake\n-----END PGP PUBLIC KEY BLOCK-----\n", encoding="utf-8")
+    key_path.write_text(
+        "-----BEGIN PGP PUBLIC KEY BLOCK-----\nfake\n-----END PGP PUBLIC KEY BLOCK-----\n",
+        encoding="utf-8",
+    )
 
     manifest_src = tmp_path / "manifest.json"
     sig_src = tmp_path / "manifest.json.sig"
     _write_manifest(manifest_src)
-    sig_src.write_text("-----BEGIN PGP SIGNATURE-----\nfake-sig\n-----END PGP SIGNATURE-----\n", encoding="utf-8")
+    sig_src.write_text(
+        "-----BEGIN PGP SIGNATURE-----\nfake-sig\n-----END PGP SIGNATURE-----\n",
+        encoding="utf-8",
+    )
 
     # Prepend our fake-bin dir to PATH. Keep the rest of PATH so bash,
     # python3, mktemp, etc. still resolve.
@@ -231,8 +236,13 @@ def harness(tmp_path: Path):
     }
 
 
-def _install_default_fakes(harness: Dict[str, Any], *, curl_exit: int = 0,
-                            gpg_exit: int = 0, docker_exit: int = 0) -> None:
+def _install_default_fakes(
+    harness: Dict[str, Any],
+    *,
+    curl_exit: int = 0,
+    gpg_exit: int = 0,
+    docker_exit: int = 0,
+) -> None:
     """Install a happy-path set of fake curl/gpg/docker binaries."""
     bin_dir = harness["bin_dir"]
     log_path = harness["log_path"]

--- a/tests/test_ota_verify_pull.py
+++ b/tests/test_ota_verify_pull.py
@@ -1,0 +1,588 @@
+"""Tests for OTA PR-B verify + pull pipeline (issue #152).
+
+PR-B extends ``scripts/platform-update.sh`` to:
+
+* Fetch ``manifest.json`` + ``manifest.json.sig`` from GitHub Releases
+  (channel-aware: ``stable`` -> latest, ``beta`` -> the literal ``beta``
+  pre-release tag).
+* GPG-verify the signature against a pinned public key at
+  ``/etc/hydra/ota-signing.pub``.
+* Validate that the manifest's channel matches the box's configured
+  channel (a stable box must never pull a beta manifest).
+* Skip the pull when the manifest version already matches the running
+  ``HYDRA_VERSION``.
+* ``docker pull ghcr.io/rmeadomavic/hydra@sha256:<digest>`` using the
+  digest from the verified manifest.
+* Write ``/var/lib/hydra/last-update.json`` atomically (tmp+rename) with
+  the schema ``{"ts": <unix>, "status": "ok"|"failed"|"up_to_date",
+  "version": str, "digest": str, "channel": str, "reason": str?}``.
+
+External tools are mocked via PATH-prepended fake binaries that log
+their invocations and obey controlled exit codes, so the tests pass on
+any host that has ``bash`` available (no real gpg/curl/docker required).
+
+PR-C will add A/B promotion + healthcheck-gated rollout; PR-D will add
+the operator dashboard. Neither is in scope here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import textwrap
+import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Repo paths and skip conditions
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PLATFORM_UPDATE_SH = REPO_ROOT / "scripts" / "platform-update.sh"
+
+
+def _bash_available() -> bool:
+    return shutil.which("bash") is not None
+
+
+pytestmark = pytest.mark.skipif(
+    not _bash_available(),
+    reason="bash not on PATH (skipping platform-update.sh subprocess tests)",
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake-binary harness
+# ---------------------------------------------------------------------------
+
+
+def _write_fake_bin(
+    bin_dir: Path,
+    name: str,
+    *,
+    exit_code: int = 0,
+    stdout: str = "",
+    stderr: str = "",
+    log_path: Path | None = None,
+    extra: str = "",
+) -> Path:
+    """Drop a shell-script fake into ``bin_dir`` named ``name``.
+
+    The fake logs its full argv to ``log_path`` (one JSON object per
+    invocation), optionally emits ``stdout``/``stderr``, runs ``extra``
+    shell snippet (for side effects like ``cp`` of a fixture file), then
+    exits with ``exit_code``.
+    """
+    script = bin_dir / name
+    body = "#!/usr/bin/env bash\n"
+    if log_path is not None:
+        # Use python3 to emit a valid JSON line; argv may contain spaces
+        # or shell metacharacters and naive printf is brittle.
+        body += textwrap.dedent(
+            f"""
+            python3 - "$@" <<'PY_EOF' >> "{log_path}"
+            import json, sys
+            print(json.dumps({{"argv": sys.argv[1:], "name": "{name}"}}))
+            PY_EOF
+            """
+        ).strip() + "\n"
+    if stdout:
+        # Use printf so we can embed newlines without quoting hell.
+        body += f"printf '%s' {shlex_quote(stdout)}\n"
+    if stderr:
+        body += f"printf '%s' {shlex_quote(stderr)} 1>&2\n"
+    if extra:
+        body += extra + "\n"
+    body += f"exit {exit_code}\n"
+    script.write_text(body, encoding="utf-8")
+    script.chmod(script.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return script
+
+
+def shlex_quote(s: str) -> str:
+    """Single-quote ``s`` for safe inclusion in a POSIX shell snippet."""
+    # Avoid importing shlex.quote at module top so the import section
+    # stays grouped with the other stdlib imports.
+    import shlex
+    return shlex.quote(s)
+
+
+def _read_log(log_path: Path) -> List[Dict[str, Any]]:
+    if not log_path.exists():
+        return []
+    rows: List[Dict[str, Any]] = []
+    for line in log_path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rows.append(json.loads(line))
+    return rows
+
+
+def _calls_for(rows: List[Dict[str, Any]], name: str) -> List[Dict[str, Any]]:
+    return [r for r in rows if r.get("name") == name]
+
+
+# ---------------------------------------------------------------------------
+# Manifest + signature fixture
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(
+    path: Path,
+    *,
+    channel: str = "stable",
+    version: str = "abc1234",
+    digest: str = "sha256:" + "0" * 64,
+    released_at: str = "2026-05-26T00:00:00Z",
+    schema: int = 1,
+    drop_field: str | None = None,
+) -> None:
+    payload: Dict[str, Any] = {
+        "channel": channel,
+        "version": version,
+        "digest": digest,
+        "released_at": released_at,
+        "manifest_schema_version": schema,
+    }
+    if drop_field is not None:
+        payload.pop(drop_field, None)
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Common harness fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def harness(tmp_path: Path):
+    """Wires a sandbox around ``platform-update.sh``.
+
+    Returns a dict with:
+      * ``env`` — environment to pass to ``subprocess.run``
+      * ``bin_dir`` — PATH-prepended dir for fake binaries
+      * ``log_path`` — JSONL log file fakes append to
+      * ``manifest_src`` — file the fake ``curl`` "downloads"
+      * ``sig_src`` — signature file the fake ``curl`` "downloads"
+      * ``last_update_path`` — where the script writes last-update.json
+      * ``key_path`` — pretend GPG keyring path
+      * ``state_dir`` — parent of last-update.json
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    log_path = tmp_path / "fake-calls.log"
+
+    state_dir = tmp_path / "var-lib-hydra"
+    state_dir.mkdir()
+    last_update_path = state_dir / "last-update.json"
+
+    etc_dir = tmp_path / "etc-hydra"
+    etc_dir.mkdir()
+    channel_file = etc_dir / "channel"
+    channel_file.write_text("stable\n", encoding="utf-8")
+    update_env = etc_dir / "update.env"
+    update_env.write_text(
+        "GHCR_REPO=ghcr.io/rmeadomavic/hydra\n"
+        f"GPG_KEY_PATH={etc_dir / 'ota-signing.pub'}\n",
+        encoding="utf-8",
+    )
+    key_path = etc_dir / "ota-signing.pub"
+    key_path.write_text("-----BEGIN PGP PUBLIC KEY BLOCK-----\nfake\n-----END PGP PUBLIC KEY BLOCK-----\n", encoding="utf-8")
+
+    manifest_src = tmp_path / "manifest.json"
+    sig_src = tmp_path / "manifest.json.sig"
+    _write_manifest(manifest_src)
+    sig_src.write_text("-----BEGIN PGP SIGNATURE-----\nfake-sig\n-----END PGP SIGNATURE-----\n", encoding="utf-8")
+
+    # Prepend our fake-bin dir to PATH. Keep the rest of PATH so bash,
+    # python3, mktemp, etc. still resolve.
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    env["HYDRA_CHANNEL_PATH"] = str(channel_file)
+    env["HYDRA_UPDATE_ENV_PATH"] = str(update_env)
+    env["HYDRA_LAST_UPDATE_PATH"] = str(last_update_path)
+    env["HYDRA_MANIFEST_SRC"] = str(manifest_src)
+    env["HYDRA_SIG_SRC"] = str(sig_src)
+    # Unset HYDRA_VERSION so "already up to date" comparison only fires
+    # in the test that opts into it.
+    env.pop("HYDRA_VERSION", None)
+
+    return {
+        "env": env,
+        "bin_dir": bin_dir,
+        "log_path": log_path,
+        "manifest_src": manifest_src,
+        "sig_src": sig_src,
+        "last_update_path": last_update_path,
+        "key_path": key_path,
+        "state_dir": state_dir,
+        "channel_file": channel_file,
+        "update_env": update_env,
+        "etc_dir": etc_dir,
+        "tmp_path": tmp_path,
+    }
+
+
+def _install_default_fakes(harness: Dict[str, Any], *, curl_exit: int = 0,
+                            gpg_exit: int = 0, docker_exit: int = 0) -> None:
+    """Install a happy-path set of fake curl/gpg/docker binaries."""
+    bin_dir = harness["bin_dir"]
+    log_path = harness["log_path"]
+    manifest_src = harness["manifest_src"]
+    sig_src = harness["sig_src"]
+
+    # curl: when invoked with --output PATH URL, copy the matching
+    # fixture file into PATH. Distinguish manifest vs. sig by URL
+    # substring (".sig").
+    curl_extra = textwrap.dedent(
+        f"""
+        out_path=""
+        last_was_output=0
+        for arg in "$@"; do
+            if [ "$last_was_output" -eq 1 ]; then
+                out_path="$arg"
+                last_was_output=0
+            fi
+            case "$arg" in
+                --output|-o) last_was_output=1 ;;
+            esac
+        done
+        url_arg="${{!#}}"
+        if [ -n "$out_path" ]; then
+            case "$url_arg" in
+                *.sig) cp -- "{sig_src}" "$out_path" ;;
+                *)     cp -- "{manifest_src}" "$out_path" ;;
+            esac
+        fi
+        """
+    ).strip()
+    _write_fake_bin(
+        bin_dir, "curl",
+        exit_code=curl_exit, log_path=log_path, extra=curl_extra,
+    )
+
+    # gpg: log and exit. Pull manifest path off argv to validate later.
+    _write_fake_bin(bin_dir, "gpg", exit_code=gpg_exit, log_path=log_path)
+
+    # docker: log and exit.
+    _write_fake_bin(bin_dir, "docker", exit_code=docker_exit, log_path=log_path)
+
+
+def _run_script(harness: Dict[str, Any]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["bash", str(PLATFORM_UPDATE_SH)],
+        env=harness["env"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_writes_ok_record(harness: Dict[str, Any]) -> None:
+    """Manifest fetched -> verified -> channel matches -> digest pulled."""
+    _install_default_fakes(harness)
+
+    result = _run_script(harness)
+
+    assert result.returncode == 0, (
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+    # last-update.json reflects ok status with all PR-B fields populated.
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert record["status"] == "ok"
+    assert record["version"] == "abc1234"
+    assert record["digest"] == "sha256:" + "0" * 64
+    assert record["channel"] == "stable"
+    assert isinstance(record["ts"], int)
+    assert record["ts"] > 0
+
+    # docker pull was actually invoked with the digest-pinned ref.
+    rows = _read_log(harness["log_path"])
+    docker_calls = _calls_for(rows, "docker")
+    assert len(docker_calls) >= 1
+    pull_args = docker_calls[0]["argv"]
+    assert pull_args[0] == "pull"
+    assert pull_args[1] == f"ghcr.io/rmeadomavic/hydra@sha256:{'0' * 64}"
+
+    # gpg verify was called against the downloaded sig + manifest.
+    gpg_calls = _calls_for(rows, "gpg")
+    assert len(gpg_calls) >= 1
+    assert "--verify" in gpg_calls[0]["argv"]
+
+
+def test_happy_path_stable_uses_latest_release_url(harness: Dict[str, Any]) -> None:
+    """The stable channel hits the ``/latest/download/manifest.json`` URL."""
+    _install_default_fakes(harness)
+    _run_script(harness)
+
+    rows = _read_log(harness["log_path"])
+    curl_calls = _calls_for(rows, "curl")
+    assert curl_calls, "expected curl to be invoked at least once"
+    urls = [c["argv"][-1] for c in curl_calls]
+    assert any("/latest/download/manifest.json" in u for u in urls), urls
+    assert any("/latest/download/manifest.json.sig" in u for u in urls), urls
+
+
+def test_beta_channel_uses_beta_tag_url(harness: Dict[str, Any]) -> None:
+    """Beta channel resolves to the literal ``download/beta`` URL."""
+    harness["channel_file"].write_text("beta\n", encoding="utf-8")
+    # Beta manifest must also self-declare ``channel: beta`` or the
+    # channel-match guard bails.
+    _write_manifest(harness["manifest_src"], channel="beta")
+    _install_default_fakes(harness)
+
+    result = _run_script(harness)
+    assert result.returncode == 0, (
+        f"stdout={result.stdout!r} stderr={result.stderr!r}"
+    )
+
+    rows = _read_log(harness["log_path"])
+    urls = [c["argv"][-1] for c in _calls_for(rows, "curl")]
+    assert any("/download/beta/manifest.json" in u for u in urls), urls
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_channel_mismatch_bails(harness: Dict[str, Any]) -> None:
+    """Manifest claims beta but box is on stable -> fail, no pull."""
+    _write_manifest(harness["manifest_src"], channel="beta")
+    _install_default_fakes(harness)
+
+    result = _run_script(harness)
+
+    assert result.returncode != 0, "expected non-zero exit on channel mismatch"
+
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert record["status"] == "failed"
+    assert record["reason"] == "channel_mismatch"
+
+    # No docker pull on channel mismatch.
+    rows = _read_log(harness["log_path"])
+    assert _calls_for(rows, "docker") == []
+
+
+def test_gpg_verify_failure_bails(harness: Dict[str, Any]) -> None:
+    """``gpg --verify`` non-zero exit -> failed, signature_invalid reason."""
+    _install_default_fakes(harness, gpg_exit=1)
+
+    result = _run_script(harness)
+
+    assert result.returncode != 0
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert record["status"] == "failed"
+    assert record["reason"] == "signature_invalid"
+
+    # No docker pull when signature is bad.
+    rows = _read_log(harness["log_path"])
+    assert _calls_for(rows, "docker") == []
+
+
+def test_missing_signing_key_records_failure_but_exits_zero(
+    harness: Dict[str, Any],
+) -> None:
+    """Missing GPG key: timer must not error, but operator must see the failure."""
+    # Remove the keyring file the script will look for.
+    harness["key_path"].unlink()
+    _install_default_fakes(harness)
+
+    result = _run_script(harness)
+
+    # systemd timer policy: an error here would mark the unit failed
+    # and stop further checks until the operator clears it. Better to
+    # exit 0 with a clearly-marked last-update record.
+    assert result.returncode == 0, (
+        f"expected exit 0 to keep the timer alive; got {result.returncode}, "
+        f"stderr={result.stderr!r}"
+    )
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert record["status"] == "failed"
+    assert record["reason"] == "missing_signing_key"
+
+    # No gpg/docker calls should have happened.
+    rows = _read_log(harness["log_path"])
+    assert _calls_for(rows, "gpg") == []
+    assert _calls_for(rows, "docker") == []
+
+
+def test_manifest_fetch_failure_bails(harness: Dict[str, Any]) -> None:
+    """curl non-zero on manifest fetch -> failed, manifest_fetch_failed."""
+    _install_default_fakes(harness, curl_exit=22)  # 22 == HTTP error
+
+    result = _run_script(harness)
+
+    assert result.returncode != 0
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert record["status"] == "failed"
+    assert record["reason"] == "manifest_fetch_failed"
+
+    rows = _read_log(harness["log_path"])
+    assert _calls_for(rows, "gpg") == []
+    assert _calls_for(rows, "docker") == []
+
+
+def test_already_current_skips_pull(harness: Dict[str, Any]) -> None:
+    """``HYDRA_VERSION`` matches manifest -> exit 0, status=up_to_date."""
+    # Manifest version (abc1234) == running version.
+    harness["env"]["HYDRA_VERSION"] = "abc1234"
+    _install_default_fakes(harness)
+
+    result = _run_script(harness)
+
+    assert result.returncode == 0
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert record["status"] == "up_to_date"
+    assert record["version"] == "abc1234"
+
+    rows = _read_log(harness["log_path"])
+    # No docker pull when we're already on the right version.
+    assert _calls_for(rows, "docker") == []
+
+
+def test_docker_pull_failure_bails(harness: Dict[str, Any]) -> None:
+    """``docker pull`` non-zero -> failed, docker_pull_failed reason."""
+    _install_default_fakes(harness, docker_exit=1)
+
+    result = _run_script(harness)
+
+    assert result.returncode != 0
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert record["status"] == "failed"
+    assert record["reason"] == "docker_pull_failed"
+    # Digest should still be recorded for forensics even though the pull failed.
+    assert record["digest"] == "sha256:" + "0" * 64
+
+
+def test_malformed_manifest_bails(harness: Dict[str, Any]) -> None:
+    """Manifest missing a required field -> failed, manifest_invalid."""
+    _write_manifest(harness["manifest_src"], drop_field="digest")
+    _install_default_fakes(harness)
+
+    result = _run_script(harness)
+
+    assert result.returncode != 0
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert record["status"] == "failed"
+    assert record["reason"] == "manifest_invalid"
+
+    # docker pull never happens without a valid digest.
+    rows = _read_log(harness["log_path"])
+    assert _calls_for(rows, "docker") == []
+
+
+# ---------------------------------------------------------------------------
+# Atomic-write guarantee
+# ---------------------------------------------------------------------------
+
+
+def test_last_update_write_is_atomic(harness: Dict[str, Any]) -> None:
+    """Pre-existing last-update.json survives intact if the new write fails.
+
+    The script writes to a tmp file in the same directory then renames
+    onto last-update.json. If the rename has not happened, the reader
+    sees the old contents — never a half-written file. We simulate this
+    by writing a sentinel old record, forcing the script to crash mid-flow
+    (via docker_exit=1), and asserting that the file content is the NEW
+    failed-record, not a truncated/zero-byte file.
+    """
+    old_record = {
+        "ts": 1000,
+        "status": "ok",
+        "version": "old-version",
+        "digest": "sha256:" + "1" * 64,
+        "channel": "stable",
+    }
+    harness["last_update_path"].write_text(
+        json.dumps(old_record), encoding="utf-8"
+    )
+    _install_default_fakes(harness, docker_exit=1)
+
+    result = _run_script(harness)
+    assert result.returncode != 0
+
+    # File must parse as valid JSON — never a zero-byte / truncated state.
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert isinstance(record, dict)
+    assert record["status"] == "failed"
+    assert record["reason"] == "docker_pull_failed"
+
+    # No leftover tmp file polluting the state dir.
+    leftovers = [
+        p.name for p in harness["state_dir"].iterdir()
+        if p.name != "last-update.json"
+    ]
+    assert leftovers == [], f"unexpected tmp leftovers: {leftovers}"
+
+
+# ---------------------------------------------------------------------------
+# Channel-allowlist guard (R3-1 from PR-A adversarial)
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_channel_in_file_bails(harness: Dict[str, Any]) -> None:
+    """``/etc/hydra/channel`` containing a non-allowlisted value never
+    reaches docker pull (defends against R3-1 from PR-A's adversarial).
+    """
+    harness["channel_file"].write_text("evil-channel\n", encoding="utf-8")
+    _install_default_fakes(harness)
+
+    result = _run_script(harness)
+    assert result.returncode != 0
+    record = json.loads(harness["last_update_path"].read_text(encoding="utf-8"))
+    assert record["status"] == "failed"
+    # Either invalid_channel or channel_mismatch is acceptable — the
+    # invariant is "no pull happens and the operator sees the reason."
+    assert record["reason"] in {"invalid_channel", "channel_mismatch"}
+
+    rows = _read_log(harness["log_path"])
+    assert _calls_for(rows, "docker") == []
+
+
+# ---------------------------------------------------------------------------
+# Schema sanity for downstream readers
+# ---------------------------------------------------------------------------
+
+
+def test_last_update_schema_compatible_with_version_surface(
+    harness: Dict[str, Any],
+) -> None:
+    """Recorded payload still parses via ``_read_last_update``.
+
+    PR-A's ``version_surface._read_last_update`` is the reader on
+    ``/api/health``. PR-B is the first writer. The reader is permissive
+    (any JSON object), so this test is a smoke check that nothing in the
+    PR-B write path introduces a non-JSON-serialisable value.
+    """
+    from hydra_detect.observability.version_surface import _read_last_update
+
+    _install_default_fakes(harness)
+    _run_script(harness)
+
+    os.environ["HYDRA_LAST_UPDATE_PATH"] = str(harness["last_update_path"])
+    try:
+        record = _read_last_update()
+    finally:
+        os.environ.pop("HYDRA_LAST_UPDATE_PATH", None)
+
+    assert record is not None
+    assert record["status"] == "ok"
+    assert record["version"] == "abc1234"
+    # PR-B fields are new but must round-trip through the reader.
+    assert record["digest"].startswith("sha256:")
+    assert record["channel"] == "stable"


### PR DESCRIPTION
## Summary

Second of four PRs implementing issue #152 (OTA updates).

PR-A landed the skeleton timer + channel + health surface (#263). This PR makes the timer-driven `platform-update.sh` actually do the verify + pull half of the OTA pipeline. Restart-with-new-image is PR-C.

## What this PR does

- **Channel-routed manifest fetch** — stable hits `${BASE}/latest/download/manifest.json` (GitHub's auto-redirect to latest), beta hits `${BASE}/download/beta/manifest.json` (literal tag).
- **GPG-verifies manifest.json against manifest.json.sig** using a pinned public key at `${GPG_KEY_PATH}` (default `/etc/hydra/ota-signing.pub`). Missing key = `signature_key_missing` + exit 0 (timer shouldn't spin on misconfigured key).
- **Schema-validates the manifest** — required fields, channel match, digest constrained to `^sha256:[0-9a-f]{64}$` (no metacharacter smuggling).
- **Short-circuits if already current** — manifest version matches `${HYDRA_VERSION}` (surfaced by PR-A's version_surface) -> `status=up_to_date` + exit 0, no pull.
- **`docker pull "${GHCR_REPO}@${digest}"`** — pull by digest, not tag. A compromised registry can't substitute a same-tag image. Tag-flip is PR-C.
- **Atomic last_update.json write** — tmpfile + rename, so crash mid-write doesn't leave a partial JSON for `version_surface.read_last_update()` to choke on.

## What this PR does NOT do

Gated to PR-C:
- Restart the running container against the pulled image.
- Health-gate the new container before flipping traffic.
- A/B slot logic.

## Test plan

- [x] 13 new tests in `tests/test_ota_verify_pull.py`:
  - Happy path (stable + beta channels separately)
  - Channel mismatch bail
  - GPG signature failure bail
  - Missing signing key -> exit 0 with `signature_key_missing`
  - Manifest fetch failure bail
  - Already-current short-circuit (no pull, no docker invocation)
  - Docker pull failure bail
  - Malformed manifest bail
  - Atomic last_update write (interrupt simulation)
  - Invalid channel in channel-file bail
  - last_update schema parsed by version_surface from PR-A
- [x] Existing `tests/test_ota_skeleton.py` (from PR-A) still passes after platform-update.sh expansion
- [ ] CI green (pending push)
- [ ] adversarial-required gate (doc added inline)

## Notes

- `platform-update.sh` now ~345 lines vs. ~24 in PR-A. Bash is unfun at this size — PR-C will likely refactor into a Python entrypoint with the systemd unit calling `python -m hydra.ota` instead. Out of scope here.
- `MANIFEST_URL_BASE` defaults to `https://github.com/rmeadomavic/Hydra/releases` and is read from the same env config the systemd unit picks up — Kyle's air-gapped deployment story is "swap MANIFEST_URL_BASE + GPG_KEY_PATH" rather than rebuilding the image.

Follows: #263