### PR TITLE
feat(#291): web UI gold polish layer + hydra-ui design drift guard

### DIFF
--- a/.claude/skills/hydra-ui/SKILL.md
+++ b/.claude/skills/hydra-ui/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: hydra-ui
+description: Design-system drift guard for the Hydra Detect web UI. MUST be read before touching anything in hydra_detect/web/ — templates, CSS, or UI-facing JS. Trigger on web UI work, dashboard styling, CSS changes, new panels/views/components, theme work, or any PR that renders pixels. Encodes the token law, radius law, motion ceiling, typography roles, and theme integrity rules that keep the UI tactical instead of drifting toward generic web defaults.
+---
+
+# Hydra UI — Design System Guard
+
+Hydra Detect's dashboard is a **tactical operator console** (reference class:
+Anduril Lattice, mission systems), not a SaaS product. AI agents trained on
+millions of average websites will drift it toward the mean — rounded cards,
+blue accents, Inter, generous whitespace, entry animations. Every rule below
+exists to stop that. When your instinct and this file disagree, this file wins.
+
+## The Laws
+
+### 1. Token law
+`hydra_detect/web/static/css/variables.css` is the single authority for
+color, spacing, type scale, radius, and transitions. **Never hardcode a hex,
+px-spacing, or easing that a token already covers.** If a value you need is
+missing, add a token, don't inline it.
+
+### 2. Theme integrity
+Three themes: `ops` (dark olive), `nvg` (monochrome green phosphor),
+`lattice` (light-dark). They work by token override on `:root[data-theme]`.
+Any NEW color must either derive from existing tokens or be defined in **all
+three** theme blocks. A color that only exists in ops-theme is a bug — check
+it under NVG, where everything must collapse to green-on-black.
+
+### 3. Radius law
+`--radius` is **2px, everywhere, flat**. Near-square, military. No
+`rounded-full`, no pills, no 8/12/16 radius language. If a component looks
+like it belongs on a marketing site, the radius is usually why.
+
+### 4. Typography roles
+- **Barlow Condensed** — headings, labels, buttons: uppercase, `--ls-condensed` tracking
+- **Barlow** — body prose only
+- **JetBrains Mono** — every data value, coordinate, ID, readout — with
+  `font-variant-numeric: tabular-nums` (gold.css applies it; keep new data
+  classes on that list)
+
+Never introduce another font. Never render telemetry in the body font.
+
+### 5. Motion ceiling
+This is a live operator console. An operator watching a strike-gate feed
+does not want theater between them and the data.
+
+- **340ms absolute ceiling** on any transition/animation
+- Easings come from tokens (`--transition-fast/normal/slow`) — never CSS
+  keyword easings (`ease`, `ease-in-out`, `linear` for UI motion)
+- **No entry animations on data** — telemetry, tracks, detections, and log
+  lines appear instantly. Panel-level fades (240ms, gold.css) are the max.
+- **No entrance animations on polled lists.** panels.js and ops.js rebuild
+  DOM nodes on poll ticks; per-row animations replay on every rebuild and
+  read as flicker. Verified constraint, do not retry it.
+- Infinite/looping animation is reserved for *live-state* indicators
+  (healthy dots, scanline) at low amplitude. Warning/danger states stay
+  steady — blinking reads as a new event.
+- Every animation this repo ships respects `prefers-reduced-motion`.
+
+### 6. Layer law
+- Structural/layout CSS → the per-view stylesheet (`ops.css`, `topbar.css`, …)
+- Aesthetic polish (depth, motion, glow, numeric discipline) → **`gold.css`**,
+  which loads LAST and must stay removable as a single unit
+- Load order in `base.html` is part of the design. `gold.css` stays last
+  among first-party sheets.
+
+### 7. Sacred vs slop
+JS state, polling, stream control, API calls, and event handlers are
+**sacred** — visual work never touches them. Class *values* in templates are
+fair game **only after** grepping `static/js/` for selector use
+(`querySelector`, `classList`, `getElementById` — main.js and panels.js
+query many of them). `id` attributes are load-bearing; never rename.
+
+## Pre-PR checklist (PASS required on all)
+
+| # | Check |
+|---|---|
+| 1 | No hardcoded colors/spacing/easing a token covers |
+| 2 | Verified under all three themes, including NVG collapse |
+| 3 | All radii 2px; no new radius language |
+| 4 | Data values in mono + tabular-nums; labels in Condensed caps |
+| 5 | No animation over 340ms; no keyword easings; no entry theater on data |
+| 6 | `prefers-reduced-motion` covered for anything that moves |
+| 7 | No JS logic touched by visual changes; selector grep done for renamed classes |
+| 8 | Polish landed in gold.css, not scattered across structural sheets |
+
+## Verification without the backend
+
+The dashboard renders without FastAPI for CSS QA — flatten the Jinja
+templates and static-serve:
+
+```bash
+python - <<'EOF'
+from jinja2 import Environment, FileSystemLoader
+env = Environment(loader=FileSystemLoader('hydra_detect/web/templates'))
+html = env.get_template('base.html').render(
+    morale_features_enabled=False, remote_abort_reachable=False)
+open('/tmp/hydra-flat/index.html', 'w', encoding='utf-8').write(
+    html.replace('/static/', 'static/'))
+EOF
+# copy hydra_detect/web/static → /tmp/hydra-flat/static, then:
+python -m http.server 8778 --bind 127.0.0.1 -d /tmp/hydra-flat
+```
+
+JS will error against missing `/api/*` — irrelevant for visual QA.
+Screenshot all three themes (`document.documentElement.dataset.theme`).

