### PR TITLE
test: clear the two stale tests keeping main CI red since 2026-07-06

### DIFF
--- a/tests/test_pixhawk_preflight.py
+++ b/tests/test_pixhawk_preflight.py
@@ -538,13 +538,18 @@ class TestManifestContent:
         assert "SR1_POSITION" in manifest["stream_rates"]
         assert manifest["stream_rates"]["SR1_POSITION"] >= 5
 
-    def test_ugv_recommends_battery_failsafe(self):
+    def test_ugv_requires_battery_failsafe(self):
+        # PR #273 promoted BATT_FS_LOW_ACT from recommended to required and
+        # paired it with the BATT_LOW_VOLT threshold that makes it fire.
         mod = _load_preflight_module()
         manifest = mod.load_manifest("ugv")
+        required_names = [e["name"] for e in manifest["required"]]
+        assert "BATT_FS_LOW_ACT" in required_names
+        assert "BATT_LOW_VOLT" in required_names  # action is inert without a threshold
+        entry = next(e for e in manifest["required"] if e["name"] == "BATT_FS_LOW_ACT")
+        assert entry["expected"] == 2  # Hold on ArduRover (1 = RTL, 2 = Hold)
         rec_names = [e["name"] for e in manifest["recommended"]]
-        assert "BATT_FS_LOW_ACT" in rec_names
-        entry = next(e for e in manifest["recommended"] if e["name"] == "BATT_FS_LOW_ACT")
-        assert entry["expected"] == 2  # RTL
+        assert "BATT_FS_LOW_ACT" not in rec_names  # promoted, not duplicated
 
     def test_drone_recommends_gcs_failsafe(self):
         mod = _load_preflight_module()

--- a/tests/test_vehicle_profile.py
+++ b/tests/test_vehicle_profile.py
@@ -326,7 +326,10 @@ class TestEffectiveConfigEndpoint:
     def test_effective_endpoint_exists_in_server(self):
         """The /api/config/effective route is registered on the FastAPI app."""
         from hydra_detect.web.server import app as fastapi_app
-        routes = [r.path for r in fastapi_app.routes]
+        # Newer starlette appends pathless _IncludedRouter entries to
+        # app.routes for each include_router() call — guard with hasattr,
+        # same idiom as test_effective_endpoint_is_get below.
+        routes = [r.path for r in fastapi_app.routes if hasattr(r, "path")]
         assert "/api/config/effective" in routes
 
     @_skip_no_server


### PR DESCRIPTION
## Summary

Un-stales the two tests that have kept main's CI `test` job red since the 2026-07-06 merges (main runs [17d4e8f](https://github.com/rmeadomavic/Hydra/actions/runs/28823268550) and [df5d5ed](https://github.com/rmeadomavic/Hydra/actions/runs/28823100969) fail with this byte-identical pair). Both failures are documented in [the PR #286 triage comment](https://github.com/rmeadomavic/Hydra/pull/286#issuecomment-4941385980). Test-only diff — zero production code touched. This PR exists so #286 (flight-safety, personally reviewed) can be reviewed against a green baseline instead of inherited red.

1. **`test_ugv_recommends_battery_failsafe` → stale against #273.** [PR #273](https://github.com/rmeadomavic/Hydra/pull/273) promoted `BATT_FS_LOW_ACT` from the ugv manifest's `recommended` list to `required` (expected `2`, correctly relabeled **Hold** on ArduRover — not RTL) and paired it with the `BATT_LOW_VOLT` threshold that makes it fire. The test was never updated and still asserted the pre-#273 shape (`recommended`, value 2 commented "RTL"). Renamed to `test_ugv_requires_battery_failsafe` and now asserts the promoted behavior: in `required` with expected `2`, threshold paired, and no longer duplicated in `recommended`. Assertions strengthened, not weakened.

2. **`test_effective_endpoint_exists_in_server` → starlette drift.** CI installs from `requirements.txt` ranges (`fastapi>=0.136.1,<2.0`) and now resolves starlette 1.3.1, where `include_router()` appends pathless `_IncludedRouter` entries to `app.routes` — the bare `[r.path for r in fastapi_app.routes]` raises `AttributeError`. Fixed with the `hasattr(r, "path")` guard, the exact idiom the sibling `test_effective_endpoint_is_get` already uses and already passes with on CI. No pins changed, nothing downgraded; the route itself (`@app.get("/api/config/effective")`, top-level `APIRoute`) is unaffected.

## Test plan

- [x] Full fast suite (CI selection flags) before/after on this machine: baseline `16 failed / 2569 passed / 109 skipped` → after `15 failed / 2570 passed / 109 skipped`. Failure-set diff is exactly the manifest test flipping to pass; the remaining 15 are the known Windows-only OTA/bash artifacts, byte-identical to baseline.
- [x] Endpoint test is Windows-skipped (`fcntl`), so its edited body was additionally executed against the real `hydra_detect.web.server` app on fastapi 0.139.0 / starlette 1.3.1 with `fcntl` stubbed: unguarded comprehension reproduces CI's exact `AttributeError: '_IncludedRouter' object has no attribute 'path'`; guarded version finds `/api/config/effective`. CI (Ubuntu) is the authoritative run for this one.
- [x] `flake8 hydra_detect/ tests/` clean (0)
- [ ] Manual verification (describe): n/a — test-only change, no runtime surface

## Adversarial review

- [ ] R3 findings triaged (blocker / gate / follow-up / accepted) — no safety-critical paths touched (tests only); CI job decides

## Risk

Test-only diff; worst case is a wrong assertion, which CI on this PR immediately exposes. Does not touch, rebase, or depend on #286.
