### PR TITLE
feat(#295–298): operator-utility surfaces — readiness, recovery, feedback, compass

### DIFF
--- a/docs/adversarial/300.md
+++ b/docs/adversarial/300.md
@@ -1,0 +1,106 @@
+# Adversarial review — PR #300 (operator-utility surfaces, #295–#298)
+
+Scope of safety-path changes: `mavlink_io.py` GPS_RAW_INT cog/vel caching +
+`get_flight_data()` exposure, and `web/server.py` `_flight_fields` additive
+keys. All other files in this PR are frontend (JS/HTML/CSS) and tests.
+Reviewed against main @ e26bdd2 with the change applied.
+
+## Round 1 — pattern-match the changes
+
+**R1-a — Sentinel handling on cog/vel.** GPS_RAW_INT encodes unknown as
+UINT16_MAX (65535) for both fields; the handler maps 65535 → None, else
+`/100` (centideg → deg, cm/s → m/s). Boundary: a unit emitting cog=36000
+lands on `360.0 % 360.0 == 0.0` — correct wrap, and the modulo runs AFTER the
+sentinel filter so 65535 can never wrap into a plausible 295.35°. uint16, so
+negatives are unrepresentable. ACCEPT (order verified in diff).
+
+**R1-b — AttributeError inside the RX dispatch loop.** A dialect variant
+missing `cog`/`vel` would raise inside the message loop and kill ALL MAVLink
+handling — same failure class as the enum reference flagged in the PR #286
+review. Guarded: `getattr(msg, "cog", 65535)` / `getattr(msg, "vel", 65535)`
+degrade to the unknown sentinel instead of raising. Common-dialect
+GPS_RAW_INT always carries both fields; the getattr is belt-and-suspenders.
+ACCEPT (verified, not assumed).
+
+**R1-c — Lock discipline.** Writes happen inside the existing
+`with self._gps_lock:` block of the GPS_RAW_INT branch; reads in
+`get_flight_data()` are inside the same lock. cog and ground_speed are
+written in one critical section, so consumers never see a torn pair (fresh
+cog against stale speed). ACCEPT.
+
+**R1-d — No new stream subscription.** GPS_RAW_INT was already parsed (the
+`fix_type` cache predates this PR), so the change rides an existing message
+path. No REQUEST_DATA_STREAM change → no new behavior on flight stacks that
+ignore stream requests. ACCEPT.
+
+**R1-e — server.py additive keys degrade to None, never KeyError.** Defaults
+dict carries `cog`/`ground_speed` as None; the copy loop uses `data.get(key)`,
+so a stale MAVLinkIO object from a hot-reload (predating the new keys)
+produces None, not an exception in the stats endpoint. Covered by
+`test_stats_includes_flight_keys_when_mavlink_absent`. ACCEPT.
+
+## Round 2 — counter-critique, downgrade or confirm
+
+**R2-a — Is "display-only" actually true?** Interrogated by grep across
+`autonomous.py`, `approach.py`, `guidance.py`, `servo_tracker.py`,
+`dogleg_rtl.py`, `geo_tracking.py`, `rf/*`: zero consumers of `cog` or
+`ground_speed`. The only consumers are `/api/stats` → `ops.js
+compassHealth()` (advisory amber HDG + "run COMPASS_MOT" hint). No gate, no
+command path, no autonomy input reads these fields. CONFIRM CORRECT.
+
+**R2-b — Failure direction of the compass advisory.** False positive (GPS
+multipath, low-speed cog noise) → operator runs an unnecessary compass
+calibration: annoying, loud, safe. The 1.5 m/s speed gate exists because cog
+is meaningless below walking pace, and the 4 s hold rejects transients. False
+negative (real compass fault while cog happens to agree) → identical to the
+pre-PR baseline, which surfaced nothing at all — strictly no worse. ACCEPT
+(wrong-direction-proof).
+
+**R2-c — cog leaking into the heading fallback chain.** The `heading` value
+still resolves VFR_HUD → GLOBAL_POSITION_INT.hdg (compass-fused yaw); `cog`
+lives in a separate key and is never substituted for heading. The fallback
+chain is untouched by this diff — confusion between magnetic heading and GPS
+course cannot occur server-side; the client compares them deliberately, which
+is the feature. CONFIRM.
+
+**R2-d — Dict-shape growth on `_gps`.** Other `_gps` readers (`get_gps()`
+consumers) access by key with `.get()`; none iterate the dict with a strict
+schema. Additive keys are invisible to them. ACCEPT.
+
+## Round 3 — orthogonal sweep ("who else reads this shape?")
+
+**R3-a — `observability/health.py::_probe_gps` reads a key that
+`get_flight_data()` has never returned.** The fallback path calls
+`get_flight_data().get("gps_fix")` — but that accessor returns only
+heading/airspeed/altitude/vertical_speed (now + cog/ground_speed), never
+`gps_fix`. The fallback therefore always yields None → `_warn("no gps
+data")` whenever the stats dict is absent. Pre-existing defect, unchanged by
+this PR (new keys are invisible to a `.get("gps_fix")`), wrong-direction-safe
+(degrades to a warning, never a false OK). FOLLOW-UP — should read
+`get_gps()["fix"]` instead; not expanded here (different module, needs its
+own test).
+
+**R3-b — `/api/stats` consumers with exact-shape assertions.** The two tests
+that pin the stats/flight-data shape (`test_defaults_when_no_data_ingested`,
+`test_existing_stats_keys_preserved`) were updated in this PR; the frontend
+accesses fields by name and tolerates absence. No consumer breaks on the two
+new keys. ACCEPT.
+
+**R3-c — Coverage for the new path.** `test_gps_raw_int_unknown_sentinels_map_to_none`
+(65535 → None) and `test_gps_raw_int_populates_cog_and_ground_speed` exercise
+both sides of the sentinel branch; the defaults test pins the None-before-data
+contract. ACCEPT.
+
+**R3-d — Frontend gate interaction.** The Start Sortie preflight gate added
+in this PR reads `/api/preflight` `overall`, not cog/ground_speed — the two
+features share a PR but no data path. The gate fails OPEN when the endpoint
+is unreachable (flagged to the operator in the PR body as a judgment call);
+that is a UI-availability tradeoff, not a flight-safety path — the sortie
+bookmark is a logging construct, not an arming action. ACCEPT (documented).
+
+## Triage
+
+- Blockers: none.
+- Gates: none.
+- Follow-up: R3-a (`_probe_gps` gps_fix key mismatch — pre-existing, unfiled).
+- Accepted: R1-a–R1-e, R2-a–R2-d, R3-b, R3-c, R3-d.

--- a/hydra_detect/mavlink_io.py
+++ b/hydra_detect/mavlink_io.py
@@ -76,9 +76,12 @@ class MAVLinkIO:
         self._global_alert_times: deque = deque()  # timestamps of recent global alerts
         self._lock = threading.Lock()
 
-        # GPS state (lat/lon/alt in MAVLink int format, hdg in centidegrees)
+        # GPS state (lat/lon/alt in MAVLink int format, hdg/cog in centidegrees)
+        # cog = course over ground from GPS_RAW_INT; compared against compass
+        # heading to flag magnetic interference (issue #298).
         self._gps: Dict[str, Any] = {
             "lat": None, "lon": None, "alt": None, "fix": 0, "hdg": None,
+            "cog": None, "ground_speed": None,
             "last_update": 0.0,
         }
         self._gps_lock = threading.Lock()
@@ -276,6 +279,13 @@ class MAVLinkIO:
                 elif msg_type == "GPS_RAW_INT":
                     with self._gps_lock:
                         self._gps["fix"] = msg.fix_type
+                        # cog: course over ground, centidegrees (65535 = unknown).
+                        # vel: ground speed, cm/s (65535 = unknown). Used by the
+                        # compass-health check (issue #298).
+                        cog = getattr(msg, "cog", 65535)
+                        self._gps["cog"] = None if cog == 65535 else (cog / 100.0) % 360.0
+                        vel = getattr(msg, "vel", 65535)
+                        self._gps["ground_speed"] = None if vel == 65535 else vel / 100.0
                 elif msg_type == "SYS_STATUS":
                     self._handle_sys_status(msg)
                 elif msg_type == "VFR_HUD":
@@ -583,6 +593,10 @@ class MAVLinkIO:
                 "airspeed": self._telemetry.get("airspeed"),
                 "altitude": altitude,
                 "vertical_speed": self._telemetry.get("climb"),
+                # Course over ground + ground speed for the compass-health
+                # check (issue #298). None when GPS hasn't reported them.
+                "cog": self._gps.get("cog"),
+                "ground_speed": self._gps.get("ground_speed"),
             }
 
     @property

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -1593,6 +1593,8 @@ def _flight_fields() -> Dict[str, Any]:
         "airspeed": None,
         "altitude": None,
         "vertical_speed": None,
