### PR TITLE
fix(security): cap request-body size — unbounded POST could OOM the Orin (#289)

### DIFF
--- a/docs/adversarial/301.md
+++ b/docs/adversarial/301.md
@@ -1,0 +1,95 @@
+# Adversarial review — PR #301 (request-body cap, #289)
+
+Scope: `web/server.py` — `_read_body_capped` helper, `_parse_json` rewire,
+4 config-admin endpoint conversions, `/api/client_error` rate-limit
+reordering, app-scoped `HTTPException` handler. Reviewed against main
+@ 3b9b902 with the fix applied.
+
+## Round 1 — pattern-match the changes
+
+**R1-a — `request._body` private-attribute cache.** The helper caches the
+assembled body on Starlette's private `_body` attr so a later
+`request.body()`/`request.json()` in the same handler still works. Verified:
+NO current handler re-reads after `_parse_json` (grep — the 4 admin
+endpoints use the helper's return value directly), so the cache is
+insurance, not load-bearing. If a future Starlette rename broke it, the
+symptom is a loud `RuntimeError: Stream consumed`, not silent corruption.
+ACCEPT.
+
+**R1-b — `HTTPException` escaping through `_parse_json` consumers.** Every
+consumer does `body = await _parse_json(request)` with NO try-block around
+the call (verified by grep: zero `try:` in the two lines preceding all 20+
+call sites), so the 413 propagates to the app handler instead of being
+swallowed into a 400/500. ACCEPT (verified, not assumed).
+
+**R1-c — Exception-handler scoping.** The handler is registered for
+`fastapi.HTTPException`. Starlette's routing 404/405 raise
+`starlette.exceptions.HTTPException`, whose MRO does not include the FastAPI
+subclass, so they keep the default `{"detail": ...}` shape. No other code in
+the app raises `fastapi.HTTPException` (grep: the import is new in this PR),
+so the handler's blast radius is exactly the new 413s. ACCEPT.
+
+**R1-d — 64 KB cap vs legitimate payloads.** The largest real bodies are
+`/api/config/import` and `/api/setup/save` full-config JSON — a few KB; both
+already enforced this exact cap (`MAX_BODY_SIZE`) pre-PR, so no legitimate
+payload regresses. The newly-capped `_parse_json` consumers all carry
+switch/mode/threshold-sized bodies. ACCEPT.
+
+**R1-e — Content-Length header parsing.** `int()` of a non-numeric header →
+`ValueError` → falls through to the streamed cap (which enforces truth). A
+negative declared value passes the header check and is again caught by the
+streamed cap. The header check is an optimization, never the enforcement
+boundary. ACCEPT.
+
+## Round 2 — counter-critique, downgrade or confirm
+
+**R2-a — This is not rate limiting.** The cap fixes memory exhaustion; a
+flood of small requests remains possible on `/api/client_error` up to its
+50/60 s window and on authed endpoints up to auth. Scope boundary of #289 —
+request-rate hardening is a different control. CONFIRM SCOPE.
+
+**R2-b — Reordering changes what counts against the rate limit.** Malformed
+or oversized posts now consume limiter slots (previously the 400 returned
+before the window append). Adversarial angle: an attacker filling a victim
+IP's window needs to share that IP — self-limiting on a WiFi AP with
+per-device addressing. Defensive direction: garbage now costs the sender
+their window. ACCEPT (behavior change is the fix working).
+
+**R2-c — Borderline-legit >64 KB error reports are now 413.** A client
+stack trace exceeding 64 KB is dropped instead of clipped. The sink already
+clips every field on push; losing a pathological report keeps the box alive
+for the class. Documented tradeoff. ACCEPT.
+
+**R2-d — Client disconnect mid-stream.** `request.stream()` raises
+`ClientDisconnect`, which propagates exactly as it did through the old
+`request.json()` path — no new failure mode, no half-processed state (the
+handler hasn't touched the body yet). ACCEPT.
+
+## Round 3 — orthogonal sweep ("what else ingests without a bound?")
+
+**R3-a — Other ingestion surfaces.** Grep for `UploadFile`, `File(`,
+`websocket` in `web/server.py`: none exist. `config_api.py` performs no
+request reads (helpers only). The session-data ZIP path is an export
+(response), not ingestion. The JSON body surface this PR caps is the
+complete request-body surface of the app. ACCEPT.
+
+**R3-b — Streamed responses unaffected.** MJPEG/status streams are
+responses; the cap sits on the request side only. ACCEPT.
+
+**R3-c — Transport-layer limits.** h11 already bounds header size (~16 KB
+default); body size was the missing app-side bound and uvicorn offers no
+knob for it — which is why the fix lives in the app. ACCEPT.
+
+**R3-d — Test honesty.** The chunked test sends a generator body
+(Transfer-Encoding: chunked, no Content-Length), proving the streamed cap
+fires with no header to check. The ordering test proves a limited IP gets
+429 on malformed JSON — the observable consequence of moving the limiter
+above the body read. ACCEPT.
+
+## Triage
+
+- Blockers: none.
+- Gates: none.
+- Follow-up: none new (request-rate hardening beyond `/api/client_error`
+  remains future work, noted in R2-a).
+- Accepted: R1-a–R1-e, R2-a–R2-d, R3-a–R3-d.

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -21,7 +21,7 @@ from urllib.parse import urlsplit
 
 import cv2
 import numpy as np
-from fastapi import FastAPI, Header, Request, Response
+from fastapi import FastAPI, Header, HTTPException, Request, Response
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from starlette.datastructures import MutableHeaders
 from fastapi.staticfiles import StaticFiles
@@ -569,10 +569,55 @@ app.add_middleware(_SessionAuthMiddleware)
 audit_log = logging.getLogger("hydra.audit")
 
 
+@app.exception_handler(HTTPException)
+async def _http_exception_handler(request: Request, exc: HTTPException):
+    """Render fastapi.HTTPException with this app's ``{"error": ...}`` body
+    convention (the 413s raised by ``_read_body_capped``). Starlette's own
+    routing exceptions (404/405) are a different class and keep the default
+    handler."""
+    return JSONResponse({"error": exc.detail}, status_code=exc.status_code)
+
+
+async def _read_body_capped(request: Request, cap: int = MAX_BODY_SIZE) -> bytes:
+    """Read the request body, never letting more than ``cap`` bytes become
+    resident (issue #289 — a single multi-GB POST could OOM the 8 GB Orin
+    and take the pipeline down for the whole class).
+
+    Rejects on the declared Content-Length first (cheap), then enforces the
+    same cap on the actual stream — chunked transfer encoding carries no
+    length declaration, and a declared length can simply lie.
+
+    Raises ``HTTPException(413)`` on an oversized body. On success the
+    assembled body is cached on the request so any later ``request.body()``
+    / ``request.json()`` call in the same handler still works.
+    """
+    declared = request.headers.get("content-length")
+    if declared is not None:
+        try:
+            if int(declared) > cap:
+                raise HTTPException(status_code=413, detail="Request body too large")
+        except ValueError:
+            pass  # malformed header — the streamed cap below still holds
+    chunks: list[bytes] = []
+    total = 0
+    async for chunk in request.stream():
+        total += len(chunk)
+        if total > cap:
+            raise HTTPException(status_code=413, detail="Request body too large")
+        chunks.append(chunk)
+    body = b"".join(chunks)
+    request._body = body  # keep Starlette's body cache coherent
+    return body
+
+
 async def _parse_json(request: Request) -> dict | None:
-    """Safely parse JSON body, returning None on malformed input."""
+    """Safely parse JSON body, returning None on malformed input.
+
+    Body size is capped via :func:`_read_body_capped` — an oversized body
+    raises ``HTTPException(413)`` before it is ever fully buffered.
+    """
     try:
-        return await request.json()
+        return json.loads(await _read_body_capped(request))
     except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
         return None
 
@@ -1519,14 +1564,17 @@ async def api_client_error(request: Request):
 
     Auth-free, same-origin only. Rate-limited to 50 reports / 60 s / IP.
     """
-    body = await _parse_json(request)
-    if body is None or not isinstance(body, dict):
-        return JSONResponse({"error": "Invalid or missing JSON body"}, status_code=400)
-
+    # Rate-limit BEFORE touching the body (issue #289): this endpoint is
+    # unauthenticated, so the body read must sit behind the per-IP limiter,
+    # not in front of it.
     client_ip = request.client.host if request.client else "unknown"
     now = time.monotonic()
     if _client_error_rate_limited(client_ip, now):
         return JSONResponse({"error": "rate limited"}, status_code=429)
+
+    body = await _parse_json(request)
+    if body is None or not isinstance(body, dict):
+        return JSONResponse({"error": "Invalid or missing JSON body"}, status_code=400)
 
     user_agent = request.headers.get("user-agent", "")[:512]
     _client_error_sink.push(
@@ -3913,9 +3961,7 @@ async def api_set_full_config(request: Request, authorization: str | None = Head
     if auth_err:
         return auth_err
     import json as _json
-    body_bytes = await request.body()
-    if len(body_bytes) > MAX_BODY_SIZE:
-        return JSONResponse({"error": "Request body too large"}, status_code=413)
+    body_bytes = await _read_body_capped(request)
     try:
         body = _json.loads(body_bytes)
     except (ValueError, _json.JSONDecodeError):
@@ -4103,10 +4149,8 @@ async def api_factory_reset(request: Request, authorization: str | None = Header
         return JSONResponse({"error": "No factory defaults available"}, status_code=404)
     # Body is optional for backward-compat: existing callers send no body.
     body: dict | None = None
-    body_bytes = await request.body()
+    body_bytes = await _read_body_capped(request)
     if body_bytes:
-        if len(body_bytes) > MAX_BODY_SIZE:
-            return JSONResponse({"error": "Request body too large"}, status_code=413)
         import json as _json
         try:
             body = _json.loads(body_bytes)
@@ -4234,9 +4278,7 @@ async def api_config_import(request: Request, authorization: str | None = Header
     if auth_err:
         return auth_err
     import json as _json
-    body_bytes = await request.body()
-    if len(body_bytes) > MAX_BODY_SIZE:
-        return JSONResponse({"error": "Request body too large"}, status_code=413)
+    body_bytes = await _read_body_capped(request)
     try:
         body = _json.loads(body_bytes)
     except (ValueError, _json.JSONDecodeError):
@@ -4389,9 +4431,7 @@ async def api_setup_save(request: Request, authorization: Optional[str] = Header
         return auth_err
 
     import json as _json
-    body_bytes = await request.body()
-    if len(body_bytes) > MAX_BODY_SIZE:
-        return JSONResponse({"error": "Request body too large"}, status_code=413)
+    body_bytes = await _read_body_capped(request)
     try:
         body = _json.loads(body_bytes)
     except (ValueError, _json.JSONDecodeError):

--- a/tests/test_body_cap.py
+++ b/tests/test_body_cap.py
@@ -1,0 +1,121 @@
+"""Tests for the request-body size cap (issue #289).
+
+`_read_body_capped` must reject oversized bodies with 413 BEFORE the full
+body is resident, on both the declared-Content-Length path and the streamed
+(chunked) path. `/api/client_error` — the unauthenticated worst case — must
+rate-limit before it touches the body.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hydra_detect.web import server as web_server
+from hydra_detect.web.config_api import MAX_BODY_SIZE
+
+
+@pytest.fixture
+def client():
+    return TestClient(web_server.app)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    with web_server._client_error_lock:
+        web_server._client_error_hits.clear()
+    yield
+    with web_server._client_error_lock:
+        web_server._client_error_hits.clear()
+
+
+def _oversized_payload() -> bytes:
+    # Valid JSON just past the cap, so only the size check can reject it.
+    return b'{"message": "' + b'x' * MAX_BODY_SIZE + b'"}'
+
+
+class TestDeclaredLengthCap:
+    def test_client_error_oversized_body_413(self, client):
+        r = client.post(
+            "/api/client_error",
+            content=_oversized_payload(),
+            headers={"Content-Type": "application/json"},
+        )
+        assert r.status_code == 413
+        assert r.json() == {"error": "Request body too large"}
+
+    def test_lying_content_length_still_rejected(self, client):
+        # Declared length under the cap; actual body over it. The streamed
+        # cap must catch what the header check waves through.
+        r = client.post(
+            "/api/client_error",
+            content=_oversized_payload(),
+            headers={
+                "Content-Type": "application/json",
+                "Content-Length": "10",
+            },
+        )
+        # Either the transport rejects the mismatch or the app returns 413 —
+        # both acceptable; what is NOT acceptable is a 2xx.
+        assert r.status_code >= 400
+
+
+class TestStreamedCap:
+    def test_chunked_body_over_cap_413(self, client):
+        # A generator body sends Transfer-Encoding: chunked — no
+        # Content-Length header at all, so only the streamed cap applies.
+        def gen():
+            chunk = b'x' * 8192
+            for _ in range((MAX_BODY_SIZE // 8192) + 2):
+                yield chunk
+
+        r = client.post(
+            "/api/client_error",
+            content=gen(),
+            headers={"Content-Type": "application/json"},
+        )
+        assert r.status_code == 413
+
+    def test_small_body_still_accepted(self, client):
+        r = client.post("/api/client_error", json={"message": "boom"})
+        assert r.status_code == 200
+        assert r.json()["status"] == "ok"
+
+
+class TestRateLimitBeforeBodyRead:
+    def test_limited_ip_gets_429_even_with_malformed_json(self, client):
+        # Exhaust the per-IP window with valid posts...
+        for _ in range(web_server._CLIENT_ERROR_MAX_PER_WINDOW):
+            assert client.post(
+                "/api/client_error", json={"message": "x"}
+            ).status_code == 200
+        # ...then a malformed body. Pre-fix this returned 400 (body parsed
+        # before the limiter); post-fix the limiter answers first.
+        r = client.post(
+            "/api/client_error",
+            content=b"not json at all",
+            headers={"Content-Type": "application/json"},
+        )
+        assert r.status_code == 429
+
+
+class TestAdminEndpointsKeep413:
+    def test_config_full_oversized_413(self, client):
+        web_server.configure_auth(None)
+        r = client.post(
+            "/api/config/full",
+            content=b'{"camera": {"source": "' + b"x" * MAX_BODY_SIZE + b'"}}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert r.status_code == 413
+
+    def test_parse_json_consumers_now_capped(self, client):
+        # Representative previously-unguarded endpoint (auth off): the cap
+        # must answer 413, not attempt to buffer the body.
+        web_server.configure_auth(None)
+        r = client.post(
+            "/api/mode",
+            content=_oversized_payload(),
+            headers={"Content-Type": "application/json"},
+        )
+        assert r.status_code == 413


### PR DESCRIPTION
## Summary
- `_read_body_capped(request, cap=MAX_BODY_SIZE)` — rejects oversized declared Content-Length with 413, then enforces the same cap chunk-by-chunk on the actual stream. No more than 64 KB + one chunk ever resident, regardless of what the client declares.
- `_parse_json` routes through it → every consumer endpoint capped at once (`/api/mode`, `/api/client_error`, target/approach/rf/tak/vehicle/mission/etc.).
- The 4 config-admin endpoints drop their buffer-then-length-check pattern (which still OOM'd) for the same helper.
- `/api/client_error` (unauthenticated) now rate-limits BEFORE reading the body.
- App-scoped `HTTPException` handler renders 413 as `{"error": ...}` to match the existing response convention; Starlette routing 404/405 keep their default shape.

## Why streaming, not read-then-check
The issue's suggested fix (read `request.body()`, reject on length) does not prevent the OOM — the multi-GB body is fully buffered before the check runs. The chunked read aborts at the cap.

## Testing
- 7 new tests in `tests/test_body_cap.py`: declared-length 413, chunked-body 413 (no Content-Length at all), lying Content-Length, small-body 200, **429-before-parse ordering** (limited IP + malformed JSON → 429, not 400), admin-endpoint 413 regression, `_parse_json`-consumer 413.
- 271 existing tests in test_web_api / test_config_api / test_zero_touch / test_observability pass.

Closes #289