### PR TITLE
fix(safety): hardware-arm strike gate rejects stale RC — dead-man fails closed (#285)

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -114,6 +114,7 @@ arm_channel = 0
 arm_pwm_armed = 1900
 arm_pwm_safe = 1100
 hardware_arm_channel = 0
+rc_max_stale_sec = 2.0
 dogleg_distance_m = 200
 dogleg_bearing = perpendicular
 dogleg_altitude_m = 50

--- a/config.ini.factory
+++ b/config.ini.factory
@@ -88,6 +88,7 @@ allowed_classes =
 strike_cooldown_sec = 30.0
 allowed_vehicle_modes = AUTO
 gps_max_stale_sec = 2.0                 ; abort if GPS data is older than this
+rc_max_stale_sec = 2.0                  ; hw-arm gate: RC older than this reads unknown (fail closed)
 require_operator_lock = true             ; require explicit target lock before auto-strike
 
 [rf_homing]

--- a/docs/adversarial/286.md
+++ b/docs/adversarial/286.md
@@ -1,0 +1,96 @@
+# Adversarial review — PR #286 (hw-arm strike gate rejects stale RC, #285)
+
+Scope: `mavlink_io.py` RC cache stamp + `approach.py` gate guard + config knob.
+Reviewed against main @ 17d4e8f with the fix applied.
+
+## Round 1 — pattern-match the changes
+
+**R1-a — CLOCK_MONOTONIC does not advance during suspend.** A Jetson resuming
+from suspend could briefly score pre-suspend RC data as fresh (age excludes the
+suspended interval). Identical semantics to the existing `gps_max_stale_sec`
+guard, which uses the same clock — consistency was the design constraint, and
+field units do not suspend mid-strike. ACCEPT (consistent with existing
+pattern; a codebase-wide clock-policy change is out of scope).
+
+**R1-b — Two-getter race between stamp and values.** `get_hardware_arm_status()`
+reads the stamp, then the values, without a cross-call lock. If an RC_CHANNELS
+message lands between the reads, the age is computed from the OLD stamp against
+NEW values — pessimistic (reads staler than truth), which can only fail closed.
+The read order is deliberate and commented at the call site. ACCEPT.
+
+**R1-c — Strict inequality at the threshold boundary.** `age > rc_max_stale_sec`
+treats exactly-threshold as fresh, matching `gps_age > self._gps_max_stale_sec`
+in `autonomous.py`. ACCEPT (consistency).
+
+**R1-d — Enum typo in `connect()` would kill ALL MAVLink connects.** The new
+`MAV_DATA_STREAM_RC_CHANNELS` reference sits inside `connect()`'s try-block; an
+AttributeError would be swallowed into "connection failed" and disable MAVLink
+entirely. Verified against the installed pymavlink:
+`common.MAV_DATA_STREAM_RC_CHANNELS == 3` (maps to ArduPilot `SRx_RC_CHAN`,
+which streams RC_CHANNELS). ACCEPT (verified, not assumed).
+
+**R1-e — `rc_max_stale_sec` floor of 0.5 s equals the 2 Hz stream period.** An
+operator setting the minimum makes the gate flap on ordinary jitter → spurious
+strike aborts. Fail-closed direction: annoying, loud, and safe. The floor
+mirrors `gps_max_stale_sec`'s schema bounds. ACCEPT (documented foot-gun,
+wrong-direction-proof).
+
+## Round 2 — counter-critique, downgrade or confirm
+
+**R2-a — Asymmetry with the GPS guard's sim-mode skip is deliberate.** The GPS
+gate SKIPS its staleness check when `last_update == 0.0` (operator-provided /
+sim GPS, bench configs). This fix does the opposite: `0.0` → None → abort.
+Interrogated: is there a sim-RC path that needs the skip? No — nothing writes
+`_rc_channels` except `_handle_rc_channels()` (no sim injection exists for RC),
+and a dead-man switch with no data is exactly the case that must read unsafe.
+The asymmetry is the point of the fix. CONFIRM CORRECT.
+
+**R2-b — FCs that ignore REQUEST_DATA_STREAM.** If a flight stack never sends
+RC_CHANNELS despite the new request, the gate reads unknown and aborts at the
+first strike gate check. Before this PR the same unit ALSO failed closed (empty
+list → None). The only behavior delta introduced by this PR is for units that
+received RC and then stopped — the defect class itself. No new regression
+surface. CONFIRM.
+
+**R2-c — Deployed configs without the new key.** Absent `rc_max_stale_sec`
+resolves via `getfloat(..., fallback=2.0)`, matching the schema default
+(`check_config_consistency.py` passes: 247 fields / 28 sections). No migration
+needed — same lifecycle as `hardware_arm_channel`, which also ships absent from
+some deployed configs. CONFIRM.
+
+**R2-d — Mock fallout in unrelated test files.** `test_approach.py`,
+`test_concurrency_stress.py`, `test_guidance.py` never set `hw_arm_channel`,
+so the gate short-circuits before touching the new mock attribute. Full fast
+suite: 2579 passed, failure set byte-identical to the pre-change baseline
+(16 Windows-only OTA/bash failures). CONFIRM.
+
+## Round 3 — orthogonal sweep ("what else reads a value nobody refreshes?")
+
+**R3-a — `get_vehicle_mode()` has no staleness guard.** Same defect class: the
+autonomous `vehicle_mode` gate could read a stale AUTO after HEARTBEAT loss. On
+real field units `gps_fresh` rejects first once a fix has ever arrived, so the
+independent exposure is limited to sim-GPS / operator-position configs.
+FOLLOW-UP — tracked in the 2026-07-10 audit notes as a defense-in-depth gap;
+deliberately not expanded into this PR (different message path, different gate,
+needs its own failure-mode analysis).
+
+**R3-b — `_telemetry["armed"]` (HEARTBEAT-derived) is unstamped.** Consumers
+are telemetry/stats surfaces, not strike gating. ACCEPT (out of scope).
+
+**R3-c — Dashboard truthfulness inherited for free.** `get_status()`'s
+`hardware_arm_status` goes through the same fixed path, so an operator watching
+the panel during RC loss now sees unknown instead of a latched "armed". ACCEPT
+(improvement, no action).
+
+**R3-d — Gate-vs-rate-limit ordering.** The hw-arm check in `_update_strike`
+runs BEFORE the waypoint-interval claim, so a stale dead-man aborts on the next
+`update()` call, not the next waypoint slot. Confirmed by
+`test_strike_aborts_when_rc_stream_stops` (second update aborts immediately).
+ACCEPT.
+
+## Triage
+
+- Blockers: none.
+- Gates: none (R1-d verified pre-merge).
+- Follow-up: R3-a (`get_vehicle_mode` staleness — audit-tracked, unfiled).
+- Accepted: R1-a, R1-b, R1-c, R1-e, R2-a–R2-d, R3-b, R3-c, R3-d.

