### PR TITLE
fix(profiles): reconcile ugv Pixhawk profile to SCX6 + close battery-failsafe gap

### DIFF
--- a/docs/pixhawk-prereqs-ugv.md
+++ b/docs/pixhawk-prereqs-ugv.md
@@ -1,9 +1,20 @@
 # Pixhawk Prerequisites: UGV (ArduRover)
 
-Platform: Traxxas Stampede running ArduRover on Pixhawk 6C.
+Platform: Axial SCX6 Trail Honcho (1/6 scale) running ArduRover on Pixhawk 6C.
 
-Run `python scripts/pixhawk_preflight.py --profile ugv --conn /dev/ttyACM0` to validate
-these params live against your flight controller.
+Run the preflight from the companion (Jetson) against the flight controller over the
+companion UART:
+
+```
+python scripts/pixhawk_preflight.py --profile ugv --conn /dev/ttyTHS1 --baud 921600
+```
+
+(`/dev/ttyTHS1` at 921600 is the SCX6 instructor build's Jetson↔FC link on TELEM3/SERIAL5.
+On reference wiring with the companion on TELEM2, use that port instead.)
+
+> **ArduRover action codes** (verified against AP source): `0` Warn/Report only · `1` RTL ·
+> `2` Hold · `3` SmartRTL · `4` SmartRTL-or-Hold · `5` Terminate. **Value `2` is Hold, not
+> RTL** — earlier revisions of this doc had this backwards.
 
 ---
 
@@ -13,39 +24,54 @@ These must be set correctly before running Hydra. Wrong values cause silent fail
 
 | Parameter | Expected | Why |
 |---|---|---|
-| `FENCE_ENABLE` | `1` | Geofence required for any autonomous behavior. Without it the rover can drive beyond the operating area with no automatic recovery. |
-| `SERIAL2_PROTOCOL` | `2` | Companion computer port (TELEM2) must be MAVLink2. MAVLink1 works but loses long-parameter and signed-message support. |
-| `SERIAL2_BAUD` | `921` | 921600 baud required for Hydra's heartbeat + param + command traffic. 57/115 are too slow under load. |
+| `FENCE_ENABLE` | `1` | Geofence required for any autonomous behavior. Without it the rover can drive beyond the operating area with no recovery. |
+| `FENCE_ACTION` | `2` (Hold) | Stop in place on breach. Preferred over RTL for shoothouse/tunnel lanes so the rover stops at the boundary instead of driving home across the lane. |
+| `FENCE_RADIUS` | `300` | Circular fence radius (m). Covers the SORCC operating area; tighten per site. |
+| `FENCE_MARGIN` | `2` | 2 m breach margin before the action escalates. Avoids a hard stop exactly at the boundary. |
+| `BATT_MONITOR` | `4` | Analog voltage + current (Holybro PM02 on POWER1). Without it the battery failsafe has nothing to measure and never fires. |
+| `BATT_VOLT_PIN` | `8` | Pixhawk 6C POWER1 voltage pin (PM02). |
+| `BATT_CURR_PIN` | `4` | Pixhawk 6C POWER1 current pin (PM02). |
+| `BATT_VOLT_MULT` | `18.18` | PM02 voltage-divider multiplier. |
+| `BATT_AMP_PERVLT` | `36.36` | PM02 current scaling (A/V). |
+| `BATT_LOW_VOLT` | `20.4` | Low-battery trigger, 3.4 V/cell on a 6S Molicel P42A Li-ion pack. Li-ion floor is 2.5 V/cell — do **not** reuse LiPo 3.5/3.3 numbers. |
+| `BATT_CRT_VOLT` | `19.2` | Critical trigger, 3.2 V/cell. If crawl-stall sag nuisance-trips, lower to 18.6. |
+| `BATT_FS_LOW_ACT` | `2` (Hold) | Hold on low battery. Inert without `BATT_LOW_VOLT` set. |
+| `BATT_FS_CRT_ACT` | `2` (Hold) | Hold on critical battery. |
+| `BATT_CAPACITY` | `12600` | 6S3P P42A pack, 3 x 4200 mAh. |
+| `SERIAL2_PROTOCOL` | `2` | Companion link must be MAVLink2. See the SERIAL warning below. |
+| `SERIAL2_BAUD` | `921` | 921600 baud on the companion link. **See warning below.** |
+
+> ⚠ **SERIAL warning — reference wiring only.** `SERIAL2_*` assumes the companion is on
+> TELEM2/SERIAL2 (Hydra default). The **SCX6 puts the Jetson on TELEM3/SERIAL5** at 921600
+> because all five UARTs are allocated (CRSF, SiK, GPS, OSD, Jetson) — and on that build
+> **SERIAL2 is the 433 MHz SiK radio at 57600**. Applying `SERIAL2_BAUD 921` there breaks
+> the SiK link. Set MAVLink2 + 921600 on whichever UART your companion actually uses.
 
 ---
 
 ## Recommended Parameters
 
