### PR TITLE
fix(#294): ops view truth pass — remove synthetic data presented as live telemetry

### DIFF
--- a/hydra_detect/web/static/css/flight-hud.css
+++ b/hydra_detect/web/static/css/flight-hud.css
@@ -266,63 +266,8 @@
     white-space: nowrap;
 }
 
-/* ── Gimbal block ── */
-.flight-hud-gimbal {
-    border-top: 1px solid #1a1f1a;
-    padding-top: 8px;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.flight-hud-gimbal-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: baseline;
-}
-
-.flight-hud-gimbal-label {
-    font-family: var(--font-cond);
-    font-size: 9px;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    color: #556;
-}
-
-.flight-hud-gimbal-mode {
-    font-family: var(--font-mono);
-    font-size: 9px;
-    letter-spacing: 0.08em;
-    color: #888;
-}
-
-.flight-hud-gimbal[data-mode="TRACK"] .flight-hud-gimbal-mode {
-    color: var(--olive-muted);
-}
-
-.flight-hud-gimbal[data-mode="STOW"] .flight-hud-gimbal-mode {
-    color: #555;
-}
-
-.flight-hud-gimbal-svg {
-    width: 100%;
-    height: 60px;
-    background: #060807;
-    border: 1px solid #1a1f1a;
-    border-radius: var(--radius);
-}
-
-.flight-hud-gimbal-row {
-    display: flex;
-    justify-content: space-between;
-    font-family: var(--font-mono);
-    font-size: 9px;
-    color: #888;
-}
-
-.flight-hud-gimbal-val {
-    color: var(--text-primary);
-}
+/* Gimbal block removed (issue #294) — no JS ever populated it; it rendered
+   a frozen "STOW / -- / --" indefinitely. Pan/tilt live on the servo dial. */
 
 /* ── Target block ── */
 .flight-hud-target {

--- a/hydra_detect/web/static/css/ops-sidebar.css
+++ b/hydra_detect/web/static/css/ops-sidebar.css
@@ -290,11 +290,6 @@
     color: var(--text-primary);
 }
 
-/* Mission rail: condense minimap so it doesn't dominate the column */
-.ops-mission-rail-minimap .ops-minimap {
-    max-height: 140px;
-}
-
 .ops-card-badge {
     font-family: var(--font-mono);
     font-size: var(--font-xs);

--- a/hydra_detect/web/static/css/ops.css
+++ b/hydra_detect/web/static/css/ops.css
@@ -242,18 +242,7 @@ body.view-ops #view-ops {
     min-width: 35px;
 }
 