--- a/docs/autonomous-operations.md
+++ b/docs/autonomous-operations.md
@@ -91,7 +91,7 @@ Strike mode uses a two-stage arm to prevent accidental engagement:
 
 **Stage 1, Software arm**: a servo channel (`arm_channel`) is set to `arm_pwm_armed` when the approach begins. Set to `arm_pwm_safe` on abort or completion.
 
-**Stage 2, Hardware arm**: an RC channel (`hardware_arm_channel`) is read. The physical switch on the RC transmitter must be in the armed position. Hydra reads, but does not write, this channel.
+**Stage 2, Hardware arm**: an RC channel (`hardware_arm_channel`) is read. The physical switch on the RC transmitter must be in the armed position. Hydra reads, but does not write, this channel. This stage is a dead-man switch: if RC data stops arriving (RC link loss, transmitter off, telemetry stall), the reading goes stale and the gate reads unknown after `rc_max_stale_sec` (default 2.0 seconds) — an in-progress strike aborts rather than continuing on the last frame received.
 
 Both stages must be armed for the strike to proceed. If `arm_channel = 0` and `hardware_arm_channel = 0`, the arm circuit is disabled (no physical safety).
 
@@ -141,4 +141,5 @@ arm_channel = 7
 arm_pwm_armed = 1900
 arm_pwm_safe = 1100
 hardware_arm_channel = 8