-Not required to start Hydra, but strongly recommended for field operations. A mismatch
-generates a `[WARN]` in the preflight report and does not block the run.
+Not required to start Hydra, but strongly recommended. A mismatch generates a `[WARN]` in the preflight report and does not block the run.
 
 | Parameter | Recommended | Why |
 |---|---|---|
-| `BATT_FS_LOW_ACT` | `2` | RTL on low battery. Without this, the rover continues until the battery dies and loses comms. Value 2 = RTL. |
-| `FENCE_ACTION` | `1` | RTL when fence is breached. Value 0 (report only) means the rover ignores the fence boundary. |
-| `FENCE_MARGIN` | `2` | 2-meter breach margin before escalation to LAND. Prevents hard stops exactly at the fence boundary. |
-| `FS_GCS_ENABLE` | `2` | GCS heartbeat failsafe enabled. If the Hydra companion loses MAVLink, the rover should RTL rather than freeze in place. |
+| `FS_GCS_ENABLE` | `2` | GCS-heartbeat failsafe. If the Hydra companion loses MAVLink, the rover recovers rather than freezing in place. |
+| `FS_THR_ENABLE` | `1` | RC-loss failsafe. RTL or hold on RC loss. Do not disable. |
 
 ---
 
 ## Stream Rates
 
-Minimum rates required on the companion port (SERIAL2). These affect how quickly Hydra
-receives GPS, telemetry, and attitude data from the autopilot.
+Minimum rates on the companion port. These affect how quickly Hydra receives GPS, telemetry, and attitude data from the autopilot.
 
-Set via `SRx_*` parameters where `x` maps to your connection port. If the companion is
-connected to SERIAL2 (TELEM2), use `SR2_*`. If using a MAVProxy router that maps to SR1,
-use `SR1_*`. Match these to whatever SRx index corresponds to the companion port in your setup.
+Set via `SRx_*` where `x` maps to your connection port. `SR1_*` maps to TELEM2 when the
+companion is on SERIAL2 with SRx overrides. If your companion is on a different UART (e.g.
+SERIAL5 on the SCX6), use the matching `SRx_*` index.
 
 | Parameter | Minimum Hz | Why |
 |---|---|---|
-| `SR1_POSITION` | `5` | GPS position data for TAK markers and geo-tracking. Below 5 Hz, the map track lags noticeably. |
-| `SR1_EXTRA1` | `4` | Attitude/heading. Used for OSD orientation display. |
+| `SR1_POSITION` | `5` | GPS position for TAK markers and geo-tracking. Below 5 Hz the map track lags. |
+| `SR1_EXTRA1` | `4` | Attitude/heading. Used for OSD orientation. |
 | `SR1_EXTRA2` | `2` | Battery voltage and current. Used for battery warnings. |
 | `SR1_RAW_SENS` | `2` | IMU data. Required if RF hunt mode is active. |
 