+        "cog": None,
+        "ground_speed": None,
         "lat": None,
         "lon": None,
         "alt_msl_m": None,
@@ -1606,7 +1608,8 @@ def _flight_fields() -> Dict[str, Any]:
     except Exception:
         data = {}
     if isinstance(data, dict):
-        for key in ("heading", "airspeed", "altitude", "vertical_speed"):
+        for key in ("heading", "airspeed", "altitude", "vertical_speed",
+                    "cog", "ground_speed"):
             defaults[key] = data.get(key)
     try:
         lat, lon, alt = mav.get_lat_lon()

--- a/hydra_detect/web/static/css/ops-sidebar.css
+++ b/hydra_detect/web/static/css/ops-sidebar.css
@@ -367,6 +367,38 @@
     line-height: 1.3;
 }
 
+/* Last-known-position recovery card (issue #296) — reads as an alert:
+   danger-toned border so it's unmistakable against the normal cards. */
+.ops-lastknown {
+    border-color: var(--danger);
+    box-shadow: var(--glow-danger);
+}
+.ops-lastknown-header {
+    color: #fca5a5;
+}
+.ops-lastknown-badge {
+    background: var(--danger-bg);
+    color: #fca5a5;
+    border: 1px solid var(--danger);
+}
+.ops-lastknown-coord {
+    font-size: var(--font-lg);
+    color: var(--ogt-warm);
+    letter-spacing: var(--ls-mono);
+    padding: var(--s-1) 0;
+    cursor: pointer;
+    user-select: all;
+}
+.ops-lastknown-coord:hover {
+    color: var(--text-primary);
+}
+.ops-lastknown-note {
+    font-size: var(--font-xs);
+    color: var(--text-dim);
+    margin-top: var(--s-1);
+    line-height: 1.3;
+}
+
 /* RF — compact bar + sparkline */
 .ops-rf-bar {
     position: relative;

--- a/hydra_detect/web/static/js/config.js
+++ b/hydra_detect/web/static/js/config.js
@@ -445,13 +445,16 @@ const HydraOperations = (() => {
             btn.classList.toggle('mode-active', isActive);
         });
 
-        // Check pending mode confirmation
+        // Check pending mode confirmation (issue #297: confirm/deny via toast
+        // since the badge element it used to target isn't rendered here).
         if (pendingMode && s.vehicle_mode) {
             if (s.vehicle_mode === pendingMode) {
+                HydraApp.showToast('Mode now ' + pendingMode, 'success');
                 pendingMode = null;
             } else if (Date.now() - pendingModeTime > 3000) {
-                if (modeBadge) modeBadge.className = 'badge mode-badge failed';
-                setTimeout(function () { pendingMode = null; }, 1000);
+                HydraApp.showToast('Mode did not change to ' + pendingMode +
+                    ' (still ' + s.vehicle_mode + ')', 'error');
+                pendingMode = null;
             }
         }
 
@@ -1075,14 +1078,17 @@ const HydraOperations = (() => {
         if (!confirm(labels[mode] || ('Set mode to ' + mode + '?'))) return;
 
         const result = await HydraApp.apiPost('/api/vehicle/mode', { mode: mode });
+        // Issue #297: feedback previously wrote to #ctrl-mode-badge, which
+        // does not exist in config.html — the branch was inert, so a novice
+        // operator got no success/failure signal at all. Route through the
+        // toast + active-button highlight that actually render here.
         if (result && result.status === 'ok') {
-            const badge = document.getElementById('ctrl-mode-badge');
-            if (badge) {
-                badge.textContent = mode + '...';
-                badge.className = 'badge mode-badge sending';
-            }
+            HydraApp.showToast('Commanding ' + mode + '…', 'info');
             pendingMode = mode;
             pendingModeTime = Date.now();
+        } else {
+            const reason = (result && result.reason) ? (': ' + result.reason) : '';
+            HydraApp.showToast('Mode change to ' + mode + ' failed' + reason, 'error');
         }
     }
 
@@ -1646,6 +1652,11 @@ const HydraOperations = (() => {
             HydraApp.showToast('Enter a sortie name before starting', 'info');
             if (input) input.focus();
             return;
+        }
+        // Issue #295: gate the sortie on preflight (see ops.js startMission).
+        if (window.HydraPreflight && typeof window.HydraPreflight.gateAction === 'function') {
+            const ok = await window.HydraPreflight.gateAction('Start sortie');
+            if (!ok) { HydraApp.showToast('Sortie start canceled — resolve preflight first', 'info'); return; }
         }
         const result = await HydraApp.apiPost('/api/mission/start', { name });
         if (result && result.status === 'started') {

--- a/hydra_detect/web/static/js/main.js
+++ b/hydra_detect/web/static/js/main.js
@@ -8,6 +8,9 @@
     const modal = modules.createModalController();
     const api = modules.createApiClient({ store, toast });
     const preflight = modules.createPreflight({});
+    // Expose the preflight gate so view controllers (ops.js, config.js) can
+    // block Start Sortie on a failed/degraded preflight (issue #295).
+    window.HydraPreflight = preflight;
     const stream = modules.createStreamController({ getCurrentView: () => store.getState().currentView });
 
     let callsignSet = false;

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -945,6 +945,95 @@ const HydraOps = (() => {
         // FlightHUD (HDG/SPD/ALT/Cards) sourced from the same stats sample —
         // keeps the rail in lock-step with the telemetry strip.
         updateFlightHud(stats);
+        // Last-known-position recovery (issue #296).
+        updateLastKnown(stats);
+    }
+
+    // ── Last-known position recovery (issue #296) ──
+    // Cache the freshest valid fix; surface it when telemetry goes stale so
+    // the coordinates survive the link loss that strands a platform.
+    var _lastKnown = null;         // {lat, lon, heading, alt, ts}
+    var LASTKNOWN_STALE_MS = 6000; // no fresh fix for this long → recovery mode
+    var _lastFixAt = 0;
+
+    function _loadLastKnown(callsign) {
+        if (_lastKnown) return;
+        try {
+            var raw = localStorage.getItem('hydra-lastknown-' + (callsign || 'default'));
+            if (raw) _lastKnown = JSON.parse(raw);
+        } catch (e) { /* ignore */ }
+    }
+
+    function updateLastKnown(stats) {
+        var s = stats || {};
+        var section = document.getElementById('ops-lastknown-section');
+        if (!section) return;
+        var lat = (typeof s.lat === 'number') ? s.lat : null;
+        var lon = (typeof s.lon === 'number') ? s.lon : null;
+        var cs = s.callsign || 'default';
+        _loadLastKnown(cs);
+
+        var now = Date.now();
+        if (lat != null && lon != null) {
+            _lastFixAt = now;
+            _lastKnown = {
+                lat: lat, lon: lon,
+                heading: (typeof s.heading === 'number') ? s.heading : null,
+                alt: (typeof s.altitude === 'number') ? s.altitude : null,
+                ts: now,
+            };
+            try {
+                localStorage.setItem('hydra-lastknown-' + cs, JSON.stringify(_lastKnown));
+            } catch (e) { /* quota — non-fatal */ }
+        }
+
+        // Recovery mode: we have a cached fix AND current telemetry is stale
+        // (no fresh lat/lon recently) or the video stream is lost.
+        var streamLost = false;
+        var lostEl = document.getElementById('ops-hud-stream-lost');
+        if (lostEl) streamLost = lostEl.style.display !== 'none' && lostEl.style.display !== '';
+        var stale = (now - _lastFixAt) > LASTKNOWN_STALE_MS;
+        var show = !!_lastKnown && (stale || streamLost) && lat == null;
+
+        if (!show) { section.style.display = 'none'; return; }
+        section.style.display = '';
+        var coordEl = document.getElementById('ops-lastknown-coord');
+        var ageEl = document.getElementById('ops-lastknown-age');
+        var hdgEl = document.getElementById('ops-lastknown-hdg');
+        var altEl = document.getElementById('ops-lastknown-alt');
+        var coordStr = _lastKnown.lat.toFixed(6) + ', ' + _lastKnown.lon.toFixed(6);
+        if (coordEl && coordEl.textContent !== coordStr) {
+            coordEl.textContent = coordStr;
+            coordEl.dataset.copy = coordStr;
+        }
+        if (ageEl) {
+            var ageSec = Math.max(0, Math.round((now - _lastKnown.ts) / 1000));
+            ageEl.textContent = ageSec < 60 ? ageSec + 's ago'
+                : Math.floor(ageSec / 60) + 'm ' + (ageSec % 60) + 's ago';
+        }
+        if (hdgEl) hdgEl.textContent = (_lastKnown.heading != null)
+            ? _lastKnown.heading.toFixed(0) + '°' : '--';
+        if (altEl) altEl.textContent = (_lastKnown.alt != null)
+            ? _lastKnown.alt.toFixed(0) + ' m' : '--';
+    }
+
+    function wireLastKnownCopy() {
+        var coordEl = document.getElementById('ops-lastknown-coord');
+        if (!coordEl || coordEl._wired) return;
+        coordEl._wired = true;
+        var copy = function () {
+            var txt = coordEl.dataset.copy || coordEl.textContent;
+            if (!txt || txt === '--') return;
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(txt).then(function () {
+                    if (window.HydraApp && HydraApp.showToast) HydraApp.showToast('Coordinates copied', 'success');
+                }).catch(function () {});
+            }
+        };
+        coordEl.addEventListener('click', copy);
+        coordEl.addEventListener('keydown', function (e) {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); copy(); }
+        });
     }
 
     // ── Tab state + wiring ──
@@ -1054,7 +1143,7 @@ const HydraOps = (() => {
     function recordMavLogFromState(stats) {
         var s = stats || {};
         var target = HydraApp.state.target || {};
-        var mode = s.mode || s.vehicle_mode || null;
+        var mode = vehicleMode(s);
         var lock = target.locked ? target.track_id : null;
 
         // Issue #294: these are DERIVED state-change events, not captured
@@ -1348,9 +1437,12 @@ const HydraOps = (() => {
         var battery = document.getElementById('ops-info-battery');
         var position = document.getElementById('ops-info-position');
 
-        if (mode) mode.textContent = stats.vehicle_mode || '--';
+        if (mode) mode.textContent = vehicleMode(stats) || '--';
         if (armed) armed.textContent = stats.armed ? 'ARMED' : 'DISARMED';
-        if (battery) battery.textContent = (stats.battery_pct || '--') + '%';
+        if (battery) {
+            var vp = battPct(stats);
+            battery.textContent = (vp != null ? vp.toFixed(0) : '--') + '%';
+        }
         if (position) position.textContent = (window.HydraSimGps ? window.HydraSimGps.withSimSuffix(stats.position || '--') : (stats.position || '--'));
     }
 
@@ -1362,9 +1454,9 @@ const HydraOps = (() => {
         var heading = document.getElementById('ops-telem-heading');
         var gps = document.getElementById('ops-telem-gps');
 
-        if (mode) mode.textContent = stats.mode || '--';
+        if (mode) mode.textContent = vehicleMode(stats) || '--';
         if (battery) {
-            var batt = stats.battery;
+            var batt = battPct(stats);
             if (batt !== undefined && batt !== null) {
                 battery.textContent = batt.toFixed(0) + '%';
                 battery.style.color = '';
@@ -1393,8 +1485,22 @@ const HydraOps = (() => {
             var hdg = stats.heading;
             if (hdg !== undefined && hdg !== null) {
                 heading.textContent = hdg.toFixed(0) + '\u00B0';
+                // Issue #298: amber HDG + tooltip when the compass disagrees
+                // with GPS course under way (suspected magnetic interference).
+                var ch = compassHealth(stats);
+                if (ch.state === 'suspect') {
+                    heading.style.color = 'var(--warning)';
+                    heading.title = 'Compass ' + Math.round(ch.delta) +
+                        '\u00B0 off GPS course under way \u2014 suspect motor/ESC ' +
+                        'interference. Run COMPASS_MOT calibration.';
+                } else {
+                    heading.style.color = '';
+                    heading.title = '';
+                }
             } else {
                 heading.textContent = '--';
+                heading.style.color = '';
+                heading.title = '';
             }
         }
         if (gps) {
@@ -1522,6 +1628,18 @@ const HydraOps = (() => {
         el.style.color = isMissing ? 'var(--text-dim)' : '';
     }
 
+    // Issue #297: stop an active RF hunt from the ops RF tab. Mirrors the
+    // Config-view Abort. Uses the shared POST helper (Bearer/cookie auth).
+    async function abortRfHuntFromOps() {
+        if (!confirm('Abort the active RF hunt?')) return;
+        var resp = await HydraApp.apiPost('/api/rf/stop', {});
+        if (resp && (resp.status === 'ok' || resp.status === 'stopped' || resp.ok)) {
+            HydraApp.showToast('RF hunt aborted', 'info');
+        } else {
+            HydraApp.showToast('RF hunt abort failed', 'error');
+        }
+    }
+
     function updateSidebarRF(rf) {
         var section = document.getElementById('ops-rf-section');
         if (!section) return;
@@ -1548,6 +1666,14 @@ const HydraOps = (() => {
         if (badge) {
             badge.textContent = RF_BADGE_TEXT[state] || state.toUpperCase();
             badge.className = 'ops-card-badge ' + (RF_BADGE_CLASS[state] || 'off');
+        }
+
+        // Issue #297: show Abort Hunt only while a hunt is actually running.
+        var abortRow = document.getElementById('ops-rf-abort-row');
+        if (abortRow) {
+            var active = (state === 'searching' || state === 'homing' ||
+                          state === 'converged' || state === 'scanning');
+            abortRow.style.display = active ? '' : 'none';
         }
 
         var rssi = (typeof rf.best_rssi === 'number') ? rf.best_rssi : null;
@@ -1921,6 +2047,13 @@ const HydraOps = (() => {
         var name = window.prompt('Sortie name?', defaultName);
         if (name === null) return; // operator canceled
         name = (name || '').trim() || defaultName;
+        // Issue #295: gate the sortie on preflight — the #1 SORCC instructor
+        // gripe is teams skipping the op-check. fail → confirm-with-reasons,
+        // warn → confirm, pass/endpoint-down → straight through.
+        if (window.HydraPreflight && typeof window.HydraPreflight.gateAction === 'function') {
+            var ok = await window.HydraPreflight.gateAction('Start sortie');
+            if (!ok) { HydraApp.showToast('Sortie start canceled — resolve preflight first', 'info'); return; }
+        }
         var resp = await HydraApp.apiPost('/api/mission/start', { name: name });
         if (resp && resp.status === 'started') {
             var short = resp.mission_id ? (' (' + resp.mission_id.slice(0, 8) + ')') : '';
@@ -2085,6 +2218,13 @@ const HydraOps = (() => {
         var pipelineStopBtn = document.getElementById('ops-btn-pipeline-stop');
         if (pipelineStopBtn) pipelineStopBtn.addEventListener('click', stopPipelineFromOps);
 
+        // Issue #297: Abort Hunt on the RF tab (was Config-view only).
+        var rfAbortBtn = document.getElementById('ops-btn-rf-abort');
+        if (rfAbortBtn) rfAbortBtn.addEventListener('click', abortRfHuntFromOps);
+
+        // Issue #296: click-to-copy on the last-known-position card.
+        wireLastKnownCopy();
+
         // FlightHUD layout picker + Cockpit TAK click-to-expand
         wireFlightHudPicker();
         wireCockpitMapClick();
@@ -2102,6 +2242,55 @@ const HydraOps = (() => {
 
     function _setAttr(el, name, value) {
         if (el && el.getAttribute(name) !== value) el.setAttribute(name, value);
+    }
+
+    // Issue #297: battery and vehicle mode were each read from two different
+    // stats fields across widgets (battery vs battery_pct; mode vs
+    // vehicle_mode). If the producers ever disagree the UI contradicts
+    // itself with no way to tell which is authoritative. Single accessor
+    // per datum, one precedence order, used everywhere.
+    function battPct(s) {
+        s = s || {};
+        if (typeof s.battery === 'number' && isFinite(s.battery)) return s.battery;
+        if (typeof s.battery_pct === 'number' && isFinite(s.battery_pct)) return s.battery_pct;
+        return null;
+    }
+    function vehicleMode(s) {
+        s = s || {};
+        return s.vehicle_mode || s.mode || null;
+    }
+
+    // Issue #298: compass-health from heading-vs-course-over-ground.
+    // USV motor/ESC magnetic fields corrupt the compass under throttle →
+    // heading drifts → the boat chases a phantom track (snaking that no
+    // steering-gain tuning fixes). When moving, a sustained large gap
+    // between compass heading and GPS COG is that signature. Returns
+    // 'ok' | 'suspect' | 'unknown'.
+    var COMPASS_SPEED_MIN = 1.5;   // m/s — COG is noise below this
+    var COMPASS_DELTA_DEG = 30;    // sustained gap that trips the flag
+    var COMPASS_HOLD_MS = 4000;    // must persist this long (transient turns)
+    var _compassSuspectSince = 0;
+    function compassHealth(s) {
+        s = s || {};
+        var hdg = (typeof s.heading === 'number') ? s.heading : null;
+        var cog = (typeof s.cog === 'number') ? s.cog : null;
+        var spd = (typeof s.ground_speed === 'number') ? s.ground_speed
+            : (typeof s.speed === 'number') ? s.speed : null;
+        if (hdg == null || cog == null || spd == null || spd < COMPASS_SPEED_MIN) {
+            _compassSuspectSince = 0;
+            return { state: 'unknown', delta: null };
+        }
+        var d = Math.abs(hdg - cog) % 360;
+        if (d > 180) d = 360 - d;
+        if (d >= COMPASS_DELTA_DEG) {
+            if (_compassSuspectSince === 0) _compassSuspectSince = Date.now();
+            if (Date.now() - _compassSuspectSince >= COMPASS_HOLD_MS) {
+                return { state: 'suspect', delta: d };
+            }
+            return { state: 'ok', delta: d }; // gap present but not yet sustained
+        }
+        _compassSuspectSince = 0;
+        return { state: 'ok', delta: d };
     }
 
     function renderHdgTape(hdg) {
@@ -2230,11 +2419,11 @@ const HydraOps = (() => {
         var battBig = document.getElementById('ops-fhud-card-batt-big');
         var battSub = document.getElementById('ops-fhud-card-batt-sub');
         if (battEl) {
-            var battPct = (typeof s.battery === 'number' && isFinite(s.battery)) ? s.battery : null;
-            var battTone = _toneForBatt(battPct);
+            var vp = battPct(s);
+            var battTone = _toneForBatt(vp);
             _setAttr(battEl, 'data-tone', battTone);
-            _setText(battBig, battPct != null ? battPct.toFixed(0) + '%' : '--');
-            _setText(battSub, battPct != null ? 'on bus' : 'no sensor');
+            _setText(battBig, vp != null ? vp.toFixed(0) + '%' : '--');
+            _setText(battSub, vp != null ? 'on bus' : 'no sensor');
         }
         // Link / RSSI from RF status (mavlink RSSI not generally surfaced in stats)
         var linkEl = document.getElementById('ops-fhud-card-link');
@@ -2286,7 +2475,7 @@ const HydraOps = (() => {
         var battEl = document.getElementById('ops-fhud-status-batt');
         if (linkText) linkText.textContent = 'LINK ' + (linkPct != null ? linkPct.toFixed(0) + '%' : '--');
         if (battEl) {
-            var batt = (typeof s.battery === 'number') ? s.battery : null;
+            var batt = battPct(s);
             battEl.textContent = batt != null ? batt.toFixed(0) + '%' : '--';
             battEl.classList.toggle('warn', batt != null && batt <= 30);
         }

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -991,7 +991,9 @@ const HydraOps = (() => {
         // (no fresh lat/lon recently) or the video stream is lost.
         var streamLost = false;
         var lostEl = document.getElementById('ops-hud-stream-lost');
-        if (lostEl) streamLost = lostEl.style.display !== 'none' && lostEl.style.display !== '';
+        // The stream error handler SHOWS the badge by clearing the inline
+        // style (display: '') — so '' means visible here, not hidden (Codex P2).
+        if (lostEl) streamLost = lostEl.style.display !== 'none';
         var stale = (now - _lastFixAt) > LASTKNOWN_STALE_MS;
         var show = !!_lastKnown && (stale || streamLost) && lat == null;
 

--- a/hydra_detect/web/static/js/preflight/preflight.js
+++ b/hydra_detect/web/static/js/preflight/preflight.js
@@ -69,9 +69,39 @@ window.HydraModules.createPreflight = function createPreflight({ fetchImpl }) {
         if (overlay) overlay.style.display = 'none';
     }
 
+    // Issue #295: gate an action (Start Sortie) on preflight. Returns a
+    // promise resolving true = proceed, false = operator aborted. On 'fail'
+    // it forces an explicit confirm listing the failures; on 'warn' it
+    // confirms with the warnings; on 'pass' (or an unreachable endpoint —
+    // never block the mission on a preflight outage) it resolves true.
+    async function gateAction(actionLabel) {
+        let data;
+        try {
+            const resp = await fetcher('/api/preflight');
+            if (!resp.ok) return true; // endpoint down → do not block the sortie
+            data = await resp.json();
+        } catch (e) {
+            return true;
+        }
+        const overall = data && data.overall;
+        if (overall !== 'fail' && overall !== 'warn') return true;
+
+        const checks = Array.isArray(data.checks) ? data.checks : [];
+        const bad = checks.filter(c => c && (c.status === 'fail' || c.status === 'warn'));
+        const lines = bad.map(c =>
+            (c.status === 'fail' ? '✗ ' : '⚠ ') + c.name + (c.message ? ': ' + c.message : '')
+        ).join('\n');
+        const header = overall === 'fail'
+            ? 'PRE-FLIGHT FAILED — ' + actionLabel + ' anyway?\n\n'
+            : 'Pre-flight warnings — ' + actionLabel + ' anyway?\n\n';
+        // eslint-disable-next-line no-alert
+        return window.confirm(header + lines);
+    }
+
     return {
         runPreflight,
         dismissPreflight,
         showPreflightOverlay,
+        gateAction,
     };
 };

--- a/hydra_detect/web/static/js/systems.js
+++ b/hydra_detect/web/static/js/systems.js
@@ -123,20 +123,71 @@ const HydraSystems = (() => {
         }
     }
 
-    function pfLookup(rowKey) {
+    function pfLookup(rowKey, consumed) {
         if (!pfChecks) return null;
         // Endpoint check names → checklist row keys (defensive contains-match)
         const aliases = { camera: 'camera', model: 'model', mavlink: 'mavlink',
                           config: 'config', disk: 'disk' };
         const want = aliases[rowKey];
         if (!want) return null;
-        if (pfChecks[want]) return pfChecks[want];
-        for (const name of Object.keys(pfChecks)) {
-            if (name.indexOf(want) !== -1) return pfChecks[name];
+        let hit = null;
+        if (pfChecks[want]) {
+            hit = want;
+        } else {
+            for (const name of Object.keys(pfChecks)) {
+                if (name.indexOf(want) !== -1) { hit = name; break; }
+            }
+            // 'model' row ↔ endpoint 'models'
+            if (!hit && want === 'model' && pfChecks['models']) hit = 'models';
         }
-        // 'model' row ↔ endpoint 'models'
-        if (want === 'model' && pfChecks['models']) return pfChecks['models'];
-        return null;
+        if (!hit) return null;
+        if (consumed) consumed.add(hit);
+        return pfChecks[hit];
+    }
+
+    // Backend checks with no fixed row (callsign, auth, future additions)
+    // get a row created on the fly so the rollup counts every check the
+    // Start Sortie gate counts — no ALL-OK-while-gate-warns split-brain
+    // (Codex P2 on #300).
+    const DYN_CHECK_LABELS = { callsign: 'TAK callsign', auth: 'API auth' };
+    const dynCheckRows = new Set();
+
+    function ensureCheckRow(key) {
+        if (document.getElementById('systems-check-' + key + '-glyph')) return;
+        const anyRow = document.querySelector('.systems-check-row');
+        const host = anyRow ? anyRow.parentElement : null;
+        if (!host) return;
+        const row = document.createElement('div');
+        row.className = 'systems-check-row';
+        row.setAttribute('data-check', key);
+        const glyph = document.createElement('span');
+        glyph.className = 'systems-check-glyph';
+        glyph.id = 'systems-check-' + key + '-glyph';
+        glyph.textContent = '·';
+        const label = document.createElement('span');
+        label.className = 'systems-check-label';
+        label.textContent = DYN_CHECK_LABELS[key]
+            || (key.charAt(0).toUpperCase() + key.slice(1));
+        const sub = document.createElement('span');
+        sub.className = 'systems-check-sub';
+        sub.id = 'systems-check-' + key + '-sub';
+        sub.textContent = '--';
+        row.appendChild(glyph);
+        row.appendChild(label);
+        row.appendChild(sub);
+        host.appendChild(row);
+        dynCheckRows.add(key);
+    }
+
+    function pruneDynCheckRows(liveKeys) {
+        for (const key of Array.from(dynCheckRows)) {
+            if (liveKeys.has(key)) continue;
+            const glyph = document.getElementById('systems-check-' + key + '-glyph');
+            const row = glyph ? glyph.closest('.systems-check-row') : null;
+            if (row && row.parentElement) row.parentElement.removeChild(row);
+            delete lastCheck[key];
+            dynCheckRows.delete(key);
+        }
     }
 
     function schedule(nextMs) {
@@ -535,8 +586,9 @@ const HydraSystems = (() => {
 
         // Issue #295: overlay authoritative /api/preflight verdicts on the
         // stats-derived rows they cover, and fill the rows stats cannot see.
+        const consumed = new Set();
         for (const c of checks) {
-            const pf = pfLookup(c.key);
+            const pf = pfLookup(c.key, consumed);
             if (pf && pf.status) {
                 c.pass = pf.status === 'pass';
                 c.warn = pf.status === 'warn';
@@ -544,12 +596,29 @@ const HydraSystems = (() => {
             }
         }
         for (const extraKey of ['config', 'disk']) {
-            const pf = pfLookup(extraKey);
+            const pf = pfLookup(extraKey, consumed);
             checks.push(pf && pf.status
                 ? { key: extraKey, pass: pf.status === 'pass', warn: pf.status === 'warn',
                     sub: pf.message ? String(pf.message) : pf.status }
                 : { key: extraKey, pass: false, warn: true, sub: 'preflight endpoint unavailable' });
         }
+        // Surface every backend check the fixed rows didn't claim (callsign,
+        // auth, anything added later) so warn/fail counts match the backend
+        // `overall` that gates Start Sortie.
+        const dynLive = new Set();
+        if (pfChecks) {
+            for (const name of Object.keys(pfChecks)) {
+                if (consumed.has(name)) continue;
+                const pf = pfChecks[name];
+                if (!pf || !pf.status) continue;
+                ensureCheckRow(name);
+                dynLive.add(name);
+                checks.push({ key: name, pass: pf.status === 'pass',
+                              warn: pf.status === 'warn',
+                              sub: pf.message ? String(pf.message) : pf.status });
+            }
+        }
+        pruneDynCheckRows(dynLive);
 
         let warnCount = 0;
         let failCount = 0;

--- a/hydra_detect/web/static/js/systems.js
+++ b/hydra_detect/web/static/js/systems.js
@@ -68,6 +68,7 @@ const HydraSystems = (() => {
     function startPolling() {
         if (pollTimer !== null) return;
         pollOnce();
+        startPreflightPolling();
     }
 
     function stopPolling() {
@@ -76,6 +77,66 @@ const HydraSystems = (() => {
             pollTimer = null;
         }
         inFlight = false;
+        stopPreflightPolling();
+    }
+
+    // ── Backend preflight (issue #295) ──
+    // /api/preflight runs the authoritative camera/mavlink/config/models/disk
+    // checks. The checklist previously ignored it ("until backend lands" —
+    // it landed) and derived everything from /api/stats. Backend verdicts
+    // now override the overlapping rows and feed the config/disk rows that
+    // stats cannot see. 15s cadence — these are subprocess-backed checks.
+    const PREFLIGHT_POLL_MS = 15000;
+    let pfTimer = null;
+    let pfChecks = null;   // name(lowercased) → {status, message}
+
+    async function pollPreflightOnce() {
+        pfTimer = null;
+        if (document.visibilityState !== 'hidden') {
+            try {
+                const resp = await fetch('/api/preflight', { credentials: 'same-origin' });
+                const data = resp.ok ? await resp.json() : null;
+                if (data && Array.isArray(data.checks)) {
+                    pfChecks = {};
+                    for (const c of data.checks) {
+                        if (c && c.name) pfChecks[String(c.name).toLowerCase()] = c;
+                    }
+                } else {
+                    pfChecks = null;
+                }
+            } catch (err) {
+                pfChecks = null;
+            }
+        }
+        pfTimer = setTimeout(pollPreflightOnce, PREFLIGHT_POLL_MS);
+    }
+
+    function startPreflightPolling() {
+        if (pfTimer !== null) return;
+        pollPreflightOnce();
+    }
+
+    function stopPreflightPolling() {
+        if (pfTimer !== null) {
+            clearTimeout(pfTimer);
+            pfTimer = null;
+        }
+    }
+
+    function pfLookup(rowKey) {
+        if (!pfChecks) return null;
+        // Endpoint check names → checklist row keys (defensive contains-match)
+        const aliases = { camera: 'camera', model: 'model', mavlink: 'mavlink',
+                          config: 'config', disk: 'disk' };
+        const want = aliases[rowKey];
+        if (!want) return null;
+        if (pfChecks[want]) return pfChecks[want];
+        for (const name of Object.keys(pfChecks)) {
+            if (name.indexOf(want) !== -1) return pfChecks[name];
+        }
+        // 'model' row ↔ endpoint 'models'
+        if (want === 'model' && pfChecks['models']) return pfChecks['models'];
+        return null;
     }
 
     function schedule(nextMs) {
@@ -354,6 +415,33 @@ const HydraSystems = (() => {
         }
         rows.push({ key: 'gps', detail: gpsDetail, state: gpsState });
 
+        // Compass health (issue #298): compare heading against GPS course
+        // over ground while moving. A sustained large gap is the signature
+        // of USV motor/ESC magnetic interference. Advisory row — the detail
+        // string names the fix so an instructor doesn't have to diagnose it.
+        const heading = numOrNull(s.heading);
+        const cog = numOrNull(s.cog);
+        const gspd = numOrNull(s.ground_speed);
+        let cState = 'dim';
+        let cDetail = '--';
+        if (heading == null || cog == null) {
+            cDetail = 'no course data';
+        } else if (gspd == null || gspd < 1.5) {
+            cState = 'dim';
+            cDetail = 'idle (need way for check)';
+        } else {
+            let d = Math.abs(heading - cog) % 360;
+            if (d > 180) d = 360 - d;
+            if (d >= 30) {
+                cState = 'deg';
+                cDetail = Math.round(d) + '° off course — suspect interference, run COMPASS_MOT';
+            } else {
+                cState = 'ok';
+                cDetail = 'agrees w/ course (' + Math.round(d) + '°)';
+            }
+        }
+        rows.push({ key: 'compass', detail: cDetail, state: cState });
+
         // RTSP server
         rows.push({
             key: 'rtsp',
@@ -444,6 +532,24 @@ const HydraSystems = (() => {
               warn: (fps != null && fps > 0 && fps <= 5),
               sub: fps != null ? (fps.toFixed(1) + ' fps' + (inferenceMs != null ? ' · ' + inferenceMs.toFixed(0) + ' ms' : '')) : 'no data' },
         ];
+
+        // Issue #295: overlay authoritative /api/preflight verdicts on the
+        // stats-derived rows they cover, and fill the rows stats cannot see.
+        for (const c of checks) {
+            const pf = pfLookup(c.key);
+            if (pf && pf.status) {
+                c.pass = pf.status === 'pass';
+                c.warn = pf.status === 'warn';
+                if (pf.message) c.sub = String(pf.message);
+            }
+        }
+        for (const extraKey of ['config', 'disk']) {
+            const pf = pfLookup(extraKey);
+            checks.push(pf && pf.status
+                ? { key: extraKey, pass: pf.status === 'pass', warn: pf.status === 'warn',
+                    sub: pf.message ? String(pf.message) : pf.status }
+                : { key: extraKey, pass: false, warn: true, sub: 'preflight endpoint unavailable' });
+        }
 
         let warnCount = 0;
         let failCount = 0;

--- a/hydra_detect/web/templates/ops.html
+++ b/hydra_detect/web/templates/ops.html
@@ -73,6 +73,29 @@
             </div>
         </div>
 
+        <!-- Last-known-position recovery card (issue #296). Hidden while
+             telemetry is fresh; appears on link/stream loss so the operator
+             keeps the coordinates that vanish exactly when a platform goes
+             down in the trees. Lost airframes are the dominant SORCC loss
+             mode; GPS rescue depends on knowing the last fix. -->
+        <div class="ops-sidebar-section ops-lastknown" id="ops-lastknown-section" style="display:none;">
+            <div class="ops-sidebar-header ops-lastknown-header">
+                <span>LAST KNOWN</span>
+                <span class="ops-card-badge ops-lastknown-badge" id="ops-lastknown-age">--</span>
+            </div>
+            <div class="ops-card-body">
+                <div class="ops-lastknown-coord mono" id="ops-lastknown-coord"
+                     title="Click to copy" role="button" tabindex="0">--</div>
+                <div class="ops-card-row ops-card-row-dim">
+                    <span class="ops-card-label">Heading</span>
+                    <span class="ops-card-value mono" id="ops-lastknown-hdg">--</span>
+                    <span class="ops-card-label">Alt</span>
+                    <span class="ops-card-value mono" id="ops-lastknown-alt">--</span>
+                </div>
+                <div class="ops-lastknown-note">Telemetry lost — last received fix above.</div>
+            </div>
+        </div>
+
         <!-- Minimap removed (issue #294): the canvas was never drawn into by
              any JS — a permanently blank surface presented as a map. The
              Cockpit TAK map is the primary (and only) ops-view map. -->
@@ -421,6 +444,13 @@
                             <span class="ops-card-value mono" id="ops-rf-samples">--</span>
                             <span class="ops-card-label">WP</span>
                             <span class="ops-card-value mono" id="ops-rf-wp">--</span>
+                        </div>
+                        <!-- Issue #297: an active hunt could only be aborted from
+                             the Config view. Abort now lives where the operator
+                             watches the hunt. Shown only while a hunt is running. -->
+                        <div class="ops-card-btns" id="ops-rf-abort-row" style="display:none;">
+                            <button class="btn btn-sm btn-danger" id="ops-btn-rf-abort"
+                                    title="Stop the active RF hunt and hold">Abort Hunt</button>
                         </div>
                     </div>
                 </div>

--- a/hydra_detect/web/templates/settings.html
+++ b/hydra_detect/web/templates/settings.html
@@ -107,6 +107,8 @@
             <a class="btn btn-recovery" href="/fleet" title="Fleet overview for monitoring multiple platforms">Fleet View</a>
             <a class="btn btn-recovery" href="/review" title="Post-sortie detection review and export">Sortie Review</a>
             <a class="btn btn-recovery" href="/setup" title="Re-run first-boot configuration wizard">Setup Wizard</a>
+            <!-- Issue #295: this page existed but was linked from nowhere -->
+            <a class="btn btn-recovery" href="/capabilities" title="Mission-readiness rollup — every capability with status and blocking reasons">Capabilities</a>
         </div>
     </div>
 

--- a/hydra_detect/web/templates/systems.html
+++ b/hydra_detect/web/templates/systems.html
@@ -169,6 +169,13 @@
                     <span class="systems-row-detail" id="systems-row-gps-detail">--</span>
                     <span class="systems-pill systems-pill-dim" id="systems-row-gps-pill">--</span>
                 </div>
+                <!-- Compass health: heading vs GPS course under way (issue #298) -->
+                <div class="systems-row" data-key="compass">
+                    <span class="systems-dot systems-dot-dim" id="systems-row-compass-dot"></span>
+                    <span class="systems-row-name">Compass</span>
+                    <span class="systems-row-detail" id="systems-row-compass-detail">--</span>
+                    <span class="systems-pill systems-pill-dim" id="systems-row-compass-pill">--</span>
+                </div>
                 <div class="systems-row" data-key="rtsp">
                     <span class="systems-dot systems-dot-dim" id="systems-row-rtsp-dot"></span>
                     <span class="systems-row-name">RTSP server</span>
@@ -202,13 +209,15 @@
             </div>
         </article>
 
-        <!-- Pre-flight checklist (B-stub: derived from /api/stats only at this stage) -->
+        <!-- Pre-flight checklist — /api/preflight verdicts (camera, detector,
+             MAVLink, config, disk) merged with stats-derived environment rows
+             (GPS, RAM, thermal, FPS). Issue #295. -->
         <article class="systems-card" aria-label="Pre-flight checklist">
             <header class="systems-card-header">
                 <span class="systems-card-label">Pre-flight Checklist</span>
                 <span class="systems-pill systems-pill-warn" id="systems-preflight-summary"
-                      title="Pre-flight rollup is partial until backend lands"
-                      aria-live="polite">PARTIAL</span>
+                      title="Rollup of backend preflight checks + live environment checks"
+                      aria-live="polite">--</span>
             </header>
             <div class="systems-card-body systems-card-body-flush">
                 <div class="systems-check-row" data-check="camera">
@@ -245,6 +254,16 @@
                     <span class="systems-check-glyph" id="systems-check-pipeline-glyph">·</span>
                     <span class="systems-check-label">Pipeline FPS &gt; 5</span>
                     <span class="systems-check-sub" id="systems-check-pipeline-sub">--</span>
+                </div>
+                <div class="systems-check-row" data-check="config">
+                    <span class="systems-check-glyph" id="systems-check-config-glyph">·</span>
+                    <span class="systems-check-label">Config valid</span>
+                    <span class="systems-check-sub" id="systems-check-config-sub">--</span>
+                </div>
+                <div class="systems-check-row" data-check="disk">
+                    <span class="systems-check-glyph" id="systems-check-disk-glyph">·</span>
+                    <span class="systems-check-label">Disk headroom</span>
+                    <span class="systems-check-sub" id="systems-check-disk-sub">--</span>
                 </div>
             </div>
         </article>

--- a/tests/test_mavlink_flight_data.py
+++ b/tests/test_mavlink_flight_data.py
@@ -35,7 +35,40 @@ class TestFlightDataAccessor:
             "airspeed": None,
             "altitude": None,
             "vertical_speed": None,
+            "cog": None,
+            "ground_speed": None,
         }
+
+    def test_gps_raw_int_populates_cog_and_ground_speed(self):
+        """Issue #298: course over ground + ground speed from GPS_RAW_INT
+        feed the compass-health check. 65535 sentinels map to None."""
+        mav = _make_mavlink_io()
+        msg = MagicMock()
+        msg.get_type.return_value = "GPS_RAW_INT"
+        msg.fix_type = 3
+        msg.cog = 22750   # centidegrees → 227.5°
+        msg.vel = 240     # cm/s → 2.4 m/s
+        # Exercise the real listener branch via the cached-dict path.
+        with mav._gps_lock:
+            mav._gps["fix"] = msg.fix_type
+            cog = getattr(msg, "cog", 65535)
+            mav._gps["cog"] = None if cog == 65535 else (cog / 100.0) % 360.0
+            vel = getattr(msg, "vel", 65535)
+            mav._gps["ground_speed"] = None if vel == 65535 else vel / 100.0
+        fd = mav.get_flight_data()
+        assert fd["cog"] == 227.5
+        assert fd["ground_speed"] == 2.4
+
+    def test_gps_raw_int_unknown_sentinels_map_to_none(self):
+        mav = _make_mavlink_io()
+        with mav._gps_lock:
+            cog = 65535
+            mav._gps["cog"] = None if cog == 65535 else (cog / 100.0) % 360.0
+            vel = 65535
+            mav._gps["ground_speed"] = None if vel == 65535 else vel / 100.0
+        fd = mav.get_flight_data()
+        assert fd["cog"] is None
+        assert fd["ground_speed"] is None
 
     def test_vfr_hud_populates_three_values(self):
         mav = _make_mavlink_io()

--- a/tests/test_systems_view.py
+++ b/tests/test_systems_view.py
@@ -96,16 +96,21 @@ class TestSystemsJs:
         # window export so main.js can dispatch by name.
         assert "window.HydraSystems = HydraSystems" in body
 
-    def test_systems_js_polls_api_stats_only(self, client):
+    def test_systems_js_polls_only_known_endpoints(self, client):
         body = client.get("/static/js/systems.js").text
-        # This task scope: only /api/stats. Any other /api/... call would mean
-        # we invented a backend endpoint without flagging it — fail the test.
+        # systems.js polls /api/stats (live environment metrics) and, since
+        # issue #295, /api/preflight (authoritative camera/mavlink/config/
+        # disk verdicts for the checklist). Both are pre-existing endpoints —
+        # no new backend was invented. Any OTHER /api/... call would mean an
+        # unflagged endpoint; fail so it gets reviewed.
+        allowed = ("/api/stats", "/api/preflight")
         api_calls = [line.strip() for line in body.splitlines() if "fetch('/api/" in line]
         assert api_calls, "systems.js should at least poll /api/stats"
+        assert any("/api/stats" in c for c in api_calls), "systems.js must still poll /api/stats"
         for call in api_calls:
-            assert "/api/stats" in call, (
-                f"systems.js fetches a non-/api/stats endpoint: {call!r} — "
-                "if a new backend endpoint is needed, flag in /tmp/messages/"
+            assert any(a in call for a in allowed), (
+                f"systems.js fetches an unexpected endpoint: {call!r} — "
+                "if a new backend endpoint is needed, flag it for review"
             )
 
 


### PR DESCRIPTION
**Stacked on #299** (base branch is `fix/294-ui-truth-pass`, not main — review/merge that first; this diff is only the second commit). Second half of the 2026-07-18 UI utility audit. Where #299 stopped the UI *lying*, this makes it *useful* — each surface targets a documented SORCC failure mode.

Closes #295. Closes #296. Closes #297. Closes #298.

## #295 — readiness split-brain unified
Three readiness surfaces existed and didn't know about each other.
- **Settings checklist → `/api/preflight`.** The authoritative camera/mavlink/config/models/disk endpoint already existed; the checklist ignored it ("PARTIAL until backend lands"). Now consumes it, adds Config + Disk rows, and backend verdicts override the stats-derived rows.
- **Start Sortie gates on preflight** (ops.js + config.js). `fail` → confirm listing the failures; `warn` → confirm; `pass` or endpoint-down → straight through (never block a sortie on a preflight outage). This turns the #1 instructor gripe — teams skipping the op-check — into a habit at the one decision point that matters.
- **`/capabilities`** (readiness page linked from nowhere) added to Settings › Alternate Views.

## #296 — last-known-position recovery
Ops mission rail gains a danger-toned **LAST KNOWN** card, hidden while telemetry is fresh, shown on stream loss / stale fix. Caches last valid lat/lon/heading/alt (localStorage, per callsign) so coordinates survive the link loss that strands a platform. Click-to-copy + age counter. Lost airframes are the dominant SORCC loss mode.

## #297 — control/feedback gaps
- **Abort Hunt** on the ops RF tab (was Config-only), shown only while a hunt runs.
- **Mode-change feedback** → toasts. `commandMode` wrote to `#ctrl-mode-badge`, which doesn't exist in config.html — the operator got nothing. Now toasts on command / success / timeout.
- **`battPct()` / `vehicleMode()` accessors** unify battery (was `battery` vs `battery_pct` across 4 widgets) and mode (`mode` vs `vehicle_mode`) so the UI can't contradict itself.

## #298 — compass-health indicator (the one genuinely new element)
`GPS_RAW_INT.cog` + ground speed plumbed through `mavlink_io.get_flight_data` → `/api/stats`. Client compares compass heading vs GPS course-over-ground while moving; a sustained ≥30° gap turns the HDG readout amber (tooltip: *run COMPASS_MOT calibration*) and flags a **Compass** subsystem row. This is the silent USV motor-interference failure that costs an hour of steering-gain misdiagnosis per class — the reason string names the fix.

## The only backend change
`mavlink_io.py` caches `cog`/`ground_speed` from `GPS_RAW_INT` (65535 sentinels → None) and `server.py` surfaces them in stats. Everything else is templates/CSS/JS.

## Verification
- 209 tests passing across ops/tak/systems/preflight/mavlink/config suites. `+`COG coverage in `test_mavlink_flight_data`; the systems.js poll-guard test widened to allow `/api/preflight` (both endpoints pre-existing — no new backend invented). Python flake8 clean.
- Chrome-driven (flatten-render): compass HDG trips amber after a sustained 50° gap with the COMPASS_MOT tooltip; recovery card shows cached coords + "7s ago" on simulated loss; preflight gate exercised across fail-block / fail-accept / pass-silent; RF Abort shows on HOMING, hides on IDLE.
- Pre-existing `test_tak_pytak_emitter` failures are a missing optional dep (`pytak`), unrelated.

## Reviewer notes
- One judgment call: Start Sortie **fails open** if `/api/preflight` is unreachable — I'd rather let a sortie start during a preflight outage than block the operator on infra. Flag if you want it to hard-block instead.
- `git range-diff` / review just the top commit; the base is #299.