+rc_max_stale_sec = 2.0
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -295,6 +295,7 @@ Autonomous strike controller. Off by default. See [Autonomous Operations](autono
 | `arm_pwm_armed` | int | `1900` | -- | PWM for software arm engaged. |
 | `arm_pwm_safe` | int | `1100` | -- | PWM for software arm safe. |
 | `hardware_arm_channel` | int | `0` | -- | RC channel for hardware arm switch. 0 disables. |
+| `rc_max_stale_sec` | float | `2.0` | 0.5-30.0 | Hardware arm reads unknown (fail closed) if RC data is older than this many seconds. |
 | `dogleg_distance_m` | float | `200` | -- | Offset distance for dogleg RTL (drones). |
 | `dogleg_bearing` | string | `perpendicular` | -- | Offset bearing. `perpendicular` or compass degrees. |
 | `dogleg_altitude_m` | float | `50` | -- | Climb altitude before dogleg waypoint. |

--- a/hydra_detect/approach.py
+++ b/hydra_detect/approach.py
@@ -45,6 +45,9 @@ class ApproachConfig:
     arm_pwm_armed: int = 1900
     arm_pwm_safe: int = 1100
     hw_arm_channel: int | None = None
+    # RC data older than this reads as unknown in the hardware-arm gate
+    # (fail closed, #285). Mirrors [autonomous] gps_max_stale_sec.
+    rc_max_stale_sec: float = 2.0
     strike_approach_m: float = 5.0  # Close-approach distance for strike (not standoff)
 
     # Pixel-lock guidance
@@ -364,11 +367,29 @@ class ApproachController:
     def get_hardware_arm_status(self) -> bool | None:
         """Read hardware arm switch from RC channel.
 
-        Returns True if armed, False if safe, None if unavailable.
+        Returns True if armed, False if safe, None if unavailable or stale.
+
+        This is a dead-man input: the RC cache latches its last frame when
+        RC_CHANNELS stops arriving (RC-link loss, TX off, telemetry stall),
+        so a value older than ``rc_max_stale_sec`` — or never received —
+        reads as unknown, not as the latched PWM (#285).
         """
         if self._cfg.hw_arm_channel is None:
             return None
         try:
+            # Read the stamp before the values: if a message lands between
+            # the two reads, the computed age is pessimistic (older), which
+            # errs toward fail-closed.
+            last_update = self._mavlink.get_rc_channels_last_update()
+            if last_update <= 0.0:
+                return None  # No RC_CHANNELS ever received
+            age = time.monotonic() - last_update
+            if age > self._cfg.rc_max_stale_sec:
+                logger.debug(
+                    "RC channels stale (%.1fs > %.1fs) — hw arm unknown",
+                    age, self._cfg.rc_max_stale_sec,
+                )
+                return None
             rc = self._mavlink.get_rc_channels()
             if rc and self._cfg.hw_arm_channel <= len(rc):
                 pwm = rc[self._cfg.hw_arm_channel - 1]
@@ -496,8 +517,11 @@ class ApproachController:
             logger.debug("Strike: target lost, holding")
             return
 
-        # Safety gate: check hardware arm if configured
-        # Treat None (unknown) as unsafe — fail closed
+        # Safety gate: check hardware arm if configured.
+        # Treat None (unknown) as unsafe — fail closed. Unknown includes
+        # stale or never-received RC data (#285): if RC_CHANNELS stops
+        # arriving the dead-man reads unknown and the strike aborts,
+        # rather than latching the last armed frame forever.
         if self._cfg.hw_arm_channel is not None:
             hw_armed = self.get_hardware_arm_status()
             if hw_armed is not True:  # False or None both mean unsafe

--- a/hydra_detect/config_schema.py
+++ b/hydra_detect/config_schema.py
@@ -595,6 +595,13 @@ SCHEMA: dict[str, dict[str, FieldSpec]] = {
             default=0,
             description="RC channel for hardware arm switch (0 = disabled)",
         ),
+        "rc_max_stale_sec": FieldSpec(
+            FieldType.FLOAT,
+            min_val=0.5,
+            max_val=30.0,
+            default=2.0,
+            description="RC staleness threshold for the hardware arm gate",
+        ),
         # These three keys are normally set per-vehicle via
         # [vehicle.<name>] autonomous.post_*_mode overrides. Listed here so
         # post-merge validation does not flag them as unknown keys.

--- a/hydra_detect/mavlink_io.py
+++ b/hydra_detect/mavlink_io.py
@@ -113,8 +113,13 @@ class MAVLinkIO:
             "last_update": 0.0,
         }
 