-.ops-minimap {
-    background: var(--bg-panel);
-    height: 200px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-}
-
-.ops-minimap canvas {
-    width: 100%;
-    height: 100%;
-}
+/* .ops-minimap removed (issue #294) — the canvas was never drawn into. */
 
 .ops-vehicle-info {
     padding: var(--s-1) var(--s-2);

--- a/hydra_detect/web/static/css/rf.css
+++ b/hydra_detect/web/static/css/rf.css
@@ -5,6 +5,12 @@
  */
 
 /* ── Source pill (LIVE / REPLAY) ─────────────────────────────────────── */
+/* Fix #292: the class's display beat the UA's [hidden] rule, so the
+   LIVE/REPLAY provenance pill rendered even while hidden — a data-source
+   badge that could not be turned off. */
+.rf-source-pill[hidden] {
+    display: none;
+}
 .rf-source-pill {
     display: inline-block;
     padding: 2px var(--s-2);

--- a/hydra_detect/web/static/css/tak.css
+++ b/hydra_detect/web/static/css/tak.css
@@ -59,6 +59,16 @@ body.view-tak #mjpeg-stream {
     font-weight: 700;
     font-size: 9px;
 }
+/* Degraded poll state (issue #294) — chips flip LIVE→STALE from real
+   poller backoff instead of claiming LIVE forever. */
+.tak-map-chip.tak-stale {
+    color: var(--bg-void);
+    background: var(--warning);
+    padding: 1px 6px;
+    border-radius: var(--radius);
+    font-weight: 700;
+    font-size: 9px;
+}
 .tak-map-sub {
     color: var(--text-secondary);
     margin-left: auto;
@@ -226,6 +236,11 @@ body.view-tak #mjpeg-stream {
     background: var(--olive-primary);
     color: var(--text-primary);
     box-shadow: var(--glow-green);
+}
+.tak-col-chip.tak-stale {
+    background: var(--warning);
+    color: var(--bg-void);
+    box-shadow: none;
 }
 
 .tak-col-body {

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -22,8 +22,11 @@ const HydraOps = (() => {
     // failure in one zone never starves the rest. SVG repaints DOM-diff via
     // a tiny `_lastSig` cache on each rendered element.
     let auxTimer = null;
-    let sdrTickTimer = null;
-    let sdrTickValue = 0;
+    // The fake SDR spectrum animator and its 700ms ticker were removed here
+    // (issue #294): the spectrum SVG was a sine+random animation presented
+    // as live RF data. The spectrum is now owned exclusively by
+    // rtl-spectrum-overlay.js — real /api/rf/spectrum data or an honest
+    // "no spectrum source" empty state.
     let hudLayoutLoaded = false;
     let zonePending = { hud: false, cockpit: false };
 
@@ -57,8 +60,6 @@ const HydraOps = (() => {
         // Slower 1Hz tick for FlightHUD + Cockpit polls — keeps FPS overhead
         // negligible while still feeling alive in the demo.
         auxTimer = setInterval(refreshAuxZones, 1000);
-        // SDR spectrum animates every 700ms (mirrors mock setInterval).
-        sdrTickTimer = setInterval(animateSdrSpectrum, 700);
         // TAK tab poller — 2s cadence, only fetches when TAK tab is active.
         takTimer = setInterval(refreshTakTab, 2000);
         loadHudLayoutFromConfig();
@@ -67,7 +68,6 @@ const HydraOps = (() => {
         wireOpsTabs();
         updateHUD();
         refreshAuxZones();
-        animateSdrSpectrum();
         refreshTakTab();
     }
 
@@ -79,10 +79,6 @@ const HydraOps = (() => {
         if (auxTimer) {
             clearInterval(auxTimer);
             auxTimer = null;
-        }
-        if (sdrTickTimer) {
-            clearInterval(sdrTickTimer);
-            sdrTickTimer = null;
         }
         if (takTimer) {
             clearInterval(takTimer);
@@ -1061,19 +1057,22 @@ const HydraOps = (() => {
         var mode = s.mode || s.vehicle_mode || null;
         var lock = target.locked ? target.track_id : null;
 
+        // Issue #294: these are DERIVED state-change events, not captured
+        // MAVLink frames. They were previously formatted as fake SET_MODE /
+        // STATUSTEXT TX traffic; now labeled as what they are.
         if (mode && mode !== mavLogLastMode) {
             mavLogLastMode = mode;
             mavLog.push({
-                t: nowHHMMSS(), dir: 'TX', msg: 'SET_MODE',
-                detail: 'mode=' + mode,
+                t: nowHHMMSS(), dir: 'EVT', msg: 'MODE',
+                detail: 'vehicle mode → ' + mode,
             });
         }
         if (lock !== mavLogLastLock) {
             mavLogLastLock = lock;
             if (lock != null) {
                 mavLog.push({
-                    t: nowHHMMSS(), dir: 'TX', msg: 'STATUSTEXT',
-                    detail: 'HYDRA: LOCK track #' + lock,
+                    t: nowHHMMSS(), dir: 'EVT', msg: 'LOCK',
+                    detail: 'target lock → track #' + lock,
                 });
             }
         }
@@ -1113,7 +1112,7 @@ const HydraOps = (() => {
                 while (log.firstChild) log.removeChild(log.firstChild);
                 var empty = document.createElement('div');
                 empty.className = 'ops-tab-empty';
-                empty.textContent = 'No MAVLink traffic';
+                empty.textContent = 'No link events';
                 log.appendChild(empty);
             }
             return;
@@ -1148,8 +1147,8 @@ const HydraOps = (() => {
             var r = log.children[i];
             if (!r) continue;
             var isTx = m.dir === 'TX';
-            var isCmd = /SET_MODE|SERVO|POSITION_TARGET|YAW/.test(m.msg || '');
-            var isStatus = m.msg === 'STATUSTEXT';
+            var isCmd = /MODE|SERVO|POSITION_TARGET|YAW/.test(m.msg || '');
+            var isStatus = m.msg === 'LOCK';
             r.classList.toggle('is-cmd', isCmd);
             r.classList.toggle('is-status', !isCmd && isStatus);
             var head2 = r.children[0];
@@ -2511,10 +2510,13 @@ const HydraOps = (() => {
 
         if (panEl) panEl.textContent = enabled ? (pan >= 0 ? '+' : '') + pan.toFixed(0) + '\u00B0' : '--';
         if (tiltEl) tiltEl.textContent = enabled ? (tilt >= 0 ? '+' : '') + tilt.toFixed(0) + '\u00B0' : '--';
+        // Issue #294: third cell shows the servo's locked track id \u2014 a real
+        // /api/servo/status field. Was a synthetic PWM (1500 + pan*5.5).
         if (rateEl) {
-            rateEl.textContent = enabled ? Math.round(1500 + pan * 5.5) : '--';
+            rateEl.textContent = (enabled && data.locked_track_id != null)
+                ? '#' + data.locked_track_id : '--';
         }
-        if (rateLabel) rateLabel.textContent = 'PWM';
+        if (rateLabel) rateLabel.textContent = 'TRK';
     }
 
     // Cockpit TAK map is now a small Leaflet instance managed by tak-map.js.
@@ -2552,25 +2554,34 @@ const HydraOps = (() => {
         if (!listEl) return;
 
         var samples = (data && Array.isArray(data.samples)) ? data.samples : [];
-        // Synthesize devices from samples — not all backends populate names;
-        // we map sample.callsign/mac/vendor/rssi when present.
-        var devices = samples.slice(0, 12).map(function (s, i) {
+        // Issue #294: render ONLY fields the backend actually supplied. The
+        // previous version fabricated MAC addresses, vendor names, and device
+        // types for every sample — operators troubleshooting Kismet/SDR
+        // binding saw invented devices and concluded RF was healthy.
+        var devices = samples.slice(0, 12).map(function (s) {
             return {
-                type: s.type || (i === 0 ? 'wifi' : 'ble'),
-                name: s.callsign || s.name || s.ssid || ('DEV-' + (s.mac || i)),
-                mac: s.mac || ('00:00:00:00:00:' + String(i).padStart(2, '0')),
-                vendor: s.vendor || '--',
-                rssi: (typeof s.rssi === 'number') ? s.rssi : -100,
-                age: (typeof s.age === 'number') ? s.age : 999,
+                type: s.type || null,
+                name: s.callsign || s.name || s.ssid ||
+                    ((typeof s.freq_mhz === 'number') ? s.freq_mhz.toFixed(1) + ' MHz' : null),
+                mac: s.mac || null,
+                vendor: s.vendor || null,
+                rssi: (typeof s.rssi === 'number') ? s.rssi
+                    : (typeof s.rssi_dbm === 'number') ? s.rssi_dbm : null,
+                age: (typeof s.age === 'number') ? s.age : null,
                 alert: !!s.alert,
                 you: !!s.you,
             };
-        }).sort(function (a, b) { return b.rssi - a.rssi; });
+        }).sort(function (a, b) { return (b.rssi != null ? b.rssi : -999) - (a.rssi != null ? a.rssi : -999); });
 
         if (devEl) devEl.textContent = devices.length || '--';
-        if (newEl) newEl.textContent = devices.filter(function (d) { return d.age < 5; }).length || '--';
+        // "new" requires a real age field; show -- rather than inventing one.
+        if (newEl) {
+            var aged = devices.filter(function (d) { return d.age != null; });
+            newEl.textContent = aged.length
+                ? String(aged.filter(function (d) { return d.age < 5; }).length) : '--';
+        }
         if (droneEl) droneEl.textContent = devices.filter(function (d) {
-            return /drone|rid|dji/i.test(d.type) || /dji|drone/i.test(d.name);
+            return /drone|rid|dji/i.test(d.type || '') || /dji|drone/i.test(d.name || '');
         }).length || '--';
 
         // DOM-diff list
@@ -2579,7 +2590,9 @@ const HydraOps = (() => {
                 while (listEl.firstChild) listEl.removeChild(listEl.firstChild);
                 var empty = document.createElement('div');
                 empty.className = 'cockpit-sdr-empty';
-                empty.textContent = 'scanning…';
+                // Honest empty state pointing at the most common cause
+                // (SORCC known issue: Kismet not bound to the SDR serial).
+                empty.textContent = 'no RF data — check Kismet / SDR source binding';
                 listEl.appendChild(empty);
             }
             return;
@@ -2606,31 +2619,11 @@ const HydraOps = (() => {
             r2.classList.toggle('is-new', d.age < 3);
             r2.classList.toggle('is-alert', d.alert);
             r2.classList.toggle('is-you', d.you);
-            _setText(r2.children[0], String(d.type).split('-')[0].toUpperCase().slice(0, 4));
-            _setText(r2.children[1], d.name);
-            _setText(r2.children[2], d.mac);
-            _setText(r2.children[3], d.vendor);
-            _setText(r2.children[4], String(d.rssi));
-        }
-    }
-
-    function animateSdrSpectrum() {
-        var svg = document.getElementById('ops-cockpit-sdr-spectrum');
-        if (!svg) return;
-        sdrTickValue++;
-        // Mock-style: 70 bars, width 2, x stride 2.9, sin(i*0.4 + tick*0.3)
-        while (svg.firstChild) svg.removeChild(svg.firstChild);
-        for (var i = 0; i < 70; i++) {
-            var h = 4 + Math.abs(Math.sin(i * 0.4 + sdrTickValue * 0.3)) * 16
-                + ((i % 11 === 0) ? 12 : 0) + Math.random() * 4;
-            var bar = document.createElementNS(SVG_NS, 'rect');
-            bar.setAttribute('x', (i * 2.9).toFixed(1));
-            bar.setAttribute('y', (34 - h).toFixed(1));
-            bar.setAttribute('width', '2');
-            bar.setAttribute('height', h.toFixed(1));
-            bar.setAttribute('fill', 'var(--olive-primary)');
-            bar.setAttribute('opacity', (0.5 + (h / 34) * 0.5).toFixed(2));
-            svg.appendChild(bar);
+            _setText(r2.children[0], d.type ? String(d.type).split('-')[0].toUpperCase().slice(0, 4) : '—');
+            _setText(r2.children[1], d.name || '—');
+            _setText(r2.children[2], d.mac || '—');
+            _setText(r2.children[3], d.vendor || '—');
+            _setText(r2.children[4], d.rssi != null ? String(d.rssi) : '—');
         }
     }
 
@@ -2676,7 +2669,25 @@ const HydraOps = (() => {
         HydraApp.apiGet('/api/config/full').then(function (cfg) {
             var layout = (cfg && cfg.web && cfg.web.hud_layout) ? cfg.web.hud_layout : 'classic';
             applyHudLayout(layout);
+            applyConfigLabels(cfg);
         }).catch(function () { applyHudLayout('classic'); });
+    }
+
+    // Issue #294: the MAVLink port and TAK multicast labels were hardcoded
+    // HTML styled identically to live data. Populate them from the actual
+    // running config; leave '--' when the config doesn't say.
+    function applyConfigLabels(cfg) {
+        if (!cfg) return;
+        var portEl = document.getElementById('ops-tab-mav-port');
+        if (portEl && cfg.mavlink && cfg.mavlink.connection_string) {
+            portEl.textContent = cfg.mavlink.connection_string
+                + (cfg.mavlink.baud ? ' · ' + cfg.mavlink.baud : '');
+        }
+        var mcastEl = document.getElementById('ops-tab-tak-multicast');
+        if (mcastEl && cfg.tak && cfg.tak.multicast_group) {
+            mcastEl.textContent = cfg.tak.multicast_group
+                + (cfg.tak.multicast_port ? ':' + cfg.tak.multicast_port : '');
+        }
     }
 
     function onHudLayoutPickerChange(e) {

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -2616,7 +2616,7 @@ const HydraOps = (() => {
             var d = devices[k];
             var r2 = listEl.children[k];
             if (!r2) continue;
-            r2.classList.toggle('is-new', d.age < 3);
+            r2.classList.toggle('is-new', d.age != null && d.age < 3);
             r2.classList.toggle('is-alert', d.alert);
             r2.classList.toggle('is-you', d.you);
             _setText(r2.children[0], d.type ? String(d.type).split('-')[0].toUpperCase().slice(0, 4) : '—');

--- a/hydra_detect/web/static/js/rtl-spectrum-overlay.js
+++ b/hydra_detect/web/static/js/rtl-spectrum-overlay.js
@@ -1,10 +1,15 @@
 'use strict';
 /**
- * rtl-spectrum-overlay.js v5 — live SDR spectrum for the Ops cockpit cell.
+ * rtl-spectrum-overlay.js v6 — live SDR spectrum for the Ops cockpit cell.
  *
- * Must be loaded BEFORE ops.js. Intercepts setInterval at registration so
- * the legacy SDR sim-animator (which clobbers the SVG every 700ms) is
- * never started. Then polls /api/rf/spectrum and repaints real bars.
+ * Sole owner of the #ops-cockpit-sdr-spectrum SVG (issue #294: the legacy
+ * sine-wave sim-animator in ops.js is deleted, along with the setInterval
+ * monkey-patch this file used to suppress it). Polls /api/rf/spectrum and
+ * paints real bars when the SDR is enabled, or an explicit "no spectrum
+ * source" state when it is not — never decorative data.
+ *
+ * The peak LIST (#ops-cockpit-sdr-list) is only touched while spectrum data
+ * is live; when the SDR is off, ops.js renderCockpitSdr owns the list.
  */
 (function () {
     var SVG_NS = 'http://www.w3.org/2000/svg';
@@ -12,21 +17,6 @@
     var PAINT_MS = 200;
     var SPAN_H = 34;
     var cached = null;
-
-    var origSetInterval = window.setInterval;
-    window.setInterval = function (fn, ms) {
-        try {
-            var fnStr = (typeof fn === 'function') ? String(fn) : '';
-            if (ms >= 500 && ms <= 900 &&
-                fnStr.indexOf('ops-cockpit-sdr-spectrum') !== -1) {
-                return -1;
-            }
-        } catch (e) {}
-        return origSetInterval.apply(window, arguments);
-    };
-    setTimeout(function () {
-        try { window.setInterval = origSetInterval; } catch (e) {}
-    }, 5000);
 
     function downsample(bins, n) {
         if (!bins || bins.length === 0) return [];
@@ -111,10 +101,40 @@
         }
     }
 
+    // Honest empty state (issue #294): a flat baseline + label instead of a
+    // blank (or previously, animated fake) spectrum. Painted once; cleared
+    // by the next real paintBars call.
+    function paintSpectrumOff() {
+        var svg = document.getElementById('ops-cockpit-sdr-spectrum');
+        if (!svg || svg.getAttribute('data-rtl-off') === '1') return;
+        while (svg.firstChild) svg.removeChild(svg.firstChild);
+        var base = document.createElementNS(SVG_NS, 'rect');
+        base.setAttribute('x', '0');
+        base.setAttribute('y', String(SPAN_H - 1));
+        base.setAttribute('width', '200');
+        base.setAttribute('height', '1');
+        base.setAttribute('fill', 'var(--text-dim, #666)');
+        base.setAttribute('opacity', '0.4');
+        svg.appendChild(base);
+        var label = document.createElementNS(SVG_NS, 'text');
+        label.setAttribute('x', '100');
+        label.setAttribute('y', String(SPAN_H / 2 + 3));
+        label.setAttribute('text-anchor', 'middle');
+        label.setAttribute('fill', 'var(--text-dim, #666)');
+        label.setAttribute('font-family', 'var(--font-mono, monospace)');
+        label.setAttribute('font-size', '7');
+        label.textContent = 'no spectrum source';
+        svg.appendChild(label);
+        svg.setAttribute('data-rtl-off', '1');
+        svg.removeAttribute('data-rtl-paint');
+    }
+
     function repaint() {
         var d = cached;
-        if (!d) return;
-        paintBars(document.getElementById('ops-cockpit-sdr-spectrum'), d);
+        if (!d) { paintSpectrumOff(); return; }
+        var svgEl = document.getElementById('ops-cockpit-sdr-spectrum');
+        if (svgEl) svgEl.removeAttribute('data-rtl-off');
+        paintBars(svgEl, d);
         paintList(document.getElementById('ops-cockpit-sdr-list'), d);
         var subEl = document.querySelector('#ops-cockpit-sdr .cockpit-sdr-sub');
         var devEl = document.getElementById('ops-cockpit-sdr-dev');
@@ -128,17 +148,33 @@
         if (newEl) newEl.textContent = pc || '--';
     }
 
+    var pollFails = 0;
     function poll() {
         fetch('/api/rf/spectrum', { cache: 'no-store' })
             .then(function (r) { return r.ok ? r.json() : null; })
-            .then(function (d) { if (d && d.enabled) cached = d; })
-            .catch(function () {});
+            .then(function (d) {
+                if (d && d.enabled) {
+                    cached = d;
+                    pollFails = 0;
+                } else {
+                    // Explicit disabled/absent signal: drop immediately so
+                    // stale bars don't linger as if live (issue #294).
+                    cached = null;
+                    pollFails = 0;
+                }
+            })
+            .catch(function () {
+                // Transient network hiccups keep the last real frame for a
+                // few seconds; sustained failure falls to the empty state.
+                pollFails++;
+                if (pollFails >= 3) cached = null;
+            });
     }
 
     function start() {
         poll();
-        origSetInterval.call(window, poll, POLL_MS);
-        origSetInterval.call(window, repaint, PAINT_MS);
+        setInterval(poll, POLL_MS);
+        setInterval(repaint, PAINT_MS);
     }
 
     if (document.readyState === 'loading') {

--- a/hydra_detect/web/static/js/tak-map.js
+++ b/hydra_detect/web/static/js/tak-map.js
@@ -113,6 +113,11 @@ window.HydraTakMap = (() => {
         let hasCentered = false;
         let timer = null;
         let stopped = false;
+        // Monotonic run token. Every stop()/start() bumps it so a tick from a
+        // superseded loop (e.g. a double-init or a stop/start race) sees its
+        // gen !== generation and bows out instead of rescheduling — otherwise
+        // two setTimeout chains poll the same map forever (Codex P2).
+        let generation = 0;
 
         function setSelfHeading(heading) {
             selfHeading = (typeof heading === 'number') ? heading : 0;
@@ -240,32 +245,37 @@ window.HydraTakMap = (() => {
             } catch (e) { return false; }
         }
 
-        async function tick() {
-            if (stopped) return;
+        async function tick(gen) {
+            if (stopped || gen !== generation) return;
             const results = await Promise.all([refreshSelf(), refreshPeers(), refreshTracks()]);
+            // Re-check after the await: a stop()/start() may have fired while
+            // the fetches were in flight, superseding this loop.
+            if (stopped || gen !== generation) return;
             if (typeof options.onHealth === 'function') {
                 const relevant = results.filter((v) => v === true || v === false);
                 try { options.onHealth(relevant.every(Boolean)); } catch (e) { /* listener */ }
             }
-            if (!stopped) timer = setTimeout(tick, pollMs);
+            timer = setTimeout(() => tick(gen), pollMs);
         }
 
         // Let Leaflet read the container's size after it has been laid out.
         requestAnimationFrame(() => {
             map.invalidateSize();
-            tick();
+            tick(generation);
         });
 
         const ctl = {
             map: map,
             stop() {
                 stopped = true;
-                if (timer) clearTimeout(timer);
+                generation += 1;
+                if (timer) { clearTimeout(timer); timer = null; }
             },
             start() {
                 if (!stopped) return;
                 stopped = false;
-                tick();
+                generation += 1;
+                tick(generation);
             },
             refresh() {
                 map.invalidateSize();

--- a/hydra_detect/web/static/js/tak-map.js
+++ b/hydra_detect/web/static/js/tak-map.js
@@ -78,10 +78,16 @@ window.HydraTakMap = (() => {
         const pollMs = options.pollMs || 2000;
         const showTracks = options.showTracks !== false;
 
-        // Guard against double-init (router may re-enter views)
+        // Guard against double-init (router may re-enter views).
+        // Found during #294 QA: the reused controller came back with its
+        // poll loop permanently stopped (onLeave calls stop(); nothing
+        // restarted it), so the map silently froze after one view switch.
+        // Restart the loop on re-entry.
         if (container._hydraMap) {
             container._hydraMap.invalidateSize();
-            return container._hydraMap._hydraCtl;
+            const prevCtl = container._hydraMap._hydraCtl;
+            if (prevCtl && typeof prevCtl.start === 'function') prevCtl.start();
+            return prevCtl;
         }
 
         const map = L.map(container, {
@@ -117,10 +123,13 @@ window.HydraTakMap = (() => {
             }
         }
 
+        // Each refresher returns true on a successful round-trip, false on
+        // failure (null = skipped) so tick() can report aggregate health to
+        // the optional onHealth callback (issue #294 — truthful LIVE chips).
         async function refreshSelf() {
             try {
                 const r = await fetch('/api/stats', { credentials: 'same-origin' });
-                if (!r.ok) return;
+                if (!r.ok) return false;
                 const s = await r.json();
                 const lat = (typeof s.lat === 'number') ? s.lat : null;
                 const lon = (typeof s.lon === 'number') ? s.lon : null;
@@ -153,13 +162,14 @@ window.HydraTakMap = (() => {
                         hasCentered = true;
                     }
                 }
-            } catch (e) { /* transient */ }
+                return true;
+            } catch (e) { return false; }
         }
 
         async function refreshPeers() {
             try {
                 const r = await fetch('/api/tak/peers', { credentials: 'same-origin' });
-                if (!r.ok) return;
+                if (!r.ok) return false;
                 const data = await r.json();
                 const peers = Array.isArray(data.peers) ? data.peers : [];
                 const seen = new Set();
@@ -189,14 +199,15 @@ window.HydraTakMap = (() => {
                         peerMarkers.delete(cs);
                     }
                 }
-            } catch (e) { /* transient */ }
+                return true;
+            } catch (e) { return false; }
         }
 
         async function refreshTracks() {
-            if (!showTracks) return;
+            if (!showTracks) return null;
             try {
                 const r = await fetch('/api/active_tracks', { credentials: 'same-origin' });
-                if (!r.ok) return;
+                if (!r.ok) return false;
                 const tracks = await r.json();
                 const list = Array.isArray(tracks) ? tracks : [];
                 const seen = new Set();
@@ -225,12 +236,17 @@ window.HydraTakMap = (() => {
                         trackMarkers.delete(id);
                     }
                 }
-            } catch (e) { /* transient */ }
+                return true;
+            } catch (e) { return false; }
         }
 
         async function tick() {
             if (stopped) return;
-            await Promise.all([refreshSelf(), refreshPeers(), refreshTracks()]);
+            const results = await Promise.all([refreshSelf(), refreshPeers(), refreshTracks()]);
+            if (typeof options.onHealth === 'function') {
+                const relevant = results.filter((v) => v === true || v === false);
+                try { options.onHealth(relevant.every(Boolean)); } catch (e) { /* listener */ }
+            }
             if (!stopped) timer = setTimeout(tick, pollMs);
         }
 
@@ -245,6 +261,11 @@ window.HydraTakMap = (() => {
             stop() {
                 stopped = true;
                 if (timer) clearTimeout(timer);
+            },
+            start() {
+                if (!stopped) return;
+                stopped = false;
+                tick();
             },
             refresh() {
                 map.invalidateSize();

--- a/hydra_detect/web/static/js/tak.js
+++ b/hydra_detect/web/static/js/tak.js
@@ -51,6 +51,30 @@ const HydraTak = (() => {
     let auditEventRowNodes = Object.create(null);
     let auditEventRowOrder = [];
 
+    // ── Chip health (issue #294) ──
+    // The five "LIVE" chips were static HTML — they claimed LIVE even while
+    // a poller was in exponential backoff against a dead endpoint. Each
+    // poller now reports its state so the chip tells the truth.
+    function setChipHealth(id, ok, backoffMs) {
+        const chip = document.getElementById(id);
+        if (!chip) return;
+        if (chip.dataset.baseTitle === undefined) chip.dataset.baseTitle = chip.title || '';
+        if (ok) {
+            if (chip.textContent !== 'LIVE') chip.textContent = 'LIVE';
+            chip.classList.remove('tak-stale');
+            chip.classList.add('tak-live');
+            if (chip.title !== chip.dataset.baseTitle) chip.title = chip.dataset.baseTitle;
+        } else {
+            if (chip.textContent !== 'STALE') chip.textContent = 'STALE';
+            chip.classList.remove('tak-live');
+            chip.classList.add('tak-stale');
+            if (backoffMs) {
+                chip.title = 'Endpoint failing — retrying in ' +
+                    Math.round(backoffMs / 1000) + 's';
+            }
+        }
+    }
+
     // ── Lifecycle ──
     let mapCtl = null;
 
@@ -75,6 +99,9 @@ const HydraTak = (() => {
                 showZoom: true,
                 showAttribution: true,
                 showTracks: true,
+                // Issue #294: the map chip was static "LIVE" HTML. Reflect
+                // the shared map module's actual poll health.
+                onHealth: (ok) => setChipHealth('tak-map-chip', ok),
                 onTitleUpdate: (callsign, info) => {
                     const t = document.getElementById('tak-map-title');
                     const s = document.getElementById('tak-map-sub');
@@ -174,8 +201,10 @@ const HydraTak = (() => {
             const data = await resp.json();
             renderFeed(Array.isArray(data.commands) ? data.commands : []);
             cmdBackoff = POLL_MS_COMMANDS;
+            setChipHealth('tak-live-chip', true);
         } catch (err) {
             cmdBackoff = Math.min(cmdBackoff * 2, 10000);
+            setChipHealth('tak-live-chip', false, cmdBackoff);
         } finally {
             cmdInflight = false;
         }
@@ -342,8 +371,10 @@ const HydraTak = (() => {
             const data = await resp.json();
             updateTypeCounts(data || {});
             typeBackoff = POLL_MS_TYPES;
+            setChipHealth('tak-type-chip', true);
         } catch (err) {
             typeBackoff = Math.min(typeBackoff * 2, 20000);
+            setChipHealth('tak-type-chip', false, typeBackoff);
         } finally {
             typeInflight = false;
         }
@@ -457,8 +488,10 @@ const HydraTak = (() => {
             const data = await resp.json();
             updatePeers(data || {});
             peersBackoff = POLL_MS_PEERS;
+            setChipHealth('tak-peers-chip', true);
         } catch (err) {
             peersBackoff = Math.min(peersBackoff * 2, 30000);
+            setChipHealth('tak-peers-chip', false, peersBackoff);
         } finally {
             peersInflight = false;
         }
@@ -635,8 +668,10 @@ const HydraTak = (() => {
             const data = await resp.json();
             updateAudit(data || {});
             auditBackoff = POLL_MS_AUDIT;
+            setChipHealth('tak-audit-chip', true);
         } catch (err) {
             auditBackoff = Math.min(auditBackoff * 2, 60000);
+            setChipHealth('tak-audit-chip', false, auditBackoff);
         } finally {
             auditInflight = false;
         }

--- a/hydra_detect/web/templates/ops.html
+++ b/hydra_detect/web/templates/ops.html
@@ -73,15 +73,9 @@
             </div>
         </div>
 
-        <!-- Minimap — relocated; the Cockpit TAK map is the primary map.
-             Kept here as a low-priority secondary indicator; ops.js still
-             draws into this canvas when present. -->
-        <div class="ops-sidebar-section ops-mission-rail-minimap">
-            <div class="ops-sidebar-header">MAP</div>
-            <div class="ops-minimap" id="ops-minimap">
-                <canvas id="ops-minimap-canvas" width="300" height="200"></canvas>
-            </div>
-        </div>
+        <!-- Minimap removed (issue #294): the canvas was never drawn into by
+             any JS — a permanently blank surface presented as a map. The
+             Cockpit TAK map is the primary (and only) ops-view map. -->
 
     </div>
 
@@ -227,19 +221,9 @@
                 </article>
             </div>
 
-            <!-- Gimbal block — always rendered; opacity drops without lock -->
-            <div class="flight-hud-gimbal" id="ops-fhud-gimbal">
-                <div class="flight-hud-gimbal-header">
-                    <span class="flight-hud-gimbal-label">Gimbal</span>
-                    <span class="flight-hud-gimbal-mode" id="ops-fhud-gimbal-mode">STOW</span>
-                </div>
-                <svg class="flight-hud-gimbal-svg" id="ops-fhud-gimbal-svg" viewBox="0 0 140 60"
-                     preserveAspectRatio="none" aria-hidden="true"></svg>
-                <div class="flight-hud-gimbal-row">
-                    <span>PAN <span class="flight-hud-gimbal-val" id="ops-fhud-gimbal-pan">--</span></span>
-                    <span>TILT <span class="flight-hud-gimbal-val" id="ops-fhud-gimbal-tilt">--</span></span>
-                </div>
-            </div>
+            <!-- Gimbal block removed (issue #294): no JS ever populated it —
+                 it rendered a frozen "STOW / -- / --" indefinitely. Live
+                 pan/tilt readouts live on the cockpit servo dial. -->
 
             <!-- Target block — dim when no lock -->
             <div class="flight-hud-target" id="ops-fhud-target">
@@ -281,8 +265,11 @@
                     <div class="cockpit-servo-cell-label">TILT</div>
                     <div class="cockpit-servo-cell-value" id="ops-cockpit-servo-tilt">--</div>
                 </div>
+                <!-- Third cell shows the servo's locked track id (real field from
+                     /api/servo/status). Was a synthetic PWM computed client-side
+                     from pan angle (issue #294). -->
                 <div class="cockpit-servo-cell">
-                    <div class="cockpit-servo-cell-label" id="ops-cockpit-servo-rate-label">PWM</div>
+                    <div class="cockpit-servo-cell-label" id="ops-cockpit-servo-rate-label">TRK</div>
                     <div class="cockpit-servo-cell-value" id="ops-cockpit-servo-rate">--</div>
                 </div>
             </div>
@@ -328,7 +315,9 @@
                     <span class="cockpit-sdr-right-align">dBm</span>
                 </div>
                 <div class="cockpit-sdr-list" id="ops-cockpit-sdr-list">
-                    <div class="cockpit-sdr-empty">scanning…</div>
+                    <!-- Honest initial state (issue #294): "scanning…" implied an
+                         active sweep before any data source was confirmed. -->
+                    <div class="cockpit-sdr-empty">no RF data — check Kismet / SDR source binding</div>
                 </div>
             </div>
         </section>
@@ -466,7 +455,8 @@
                          aria-label="Recent ambient RF samples"></div>
                 </div>
 
-                <div class="ops-tab-empty" id="ops-rf-empty" style="display:none;">No RF activity</div>
+                <!-- ops-rf-empty removed (issue #294): never toggled by any JS.
+                     RF sections self-hide when empty. -->
             </div>
 
             <!-- MAVLINK panel -->
@@ -477,7 +467,6 @@
                         <div class="ops-mavlink-label">Pipeline FPS</div>
                         <div class="ops-mavlink-value-row">
                             <span class="ops-mavlink-value mono" id="ops-tab-mav-fps">--</span>
-                            <span class="ops-mavlink-sub">min 5.0</span>
                         </div>
                     </div>
                     <div class="ops-mavlink-metric">
@@ -486,11 +475,16 @@
                             <span class="ops-mavlink-value mono" id="ops-tab-mav-latency">--</span>
                             <span class="ops-mavlink-sub">ms</span>
                         </div>
-                        <div class="ops-mavlink-port" id="ops-tab-mav-port">/dev/ttyTHS1 · 921600</div>
+                        <!-- Populated from /api/config/full [mavlink] (issue #294 —
+                             was a hardcoded label styled as live data) -->
+                        <div class="ops-mavlink-port" id="ops-tab-mav-port">--</div>
                     </div>
                 </div>
-                <div class="ops-mavlink-log" id="ops-tab-mav-log">
-                    <div class="ops-tab-empty">No MAVLink traffic</div>
+                <!-- Derived link events (mode changes, target locks) observed from
+                     pipeline state — NOT a raw MAVLink frame capture (issue #294). -->
+                <div class="ops-mavlink-log" id="ops-tab-mav-log"
+                     title="Link events derived from pipeline state — not a raw MAVLink frame capture">
+                    <div class="ops-tab-empty">No link events</div>
                 </div>
             </div>
 
@@ -503,8 +497,10 @@
                         <span class="ops-card-value mono accent" id="ops-tab-tak-callsign">HYDRA-1</span>
                     </div>
                     <div class="ops-tak-row">
+                        <!-- Populated from /api/config/full [tak] (issue #294 —
+                             was a hardcoded label styled as live data) -->
                         <span class="ops-card-label">Multicast</span>
-                        <span class="ops-card-value mono" id="ops-tab-tak-multicast">239.2.3.1:6969</span>
+                        <span class="ops-card-value mono" id="ops-tab-tak-multicast">--</span>
                     </div>
                     <div class="ops-tak-row">
                         <span class="ops-card-label">Peers</span>

--- a/hydra_detect/web/templates/tak.html
+++ b/hydra_detect/web/templates/tak.html
@@ -4,7 +4,7 @@
 <section class="tak-map-pane" id="tak-map-pane" aria-label="TAK tactical map">
     <header class="tak-map-header">
         <span class="tak-map-title" id="tak-map-title">TAK · HYDRA-1</span>
-        <span class="tak-map-chip tak-live" id="tak-map-chip" title="Polling /api/stats + /api/tak/peers">LIVE</span>
+        <span class="tak-map-chip tak-live" id="tak-map-chip" title="Polling /api/stats + /api/tak/peers + /api/active_tracks">LIVE</span>
         <span class="tak-map-sub" id="tak-map-sub">no fix</span>
         <button class="tak-map-action" id="tak-test-broadcast" type="button"
                 title="Force an immediate self-SA emit — useful to verify the marker appears in ATAK before a sortie.">

--- a/tests/test_ops_layout.py
+++ b/tests/test_ops_layout.py
@@ -47,7 +47,7 @@ class TestNewZoneElements:
 
     def test_flight_hud_subzones_present(self):
         html = OPS_HTML.read_text()
-        # HDG tape, VTapes, ReadoutCards, gimbal, target, status
+        # HDG tape, VTapes, ReadoutCards, target, status
         for needle in (
             'id="ops-fhud-hdg-svg"',
             'id="ops-fhud-spd-svg"',
@@ -56,11 +56,17 @@ class TestNewZoneElements:
             'id="ops-fhud-card-link"',
             'id="ops-fhud-card-pos"',
             'id="ops-fhud-card-gps"',
-            'id="ops-fhud-gimbal"',
             'id="ops-fhud-target"',
             'id="ops-fhud-status"',
         ):
             assert needle in html, f"ops.html should contain {needle}"
+
+    def test_gimbal_block_removed(self):
+        """Issue #294: the gimbal block was never populated by any JS — it
+        rendered a frozen 'STOW / -- / --' presented as live telemetry."""
+        html = OPS_HTML.read_text()
+        assert 'id="ops-fhud-gimbal"' not in html
+        assert 'ops-fhud-gimbal-pan' not in html
 
     def test_cockpit_strip_root_present(self):
         html = OPS_HTML.read_text()
@@ -109,12 +115,17 @@ class TestOpsJsExports:
 
     def test_aux_zones_polled_on_enter(self):
         src = OPS_JS.read_text()
-        # New 1Hz aux poller and 700ms SDR ticker registered in onEnter
+        # 1Hz aux poller registered in onEnter and torn down in onLeave
         assert "setInterval(refreshAuxZones, 1000)" in src
-        assert "setInterval(animateSdrSpectrum, 700)" in src
-        # And torn down in onLeave
         assert "if (auxTimer)" in src
-        assert "if (sdrTickTimer)" in src
+
+    def test_fake_sdr_animator_removed(self):
+        """Issue #294: the SDR spectrum was a sine+random animation presented
+        as live RF data. rtl-spectrum-overlay.js is now the sole owner of the
+        spectrum SVG (real /api/rf/spectrum data or an honest empty state)."""
+        src = OPS_JS.read_text()
+        assert "animateSdrSpectrum" not in src
+        assert "sdrTickTimer" not in src
 
 
 # ── (c) Layout picker emits all four valid hud_layout values ──
@@ -240,7 +251,7 @@ class TestNewCssAssets:
         assert resp.status_code == 200
         body = resp.text
         for cls in (".flight-hud", ".flight-hud-hdg", ".flight-hud-vtape",
-                    ".flight-hud-card", ".flight-hud-gimbal",
+                    ".flight-hud-card",
                     ".flight-hud-target", ".flight-hud-status"):
             assert cls in body
 

--- a/tests/test_ops_sidebar.py
+++ b/tests/test_ops_sidebar.py
@@ -73,12 +73,14 @@ class TestSidebarCardIds:
         assert 'id="ops-detlog-section"' in html
         assert 'id="ops-detlog"' in html
 
-    def test_vehicle_and_map_preserved(self):
+    def test_vehicle_preserved_minimap_removed(self):
         html = OPS_HTML.read_text()
-        # Existing must-preserve IDs — map canvas + vehicle info block
-        assert 'id="ops-minimap-canvas"' in html
+        # Vehicle info block must survive
         assert 'id="ops-vehicle-info"' in html
         assert 'id="ops-info-position"' in html  # SIM GPS sink
+        # Issue #294: the minimap canvas was never drawn into by any JS — a
+        # permanently blank surface presented as a map. Removed.
+        assert 'id="ops-minimap-canvas"' not in html
 
 
 # ── (b) ops.js exposes expected sidebar-update functions ──

--- a/tests/test_ops_sidebar_tabs.py
+++ b/tests/test_ops_sidebar_tabs.py
@@ -186,11 +186,13 @@ class TestTabCountBadges:
 
     def test_empty_states_match_mock_tone(self):
         html = OPS_HTML.read_text()
-        # "No RF activity" per task spec
-        assert "No RF activity" in html or "No RF" in html
-        assert "No MAVLink" in html
+        # Issue #294: the MAVLink tab log is derived link events, not a fake
+        # frame capture — empty state renamed accordingly. The never-toggled
+        # "No RF activity" div is gone (RF sections self-hide when empty).
+        assert "No link events" in html
         assert "No inbound commands" in html
         assert "No audit events" in html
+        assert 'id="ops-rf-empty"' not in html
 
 
 # ── (e) Mission + Pipeline relocated to left mission rail ──
@@ -264,11 +266,11 @@ class TestProtectedCodePathsRegression:
         assert "addEventListener('dblclick'" in src
         assert "requestFullscreen" in src
 
-    def test_minimap_canvas_survives(self):
-        """test_ops_sidebar.py + test_ops_layout.py still require the minimap
-        canvas ID to exist. Tab refactor must keep it alive."""
+    def test_minimap_canvas_removed(self):
+        """Issue #294: the minimap canvas was dead weight — no JS ever drew
+        into it. The cockpit TAK map is the ops-view map."""
         html = OPS_HTML.read_text()
-        assert 'id="ops-minimap-canvas"' in html
+        assert 'id="ops-minimap-canvas"' not in html
 
 
 # ── CSS: tab strip styles ──


### PR DESCRIPTION
Closes #294. Closes #292. First of two PRs implementing the 2026-07-18 UI utility audit (companion feature PR follows, stacked on this one).

## Why

The ops view rendered fabricated or frozen data styled identically to live telemetry. SORCC students' documented failure modes (Kismet binding, GPS triage) are the exact subsystems that were being faked — an operator debugging "SDR detects nothing" saw animated spectrum bars and concluded RF was healthy.

## Removed fabrications

- **SDR spectrum**: the sine+random animator is gone. `rtl-spectrum-overlay.js` is now sole owner (its fragile `setInterval` monkey-patch suppressor is also gone) — real `/api/rf/spectrum` bars when enabled, an explicit **"no spectrum source"** state when not, with 3-poll tolerance so transient hiccups don't flicker.
- **SDR device list**: no more invented MAC/type/vendor/name per ambient sample. Backend-supplied fields only; em-dash for absent. Empty state: *"no RF data — check Kismet / SDR source binding"* (points at the #1 known cause).
- **Servo PWM cell**: was `1500 + pan*5.5` computed client-side. Now shows the real `locked_track_id` (label TRK).
- **MAVLink tab log**: relabeled derived link events (`EVT MODE`, `EVT LOCK`) — it was never a frame capture; fake `SET_MODE`/`STATUSTEXT TX` framing removed. Header tooltip states the derivation.

## Removed dead surfaces

- Mission-rail **minimap** (no JS ever drew into the canvas; the HTML comment claiming otherwise was false) + CSS.
- FlightHUD **gimbal block** (permanently "STOW / -- / --") + CSS.
- `ops-rf-empty` (never toggled).

## Frozen labels → config-driven

MAVLink port and TAK multicast now populate from `/api/config/full` (`[mavlink]`, `[tak]`), showing `--` until config arrives. The unexplained "min 5.0" is gone.

## Truthful status chips (+ #292)

- All **five TAK-view "LIVE" chips** were static HTML. They now flip **LIVE ⇄ STALE** (amber) from each poller's real success/backoff state; STALE tooltip shows the retry interval. `tak-map.js` grew an `onHealth` callback — refreshers return per-fetch success, `tick()` aggregates.
- **#292**: `.rf-source-pill[hidden] { display: none; }` — the class display was defeating the `hidden` attribute, so the LIVE/REPLAY provenance badge could never be hidden.

## Bug found during QA, fixed here

`HydraTakMap`'s double-init guard returned a **permanently stopped controller**: `onLeave` → `ctl.stop()` set `stopped = true`, and re-entering the TAK view reused it without restarting — the big map silently froze after one view switch. Added `ctl.start()`; the guard now restarts the loop on re-entry.

## Verification

- 128 tests passing across ops/tak/topbar/demo/rf suites; assertions updated to pin the new truth (including inverting `test_minimap_canvas_survives`, which existed specifically to protect the dead canvas).
- Chrome-driven against flatten-rendered templates (no backend): honest empty states confirmed, config labels fall back to `--`, all five chips exercised LIVE→STALE against 404ing endpoints, pill hides, map poll loop survives leave/re-enter.

No Python changes.