@@ -53,10 +79,13 @@ use `SR1_*`. Match these to whatever SRx index corresponds to the companion port
 
 ## Failsafe Expectations
 
-- **RC Loss:** Set `FS_THR_ENABLE = 1`. RTL or hold on RC loss. Do not disable.
-- **GCS Loss:** `FS_GCS_ENABLE = 2` (see recommended above). RTL after 5 seconds of missed heartbeats.
-- **Battery:** `BATT_FS_LOW_ACT = 2` triggers RTL at low voltage. `BATT_FS_CRT_ACT = 1` (Hold) or `2` (RTL) for critical.
-- **Geofence:** `FENCE_ACTION = 1` (RTL) on breach. Confirm `FENCE_RADIUS` and `FENCE_ALT_MAX` match your operating area.
+- **RC Loss:** `FS_THR_ENABLE = 1`. RTL or hold on RC loss. Do not disable.
+- **GCS Loss:** `FS_GCS_ENABLE = 2`. Recover after missed heartbeats rather than freezing.
+- **Battery:** `BATT_MONITOR = 4` plus `BATT_LOW_VOLT`/`BATT_CRT_VOLT` thresholds, with
+  `BATT_FS_LOW_ACT = 2` and `BATT_FS_CRT_ACT = 2` — both **Hold** (value `2` is Hold on
+  ArduRover; `1` is RTL). An action without a voltage threshold never fires.
+- **Geofence:** `FENCE_ACTION = 2` (Hold) on breach. Confirm `FENCE_RADIUS` matches your
+  operating area.
 
 ---
 
@@ -65,8 +94,8 @@ use `SR1_*`. Match these to whatever SRx index corresponds to the companion port
 Engagement actions (drop, arm) are operator-configured at mission time. Hydra reads
 these from `config.ini [drop]`. The preflight does not require or validate specific servo assignments.
 