-        # RC channel values (updated by _message_reader from RC_CHANNELS)
+        # RC channel values (updated by _message_reader from RC_CHANNELS).
+        # last_update is monotonic, 0.0 = never received — same convention
+        # as _gps / _attitude. Safety consumers (hardware-arm dead-man gate,
+        # #285) must check freshness: the values alone cannot distinguish a
+        # live feed from a cache frozen by RC/telemetry loss.
         self._rc_channels: list[int] = []
+        self._rc_channels_last_update: float = 0.0
         self._rc_channels_lock = threading.Lock()
 
         # Vehicle mode state (from HEARTBEAT)
@@ -200,6 +205,11 @@ class MAVLinkIO:
             for stream_id in (
                 mavlink2.MAV_DATA_STREAM_EXTENDED_STATUS,
                 mavlink2.MAV_DATA_STREAM_EXTRA1,
+                # RC_CHANNELS feeds the hardware-arm dead-man gate. Request
+                # it explicitly instead of relying on the FC's default
+                # SRx_RC_CHAN rate, so the freshness guard (#285) measures
+                # a stream we actually solicited.
+                mavlink2.MAV_DATA_STREAM_RC_CHANNELS,
             ):
                 self._mav.mav.request_data_stream_send(
                     self._mav.target_system,
@@ -273,15 +283,7 @@ class MAVLinkIO:
                 elif msg_type == "ATTITUDE":
                     self._handle_attitude(msg)
                 elif msg_type == "RC_CHANNELS":
-                    with self._rc_channels_lock:
-                        self._rc_channels = [
-                            msg.chan1_raw, msg.chan2_raw, msg.chan3_raw,
-                            msg.chan4_raw, msg.chan5_raw, msg.chan6_raw,
-                            msg.chan7_raw, msg.chan8_raw, msg.chan9_raw,
-                            msg.chan10_raw, msg.chan11_raw, msg.chan12_raw,
-                            msg.chan13_raw, msg.chan14_raw, msg.chan15_raw,
-                            msg.chan16_raw, msg.chan17_raw, msg.chan18_raw,
-                        ]
+                    self._handle_rc_channels(msg)
                 elif msg_type == "HEARTBEAT":
                     from pymavlink import mavutil as _mavutil
                     if msg.type == _mavutil.mavlink.MAV_TYPE_GCS:  # Skip GCS heartbeats
@@ -367,6 +369,24 @@ class MAVLinkIO:
             self._attitude["pitch"] = float(msg.pitch)
             self._attitude["yaw"] = float(msg.yaw)
             self._attitude["last_update"] = time.monotonic()
+
+    def _handle_rc_channels(self, msg) -> None:
+        """Cache RC channel PWM values + freshness stamp from RC_CHANNELS.
+
+        The stamp advances on every receipt, value change or not — the
+        hardware-arm dead-man gate uses it to reject a cache frozen by
+        RC-link loss or a telemetry stall (#285).
+        """
+        with self._rc_channels_lock:
+            self._rc_channels = [
+                msg.chan1_raw, msg.chan2_raw, msg.chan3_raw,
+                msg.chan4_raw, msg.chan5_raw, msg.chan6_raw,
+                msg.chan7_raw, msg.chan8_raw, msg.chan9_raw,
+                msg.chan10_raw, msg.chan11_raw, msg.chan12_raw,
+                msg.chan13_raw, msg.chan14_raw, msg.chan15_raw,
+                msg.chan16_raw, msg.chan17_raw, msg.chan18_raw,
+            ]
+            self._rc_channels_last_update = time.monotonic()
 
     def _update_armed_state(self, heartbeat_msg) -> None:
         """Extract armed state from HEARTBEAT base_mode."""
@@ -1243,9 +1263,23 @@ class MAVLinkIO:
 
         Returns a list of up to 18 PWM values, or an empty list if no
         RC_CHANNELS message has been received yet.
+
+        These are cached values: check ``get_rc_channels_last_update()``
+        before trusting them for any safety decision — after RC-link loss
+        the list stays latched at the last received frame (#285).
         """
         with self._rc_channels_lock:
             return list(self._rc_channels)
+
+    def get_rc_channels_last_update(self) -> float:
+        """Return the monotonic timestamp of the last RC_CHANNELS receipt.
+
+        0.0 if never received — same convention as the GPS and attitude
+        ``last_update`` fields. Consumers compare against
+        ``time.monotonic()`` to reject stale RC data (#285).
+        """
+        with self._rc_channels_lock:
+            return self._rc_channels_last_update
 
     def command_do_change_speed(self, speed_m_s: float) -> bool:
         """Set vehicle ground speed via MAV_CMD_DO_CHANGE_SPEED.

--- a/hydra_detect/pipeline/facade.py
+++ b/hydra_detect/pipeline/facade.py
@@ -635,6 +635,8 @@ class Pipeline:
                     "autonomous", "arm_pwm_safe", fallback=1100),
                 hw_arm_channel=self._cfg.getint(
                     "autonomous", "hardware_arm_channel", fallback=0) or None,
+                rc_max_stale_sec=self._cfg.getfloat(
+                    "autonomous", "rc_max_stale_sec", fallback=2.0),
                 camera_hfov_deg=self._cfg.getfloat(
                     "camera", "hfov_deg", fallback=_hfov_default),
                 abort_mode=self._cfg.get(

--- a/tests/test_drop_strike.py
+++ b/tests/test_drop_strike.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock
+
+import pytest
 
 from hydra_detect.approach import ApproachConfig, ApproachController, ApproachMode
 
@@ -18,8 +21,17 @@ def _make_mavlink():
     mav.estimate_target_position.return_value = (34.051, -118.251)
     mav.command_guided_to.return_value = True
     mav.get_rc_channels.return_value = [1500] * 16
+    # Fresh stamp on every read — simulates a live RC_CHANNELS feed (#285).
+    mav.get_rc_channels_last_update.side_effect = time.monotonic
     mav.set_mode.return_value = True
     return mav
+
+
+def _freeze_rc_stamp(mav, age_sec: float) -> None:
+    """Simulate the RC_CHANNELS stream stopping `age_sec` ago: the cached
+    values stay latched, only the freshness stamp stops advancing."""
+    mav.get_rc_channels_last_update.side_effect = None
+    mav.get_rc_channels_last_update.return_value = time.monotonic() - age_sec
 
 
 def _make_track(x1=100, y1=100, x2=200, y2=200):
@@ -306,3 +318,70 @@ class TestHardwareArm:
         ctrl, mav = _make_controller(hw_arm_channel=8)
         mav.get_rc_channels.side_effect = Exception("no RC data")
         assert ctrl.get_hardware_arm_status() is None
+
+
+# ---------------------------------------------------------------------------
+# Hardware arm — RC freshness (#285)
+# ---------------------------------------------------------------------------
+
+class TestHardwareArmStaleness:
+    """The hardware arm switch is a dead-man input. When RC_CHANNELS stops
+    arriving (RC link loss, TX off, serial stall) the cache freezes at the
+    last frame — the gate must read that as unknown (None), never as armed.
+    Issue #285."""
+
+    def test_fresh_rc_armed_reads_true(self):
+        ctrl, mav = _make_controller(hw_arm_channel=8)
+        mav.get_rc_channels.return_value = [1500] * 7 + [1900] + [1500] * 8
+        assert ctrl.get_hardware_arm_status() is True
+
+    def test_fresh_rc_safe_reads_false(self):
+        ctrl, mav = _make_controller(hw_arm_channel=8)
+        mav.get_rc_channels.return_value = [1500] * 7 + [1200] + [1500] * 8
+        assert ctrl.get_hardware_arm_status() is False
+
+    @pytest.mark.regression
+    def test_stale_rc_reads_unknown(self):
+        """Regression #285: armed PWM latched in the cache with a stale
+        stamp must read None (unknown), not True. Before the fix the gate
+        returned True forever off the frozen frame."""
+        ctrl, mav = _make_controller(hw_arm_channel=8)
+        mav.get_rc_channels.return_value = [1500] * 7 + [1900] + [1500] * 8
+        _freeze_rc_stamp(mav, age_sec=10.0)
+        assert ctrl.get_hardware_arm_status() is None
+
+    def test_never_received_reads_none_not_crash(self):
+        """No RC_CHANNELS ever: empty cache + zero stamp reads None."""
+        ctrl, mav = _make_controller(hw_arm_channel=8)
+        mav.get_rc_channels.return_value = []
+        mav.get_rc_channels_last_update.side_effect = None
+        mav.get_rc_channels_last_update.return_value = 0.0
+        assert ctrl.get_hardware_arm_status() is None
+
+    def test_threshold_respects_config(self):
+        ctrl, mav = _make_controller(hw_arm_channel=8, rc_max_stale_sec=5.0)
+        mav.get_rc_channels.return_value = [1500] * 7 + [1900] + [1500] * 8
+        _freeze_rc_stamp(mav, age_sec=3.0)
+        assert ctrl.get_hardware_arm_status() is True  # within window
+        _freeze_rc_stamp(mav, age_sec=6.0)
+        assert ctrl.get_hardware_arm_status() is None  # past window
+
+    @pytest.mark.regression
+    def test_strike_aborts_when_rc_stream_stops(self):
+        """Full failure-mode simulation for #285: RC arrives armed and the
+        strike gate passes; then the stream stops with the armed frame
+        latched. The next gate check must abort instead of continuing the
+        close approach after the operator lost the ability to disarm."""
+        ctrl, mav = _make_controller(hw_arm_channel=8, waypoint_interval=0.0)
+        mav.get_rc_channels.return_value = [1500] * 7 + [1900] + [1500] * 8
+
+        assert ctrl.start_strike(1) is True
+        track = _make_track()
+        ctrl.update(track, 640, 480)
+        assert ctrl.mode == ApproachMode.STRIKE  # gate passed on live data
+
+        # RC stream stops — values stay latched armed, stamp freezes.
+        _freeze_rc_stamp(mav, age_sec=10.0)
+        ctrl.update(track, 640, 480)
+        assert ctrl.mode == ApproachMode.IDLE, \
+            "Strike must abort once RC data backing the dead-man goes stale"

--- a/tests/test_mavlink_safety.py
+++ b/tests/test_mavlink_safety.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from hydra_detect.mavlink_io import MAVLinkIO
 
@@ -242,3 +245,46 @@ class TestCommandGuided:
         assert m.command_guided_to(34.001, -118.001) is True
         m._mav.set_mode_apm.assert_called_once_with(4)
         m._mav.mav.set_position_target_global_int_send.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# RC channel freshness (#285)
+# ---------------------------------------------------------------------------
+
+def _rc_channels_msg(pwm: int = 1500):
+    """Fake RC_CHANNELS message with all 18 channels at ``pwm``."""
+    msg = MagicMock()
+    for i in range(1, 19):
+        setattr(msg, f"chan{i}_raw", pwm)
+    return msg
+
+
+class TestRCChannelFreshness:
+    """The hardware-arm dead-man gate reads RC through this cache. Values
+    alone cannot distinguish a live feed from a frozen cache, so every
+    RC_CHANNELS receipt must stamp a monotonic last_update — mirroring the
+    GPS/attitude convention. Issue #285."""
+
+    def test_never_received_reads_zero(self):
+        m = _make_mavlink()
+        assert m.get_rc_channels() == []
+        assert m.get_rc_channels_last_update() == 0.0
+
+    def test_receipt_stamps_last_update(self):
+        m = _make_mavlink()
+        before = time.monotonic()
+        m._handle_rc_channels(_rc_channels_msg(1700))
+        after = time.monotonic()
+        assert m.get_rc_channels() == [1700] * 18
+        assert before <= m.get_rc_channels_last_update() <= after
+
+    @pytest.mark.regression
+    def test_stamp_advances_on_identical_frames(self):
+        """Regression #285: an unchanged PWM frame must still refresh the
+        stamp — freshness is about receipt, not value change."""
+        m = _make_mavlink()
+        m._handle_rc_channels(_rc_channels_msg(1900))
+        first = m.get_rc_channels_last_update()
+        assert first > 0.0
+        m._handle_rc_channels(_rc_channels_msg(1900))
+        assert m.get_rc_channels_last_update() >= first

--- a/tests/test_safety_invariants.py
+++ b/tests/test_safety_invariants.py
@@ -14,6 +14,7 @@ import ast
 import logging
 import pathlib
 import re
+import time
 import xml.etree.ElementTree as ET
 from unittest.mock import MagicMock
 
@@ -46,6 +47,8 @@ def _mavlink_stub(**overrides):
     mav.set_mode.return_value = True
     mav.set_servo.return_value = True
     mav.get_rc_channels.return_value = [1500] * 16
+    # Fresh stamp on every read — simulates a live RC_CHANNELS feed (#285).
+    mav.get_rc_channels_last_update.side_effect = time.monotonic
     for k, v in overrides.items():
         getattr(mav, k).return_value = v
     return mav
@@ -233,6 +236,29 @@ def test_strike_fails_closed_when_hw_arm_unknown():
     ctrl.update(track, 640, 480)
     assert ctrl.mode == ApproachMode.IDLE, \
         "Strike must abort when HW arm status is unknown"
+
+
+@pytest.mark.regression
+def test_strike_fails_closed_when_rc_stale():
+    """#285: with hw_arm_channel configured, strike must abort when the RC
+    data behind the arm switch is stale — even though the cached frame
+    still reads armed. A dead-man switch that latches its last frame on
+    RC/telemetry loss is fail-open, inverting the gate's stated intent."""
+    mav = _mavlink_stub()
+    mav.get_rc_channels.return_value = [1500] * 7 + [1900] + [1500] * 8
+    # RC stream stopped 60 s ago; cache latched at the armed frame.
+    mav.get_rc_channels_last_update.side_effect = None
+    mav.get_rc_channels_last_update.return_value = time.monotonic() - 60.0
+    cfg = ApproachConfig(arm_channel=7, hw_arm_channel=8)
+    ctrl = ApproachController(mav, cfg)
+    assert ctrl.start_strike(track_id=42)
+
+    track = MagicMock()
+    track.x1, track.y1, track.x2, track.y2 = 100, 100, 200, 200
+    track.track_id = 42
+    ctrl.update(track, 640, 480)
+    assert ctrl.mode == ApproachMode.IDLE, \
+        "Strike must abort when RC data backing the HW arm switch is stale"
 
 
 # ── Invariant 6: /api/abort always responds ──────────────────────────


### PR DESCRIPTION
## Summary

**Flight-safety path — Kyle reviews personally. Do not merge without Kyle's review.**

Closes #285.

The strike-approach hardware-arm interlock (`_update_strike` → `get_hardware_arm_status()` → `MAVLinkIO.get_rc_channels()`) read a cached RC channel list that was never freshness-stamped. When `RC_CHANNELS` stops arriving — RC link loss, TX powered off, RC failsafe holding a channel, or a Jetson↔FC serial stall — the cache froze at the last received PWM frame, the gate kept returning armed, and the autonomous close-approach strike continued after the operator had lost the ability to disarm. The gate's own comment claimed fail-closed; it failed open. GPS, battery, and attitude all carry `last_update` staleness guards; RC — the one input gating a strike — had none.

Fix, mirroring the existing GPS staleness pattern in the same module:

- `MAVLinkIO` stamps `_rc_channels_last_update = time.monotonic()` on every `RC_CHANNELS` receipt (0.0 = never received, same convention as `_gps`/`_attitude`). The inline reader block is extracted into `_handle_rc_channels()`, mirroring `_handle_attitude()`. New accessor `get_rc_channels_last_update()`.
- `get_hardware_arm_status()` returns `None` — which the strike gate already treats as unsafe → abort — when RC data was never received **or** is older than `rc_max_stale_sec`. The stamp is read before the values so a racing update biases toward stale (fail-closed), never fresh.
- New `[autonomous] rc_max_stale_sec` config knob (FLOAT, 0.5–30.0, default **2.0 s**), mirroring `gps_max_stale_sec` in name, section, bounds, and default. Threshold justification: `connect()` now explicitly requests `MAV_DATA_STREAM_RC_CHANNELS` at 2 Hz (same rate as the existing stream requests), so 2.0 s means four consecutive missed frames before the dead-man releases — tolerant of ordinary jitter, and identical to the freshness window the GPS strike gate already uses.
- `connect()` previously never requested the RC stream group (`SRx_RC_CHAN`), leaving cadence to FC defaults — the secondary aggravator in #285.
- Comments/docs updated so the fail-closed claim is now true: gate comment in `_update_strike`, `configuration.md` table row, `autonomous-operations.md` Stage-2 dead-man wording.

### Other `get_rc_channels()` consumers checked

The only production consumer is `approach.py:get_hardware_arm_status()` (both the strike gate and `get_status()`'s `hardware_arm_status` field go through it). No other code reads the unstamped cache; all remaining references are test mocks. Related but out of scope: today's audit also noted `get_vehicle_mode()` has no staleness guard (defense-in-depth gap behind the `gps_fresh` gate, tracked in the audit notes, unfiled).

## Test plan

- [x] `pytest tests/` green locally — 2579 passed, 109 skipped (16 pre-existing Windows-only OTA/bash-script failures, identical set before and after this change; CI runs them on ubuntu)
- [x] `flake8 hydra_detect/ tests/` clean (0)
- [x] `scripts/check_config_consistency.py` OK (247 fields / 28 sections; facade fallback matches schema default)
- [x] `scripts/lint_no_duplicate_init_assignments.py hydra_detect/pipeline/facade.py` clean
- [x] Manual verification: red→green TDD — all behavioral tests written first and confirmed failing on unfixed code (stale-armed read returned `True`, strike continued after stream stop), then passing after the fix.

10 new tests (test count 2569 → 2579):

```
tests/test_drop_strike.py::TestHardwareArmStaleness::test_fresh_rc_armed_reads_true PASSED [ 10%]
tests/test_drop_strike.py::TestHardwareArmStaleness::test_fresh_rc_safe_reads_false PASSED [ 20%]
tests/test_drop_strike.py::TestHardwareArmStaleness::test_stale_rc_reads_unknown PASSED [ 30%]
tests/test_drop_strike.py::TestHardwareArmStaleness::test_never_received_reads_none_not_crash PASSED [ 40%]
tests/test_drop_strike.py::TestHardwareArmStaleness::test_threshold_respects_config PASSED [ 50%]
tests/test_drop_strike.py::TestHardwareArmStaleness::test_strike_aborts_when_rc_stream_stops PASSED [ 60%]
tests/test_mavlink_safety.py::TestRCChannelFreshness::test_never_received_reads_zero PASSED [ 70%]
tests/test_mavlink_safety.py::TestRCChannelFreshness::test_receipt_stamps_last_update PASSED [ 80%]
tests/test_mavlink_safety.py::TestRCChannelFreshness::test_stamp_advances_on_identical_frames PASSED [ 90%]
tests/test_safety_invariants.py::test_strike_fails_closed_when_rc_stale PASSED [100%]
======================== 10 passed, 1 warning in 0.62s ========================
```

The keystone test is `test_strike_aborts_when_rc_stream_stops`: RC arrives armed and the gate passes; the stream then stops with the armed frame latched in the cache; the next gate check aborts the strike instead of continuing.

## Adversarial review

- [x] R3 findings triaged (blocker / gate / follow-up / accepted) — report committed at `docs/adversarial/286.md` — no blockers; one follow-up noted (unstamped `get_vehicle_mode`, audit-tracked, out of scope)

## Risk

Behavioral change is deliberately one-directional: a configured hw-arm gate can now abort in cases where it previously (wrongly) continued — including on a genuinely slow RC_CHANNELS feed, mitigated by explicitly requesting the stream at 2 Hz in `connect()` and by the `rc_max_stale_sec` knob (0.5–30.0 s). Deployments with `hardware_arm_channel = 0` (disabled, the shipped default) are unaffected.