--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,11 @@ htmlcov/
 # never pushed to the public repo. If you add a new agent/skill/plan,
 # put it here so it stays out of the public surface.
 
-# Claude Code & sub-agent scaffolding (covers .claude/worktrees/ too)
-.claude/
+# Claude Code & sub-agent scaffolding (covers .claude/worktrees/ too).
+# Curated project skills are the one exception — .claude/skills/ is
+# checked in deliberately (design-system guard, issue #291).
+.claude/*
+!.claude/skills/
 .agents/
 
 # Repo-specific AI assistant guidelines (kept local)

--- a/hydra_detect/web/static/css/gold.css
+++ b/hydra_detect/web/static/css/gold.css
@@ -1,0 +1,160 @@
+/* ════════════════════════════════════════════════════════════════════════
+ * gold.css — the polish layer (issue #291)
+ *
+ * Single-file visual upgrade, loaded LAST in base.html so it overrides by
+ * cascade order. Contains NO structural CSS — layout lives in the per-view
+ * stylesheets. Removing the one <link> in base.html reverts every change
+ * in this file. Zero JS, zero template restructuring.
+ *
+ * Rules for editing this file live in .claude/skills/hydra-ui/SKILL.md.
+ * ════════════════════════════════════════════════════════════════════════ */
+
+/* ── 1. Easing tokens ────────────────────────────────────────────────────
+ * Replace keyword `ease-out` with custom curves. Every existing
+ * `var(--transition-*)` usage across the app upgrades automatically.
+ * Durations stay short — this is a console, not a landing page. */
+:root {
+    --ease-snap: cubic-bezier(0.22, 1, 0.36, 1);
+    --ease-glide: cubic-bezier(0.16, 1, 0.3, 1);
+    --transition-fast: 120ms var(--ease-snap);
+    --transition-normal: 220ms var(--ease-snap);
+    --transition-slow: 340ms var(--ease-glide);
+}
+
+/* ── 2. Edge-light on raised surfaces ────────────────────────────────────
+ * A 1px inset top highlight sells layered depth without adding chrome.
+ * Uses a token so themes can retune it later if needed. */
+:root {
+    --edge-light: inset 0 1px 0 rgba(255, 255, 255, 0.035);
+}
+.topbar {
+    box-shadow: var(--edge-light), 0 1px 12px rgba(0, 0, 0, 0.5);
+}
+.ops-sidebar-section,
+.cockpit-cell,
+.flight-hud {
+    box-shadow: var(--edge-light);
+}
+
+/* ── 3. Stencil tick on section headers ──────────────────────────────────
+ * Small glowing accent bar left of each .ops-sidebar-header title.
+ * Absolutely positioned so it works regardless of the header's flex
+ * layout; padding-left makes room for it. */
+.ops-sidebar-header {
+    position: relative;
+    padding-left: 18px;
+}
+.ops-sidebar-header::before {
+    content: '';
+    position: absolute;
+    left: 7px;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 3px;
+    height: 10px;
+    background: var(--olive-muted);
+    box-shadow: var(--glow-subtle);
+}
+
+/* ── 4. Animated underline on active tabs ────────────────────────────────
+ * The static 2px border-bottom becomes a bar that slides in from the left
+ * on activation. Border is blanked (not removed) so tab height is stable. */
+.topbar-tab,
+.ops-tab {
+    position: relative;
+}
+.topbar-tab.active,
+.topbar-tab.active:hover,
+.ops-tab.active {
+    border-bottom-color: transparent;
+}
+.topbar-tab::after,
+.ops-tab::after {
+    content: '';
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 2px;
+    background: var(--olive-muted);
+    box-shadow: var(--glow-subtle);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform var(--transition-normal);
+}
+.topbar-tab.active::after,
+.ops-tab.active::after {
+    transform: scaleX(1);
+}
+.topbar-tab::after {
+    left: 8px;
+    right: 8px;
+}
+
+/* ── 5. Pulse on healthy status dots ─────────────────────────────────────
+ * Live systems breathe. 3s cycle, glow only — size never changes, so
+ * nothing reflows. Applied to healthy/live states only; warning and
+ * danger dots stay steady (a blinking warning reads as a new event). */
+/* Glow comes from theme tokens so NVG/lattice re-tint automatically. */
+@keyframes gold-dot-pulse {
+    0%, 100% { box-shadow: var(--glow-green); }
+    50%      { box-shadow: var(--glow-subtle); }
+}
+.topbar[data-mock="1"] .tb-dot.green,
+.cockpit-cell-dot,
+.flight-hud-status-dot {
+    animation: gold-dot-pulse 3s var(--ease-glide) infinite;
+}
+
+/* ── 6. Tabular figures on data readouts ─────────────────────────────────
+ * Fixed-width digits stop numeric readouts from jittering as values
+ * change. Applied to every mono data surface. */
+.mono,
+.data-value,
+.stat-value,
+.ops-card-value,
+.ops-info-value,
+.ops-telem-value,
+.ops-mavlink-value,
+.ops-tab-count,
+.flight-hud-card-big,
+.flight-hud-card-sub,
+.flight-hud-hdg-readout,
+.flight-hud-gimbal-val,
+.cockpit-servo-cell-value,
+.cockpit-sdr-stats b,
+.tb-fps-value,
+.tb-lat-value,
+.tb-battery-pct {
+    font-variant-numeric: tabular-nums;
+}
+
+/* ── 7. Tab panel fade-in ────────────────────────────────────────────────
+ * Sidebar tab switches get a 240ms fade-up. Scoped to .ops-tab-panel only:
+ * view containers are left alone (the persistent MJPEG stream and
+ * stream-controller.js must not be affected). */
+@keyframes gold-panel-in {
+    from { opacity: 0; transform: translateY(5px); }
+    to   { opacity: 1; transform: none; }
+}
+.ops-tab-panel:not([hidden]) {
+    animation: gold-panel-in 240ms var(--ease-glide);
+}
+
+/* ── 8. Reduced motion ───────────────────────────────────────────────────
+ * Everything this layer animates shuts off. The scanline in ops.css
+ * already handles itself. */
+@media (prefers-reduced-motion: reduce) {
+    .topbar[data-mock="1"] .tb-dot.green,
+    .cockpit-cell-dot,
+    .flight-hud-status-dot {
+        animation: none;
+    }
+    .ops-tab-panel:not([hidden]) {
+        animation: none;
+    }
+    .topbar-tab::after,
+    .ops-tab::after {
+        transition: none;
+    }
+}