-The preflight does not check servo functions because they are valid only during armed
-operation and vary by loadout. Document your team's setup here for reference:
+> Note: on the SCX6, `CH5` / `SERVO5` drives the **2-speed transmission shift**, not a
+> diff lock. Do not repurpose it for engagement.
 
 ```
 # Example SORCC UGV engagement setup (not validated by preflight)
@@ -77,10 +106,3 @@ RELAY_PIN       = 13   # AUX1 on Pixhawk 6C
 Set `[drop] relay_pin` in `config.ini` to match.
 
 ---
-
-## Notes
-
-- `SERIAL2_BAUD = 921` encodes 921600 baud in ArduPilot's compressed format (value `921` = 921600).
-- If using MAVProxy as a router, set baud on the MAVProxy master port, not on the ArduPilot serial port directly.
-- Stream rates set in Mission Planner apply immediately but do not persist across reboots unless saved. Run **Write Params** after adjusting.
-- The UGV profile does not check `FLTMODE_CH` because ArduRover does not use flight mode channels the same way ArduCopter does. Mode switching is done via `MODE_CH` (default CH 8 for Rover); verify GUIDED is reachable on your RC transmitter.

--- a/hydra_detect/profiles/ugv/param_pack.param
+++ b/hydra_detect/profiles/ugv/param_pack.param
@@ -1,8 +1,26 @@
 # Hydra ugv Pixhawk required params
-# Generated from pixhawk_prereqs.yaml — keep in sync
+# Generated from pixhawk_prereqs.yaml — keep in sync.
+# Reconciled to the Axial SCX6 instructor build 2026-06-01 (live 934-param pull).
 # Standard ArduPilot .param format: PARAM_NAME,value per line.
 # Hard-requirements only; recommended params are intentionally excluded.
+#
+# WARNING: SERIAL2 entries are REFERENCE wiring (companion on TELEM2). The SCX6
+# puts the Jetson on SERIAL5 — SERIAL2 there is the SiK radio at 57600. Applying
+# SERIAL2_BAUD 921 on that build breaks the SiK link. See pixhawk_prereqs.yaml.
 FENCE_ENABLE,1
+FENCE_ACTION,2
+FENCE_RADIUS,300
+FENCE_MARGIN,2
+BATT_MONITOR,4
+BATT_VOLT_PIN,8
+BATT_CURR_PIN,4
+BATT_VOLT_MULT,18.18
+BATT_AMP_PERVLT,36.36
+BATT_LOW_VOLT,20.4
+BATT_CRT_VOLT,19.2
+BATT_FS_LOW_ACT,2
+BATT_FS_CRT_ACT,2
+BATT_CAPACITY,12600
 SERIAL2_PROTOCOL,2
 SERIAL2_BAUD,921
 SR1_POSITION,5

--- a/hydra_detect/profiles/ugv/pixhawk_prereqs.yaml
+++ b/hydra_detect/profiles/ugv/pixhawk_prereqs.yaml
@@ -1,9 +1,17 @@
 profile: ugv
 firmware: ArduRover
 
-# ArduRover UGV (Traxxas Stampede) Pixhawk prerequisites for Hydra Detect.
-# Required = Hydra will not function correctly without these.
-# Recommended = strong operational best practice, but Hydra will still run.
+# ArduRover UGV (Axial SCX6 Trail Honcho, 1/6 scale) Pixhawk 6C prerequisites for
+# Hydra Detect. Reconciled to the SCX6 instructor build on 2026-06-01 from a live
+# 934-param pull off the flight controller (replaces the prior Traxxas Stampede
+# profile).
+#
+# Required    = Hydra autonomy is unsafe or non-functional without these.
+# Recommended = strong operational best practice; Hydra still runs.
+#
+# ArduRover failsafe/fence action codes (verified against AP source 2026-06-01):
+#   0 Warn/Report only   1 RTL   2 Hold   3 SmartRTL   4 SmartRTL-or-Hold   5 Terminate
+# NOTE: value 2 is HOLD, not RTL. Earlier revisions of this file mislabeled it.
 
 required:
   - name: FENCE_ENABLE
@@ -12,21 +20,98 @@ required:
       Geofence required for any autonomous behavior. Without it the rover can
       drive beyond the operating area with no automatic recovery.
 
+  - name: FENCE_ACTION
+    expected: 2
+    reason: >
+      Hold (stop in place) on fence breach. Value 2 is Hold on ArduRover.
+      Preferred over RTL for the shoothouse/tunnel lanes so the rover stops at
+      the boundary instead of autonomously driving home across the lane.
+
+  - name: FENCE_RADIUS
+    expected: 300
+    reason: >
+      Circular fence radius in metres. 300 m covers the SORCC operating area;
+      tighten per site. An enabled fence with no radius leaves a default that
+      may not match the lane.
+
+  - name: FENCE_MARGIN
+    expected: 2
+    reason: >
+      2 m breach margin before the fence action escalates. Prevents a hard stop
+      exactly at the boundary.
+
+  - name: BATT_MONITOR
+    expected: 4
+    reason: >
+      Analog voltage + current monitor (Holybro PM02 on POWER1). Without a
+      monitor the battery failsafe below has nothing to measure and never fires.
+
+  - name: BATT_VOLT_PIN
+    expected: 8
+    reason: Pixhawk 6C POWER1 analog voltage pin for the PM02.
+
+  - name: BATT_CURR_PIN
+    expected: 4
+    reason: Pixhawk 6C POWER1 analog current pin for the PM02.
+
+  - name: BATT_VOLT_MULT
+    expected: 18.18
+    reason: PM02 voltage-divider multiplier.
+
+  - name: BATT_AMP_PERVLT
+    expected: 36.36
+    reason: PM02 current scaling (amps per volt).
+
+  - name: BATT_LOW_VOLT
+    expected: 20.4
+    reason: >
+      Low-battery threshold, 3.4 V/cell on a 6S Molicel P42A Li-ion pack. This is
+      the trigger BATT_FS_LOW_ACT needs to fire. Li-ion floor is 2.5 V/cell — do
+      NOT reuse LiPo 3.5/3.3 numbers.
+
+  - name: BATT_CRT_VOLT
+    expected: 19.2
+    reason: >
+      Critical threshold, 3.2 V/cell (6S P42A). If crawl-stall current sag
+      nuisance-trips this, lower to 18.6 (3.1 V/cell).
+
+  - name: BATT_FS_LOW_ACT
+    expected: 2
+    reason: >
+      Hold on low battery (value 2 is Hold on ArduRover). Inert without a paired
+      BATT_LOW_VOLT threshold.
+
+  - name: BATT_FS_CRT_ACT
+    expected: 2
+    reason: Hold on critical battery (value 2 is Hold on ArduRover).
+
+  - name: BATT_CAPACITY
+    expected: 12600
+    reason: 6S3P Molicel P42A pack — 3 x 4200 mAh. Enables mAh fuel gauging.
+
   - name: SERIAL2_PROTOCOL
     expected: 2
     reason: >
-      Companion computer port (TELEM2) must be set to MAVLink2. MAVLink1
-      (value 1) works but loses long-parameter and signed-message support.
+      Companion-computer link must be MAVLink2. MAVLink1 (1) works but loses
+      long-parameter and signed-message support. See the SERIAL warning on
+      SERIAL2_BAUD — on the SCX6 the companion is on SERIAL5, not SERIAL2.
 
   - name: SERIAL2_BAUD
     expected: 921
+    # WARNING — REFERENCE WIRING ONLY. This assumes the companion is on
+    # TELEM2/SERIAL2 (the Hydra default). The SCX6 instructor build puts the
+    # Jetson on TELEM3/SERIAL5 at 921600 because all five UARTs are allocated
+    # (CRSF, SiK, GPS, OSD, Jetson). On that build SERIAL2 is the 433 MHz SiK
+    # radio at 57600 baud — applying 921600 here BREAKS the SiK link. Set
+    # MAVLink2 + 921600 on whichever UART your companion actually uses.
+    # TODO(#158 PR-B): the wizard should set protocol/baud on the operator-
+    # detected companion UART instead of hardcoding SERIAL2.
     reason: >
-      921600 baud required for Hydra's heartbeat + param + command traffic.
-      Lower rates cause message drops under load (57 and 115 are too slow).
+      921600 baud on the companion link. Lower rates drop messages under load.
 
-# Stream rates — values are minimum Hz on SERIAL2 (companion computer port).
-# SR1 maps to TELEM2 when the companion is on SERIAL2 with SRx overrides.
-# If your setup uses SR2 instead (SERIAL2 with no SRx remap), adjust accordingly.
+# Stream rates — minimum Hz on the companion port. SR1 maps to TELEM2 when the
+# companion is on SERIAL2 with SRx overrides. If your setup uses a different SRx
+# index for the companion UART (e.g. SERIAL5 on the SCX6), adjust accordingly.
 stream_rates:
   SR1_POSITION: 5
   SR1_EXTRA1: 4
@@ -34,35 +119,20 @@ stream_rates:
   SR1_RAW_SENS: 2
 
 recommended:
-  - name: BATT_FS_LOW_ACT
-    expected: 2
-    reason: >
-      RTL on low battery. Without this, the rover will continue running until
-      the battery dies and loses comms with no automatic recovery.
-
-  - name: FENCE_ACTION
-    expected: 1
-    reason: >
-      RTL when fence breached. Value 0 (report only) means the rover ignores
-      the fence boundary — defeat the purpose of having a fence.
-
-  - name: FENCE_MARGIN
-    expected: 2
-    reason: >
-      2-meter breach margin before escalation to LAND. Prevents hard stops at
-      the exact fence boundary; gives the mission controller time to respond.
-
   - name: FS_GCS_ENABLE
     expected: 2
     reason: >
-      Enable GCS heartbeat failsafe. If the Hydra companion loses MAVLink
-      the rover should RTL rather than freeze in place.
+      Enable GCS-heartbeat failsafe. If the Hydra companion loses MAVLink the
+      rover should recover rather than freeze in place.
 
-# Servo/relay function assignments for engagement modes.
-# These are operator-set at mission time; Hydra reads them but does not
-# require specific values for DROP/ARM/STRIKE actions.
-# Document your setup in config.ini [drop] section.
-#
-# Typical SORCC UGV setup (not validated by preflight):
-#   SERVO9_FUNCTION = 0  (GPIO — controlled by Hydra relay)
-#   RELAY_PIN = 13       (matches Pixhawk 6C AUX1)
+  - name: FS_THR_ENABLE
+    expected: 1
+    reason: >
+      RC-loss failsafe. RTL or hold on RC loss. Do not disable.
+
+# Servo/relay assignments for engagement modes are operator-set at mission time;
+# Hydra reads them but preflight does not validate them. Document your setup in
+# config.ini [drop].
+# NOTE: on the SCX6, CH5 / SERVO5 drives the 2-speed transmission shift, not a
+# diff lock — do not repurpose it.
+#   Typical SORCC UGV engagement: SERVO9_FUNCTION 0 (GPIO relay), RELAY_PIN 13 (AUX1).


### PR DESCRIPTION
## What

Reconciles the `ugv` Pixhawk profile to the **Axial SCX6** instructor build (it was still written for the retired Traxxas Stampede) and closes a real battery-failsafe hole, using a live 934-param pull off the SCX6 flight controller (2026-06-01).

## Why

The profile *looked* like it had battery protection but didn't:

- `BATT_FS_LOW_ACT,2` was present (in `recommended`) with **no `BATT_LOW_VOLT` threshold anywhere** — an action with nothing to trigger it never fires.
- No `BATT_CRT_VOLT` / `BATT_FS_CRT_ACT` / `BATT_MONITOR` at all.
- `FENCE_ENABLE,1` was required but `FENCE_ACTION` / `FENCE_RADIUS` weren't in the pack — a fence enabled with undefined behavior.
- **Action codes were mislabeled.** yaml + docs called value `2` "RTL"; on ArduRover `2` is **Hold** (`1` is RTL), verified against AP source. The doc even had `BATT_FS_CRT_ACT` 1/2 reversed — an operator following it sets the wrong failsafe.

## Changes

Promotes the battery + fence safety params to `required` with values validated live on the SCX6:

- **Battery:** `BATT_MONITOR 4` (PM02) + volt/curr pins + mults, `BATT_LOW_VOLT 20.4` / `BATT_CRT_VOLT 19.2` (6S Molicel P42A, 3.4 / 3.2 V per cell), `BATT_FS_LOW_ACT` and `BATT_FS_CRT_ACT 2` (Hold), `BATT_CAPACITY 12600`.
- **Fence:** `FENCE_RADIUS 300`, `FENCE_ACTION 2` (Hold), `FENCE_MARGIN 2`.
- **Labels:** fixed `2 = Hold` (not RTL) across yaml + docs; un-reversed the docs crit-action labels.
- **Serial:** documented the SCX6 deviation — the companion is on **SERIAL5**, not SERIAL2 (SiK owns SERIAL2 at 57600; applying 921600 there breaks the SiK link). Added `TODO(#158 PR-B)` to set protocol/baud on the operator-detected companion UART instead of hardcoding SERIAL2.

Files: `hydra_detect/profiles/ugv/pixhawk_prereqs.yaml`, `hydra_detect/profiles/ugv/param_pack.param`, `docs/pixhawk-prereqs-ugv.md`.

## Test

- `load_param_pack('ugv')` parses, non-empty, still differs from `usv` (existing test invariant held).
- Values cross-checked against the live 934-param FC pull and the ArduRover action-code enum (AP source).

Relates to #158 — improves the param pack the Pixhawk wizard applies. Does **not** close it (PR-B UI + preflight gate still pending).