--- a/hydra_detect/web/templates/base.html
+++ b/hydra_detect/web/templates/base.html
@@ -16,6 +16,9 @@
     <link rel="stylesheet" href="/static/css/systems.css">
     <link rel="stylesheet" href="/static/css/autonomy.css">
     <link rel="stylesheet" href="/static/css/rf.css">
+    <!-- gold.css is the removable polish layer (issue #291) — must stay LAST
+         among first-party sheets so it overrides by cascade order. -->
+    <link rel="stylesheet" href="/static/css/gold.css">
     <!-- Leaflet (used by Cockpit TAK map on Ops + large map on TAK tab) -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="anonymous">
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin="anonymous"></script>


### PR DESCRIPTION
Closes #291. Companion mockup review happened off-repo (vault `_attachments/hydra-ops-mockup.html`).

## What

**`gold.css`** — single-file, removable polish layer, loaded last among first-party sheets. Zero JS, zero template restructuring; delete one `<link>` to fully revert.

- `--transition-*` tokens: keyword `ease-out` → custom cubic-bezier curves. Every existing `var(--transition-*)` usage in the app upgrades from this one change.
- Inset edge-light on raised surfaces (topbar, sidebar sections, cockpit cells, flight HUD)
- Stencil accent tick on `.ops-sidebar-header`
- Active tab underline now slides in (`::after` scaleX; the static border is blanked, not removed, so tab metrics are unchanged)
- Healthy status dots get a 3s glow pulse driven by `--glow-green`/`--glow-subtle`, so NVG re-tints it to phosphor automatically. Warning/danger dots stay steady by design.
- `font-variant-numeric: tabular-nums` on all mono readouts — numeric displays stop jittering as digits change
- 240ms fade on sidebar tab panel switches. View containers deliberately untouched (persistent MJPEG stream + stream-controller.js).
- Full `prefers-reduced-motion` coverage

**`.claude/skills/hydra-ui/SKILL.md`** — design drift guard. Encodes the existing system as enforceable law for agent sessions: token law, 2px radius, 340ms motion ceiling, typography roles, three-theme integrity (NVG collapse check), sacred-JS rules, pre-PR checklist, and a backend-free verification recipe (Jinja flatten-render + static serve).

## Judgment call — flag for review

`.gitignore` previously ignored `.claude/` wholesale ("out of the public surface"). Scoped it to `.claude/*` + `!.claude/skills/` so the curated skill ships while worktrees/local state stay ignored. The skill reads as public design-system docs and contains nothing sensitive — but if you want zero AI-tooling artifacts on the public surface, say the word and I'll move it to `docs/web-ui-design-system.md` (losing agent auto-load).

## Verification

Flatten-rendered the real templates (no backend) and drove them in Chrome:
- gold.css loads last, 17 rules active; disabling the link cleanly reverts (A/B verified)
- Tab underline + panel fade exercised via live click on the RF tab
- Header tick renders without breaking the badge/pill layout in section headers
- Dot pulse verified under NVG: computed glow resolves to `rgba(0,255,65,…)` phosphor, not olive (caught my own hardcoded-rgba violation of the skill's Law 2 during QA; fixed by tokenizing the keyframes)
- All three themes screenshot-checked (`ops`, `nvg`, `lattice`)
- No Python touched; flake8/pytest surface unchanged

QA also surfaced pre-existing #292 (`.rf-source-pill` defeats the `hidden` attribute) — reproduced with gold.css disabled, so it's not from this layer; left out of scope.

## Preview locally

```bash
git checkout feat/web-ui-gold-polish
# recipe in .claude/skills/hydra-ui/SKILL.md — flatten + http.server, no backend needed
```