### PR TITLE
fix(observability): _probe_gps reads fix type from get_gps, not a phantom key (#302)

### DIFF
--- a/hydra_detect/observability/health.py
+++ b/hydra_detect/observability/health.py
@@ -98,16 +98,21 @@ def _probe_gps(mavlink_ref: Any, stats: Dict[str, Any]) -> Dict[str, str]:
     fix = None
     if stats:
         fix = stats.get("gps_fix")
-    if fix is None and mavlink_ref is not None:
+    if (fix is None or fix == 0) and mavlink_ref is not None:
         # Issue #302: the fix type lives in get_gps() (key "fix") — the old
         # fallback asked get_flight_data() for a "gps_fix" key it has never
         # returned, so this probe always degraded to "no gps data" whenever
-        # the stats cache was empty (e.g. right after boot).
+        # the stats cache was empty. StreamState also DEFAULTS gps_fix to 0
+        # before the pipeline publishes, so a 0 must consult the live
+        # MAVLink cache too — get_gps() feeds the published stats and is
+        # never staler than them; prefer its value when it has one.
         getter = getattr(mavlink_ref, "get_gps", None)
         if callable(getter):
             data = getter()
             if isinstance(data, dict):
-                fix = data.get("fix")
+                live = data.get("fix")
+                if live is not None:
+                    fix = live
     if fix is None:
         return _warn("no gps data")
     try:

--- a/hydra_detect/observability/health.py
+++ b/hydra_detect/observability/health.py
@@ -99,11 +99,15 @@ def _probe_gps(mavlink_ref: Any, stats: Dict[str, Any]) -> Dict[str, str]:
     if stats:
         fix = stats.get("gps_fix")
     if fix is None and mavlink_ref is not None:
-        getter = getattr(mavlink_ref, "get_flight_data", None)
+        # Issue #302: the fix type lives in get_gps() (key "fix") — the old
+        # fallback asked get_flight_data() for a "gps_fix" key it has never
+        # returned, so this probe always degraded to "no gps data" whenever
+        # the stats cache was empty (e.g. right after boot).
+        getter = getattr(mavlink_ref, "get_gps", None)
         if callable(getter):
             data = getter()
             if isinstance(data, dict):
-                fix = data.get("gps_fix")
+                fix = data.get("fix")
     if fix is None:
         return _warn("no gps data")
     try:

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -146,6 +146,39 @@ class TestHealthSnapshot:
         snap = health_snapshot(stats={"camera_ok": True, "fps": 5.0, "gps_fix": 0})
         assert snap["subsystems"]["gps"]["status"] == "warn"
 
+    def test_gps_fallback_reads_get_gps_fix(self):
+        # Issue #302: stats has no gps_fix → probe must read the fix type
+        # from get_gps()["fix"] (the old code asked get_flight_data() for a
+        # "gps_fix" key it never returned, so this path always warned).
+        class Mav:
+            connected = True
+
+            def get_gps(self):
+                return {"fix": 3, "lat": 1, "lon": 2, "last_update": 12.5}
+
+        snap = health_snapshot(
+            stats={"camera_ok": True, "fps": 5.0},
+            mavlink_ref=Mav(),
+        )
+        assert snap["subsystems"]["gps"]["status"] == "ok"
+        assert "gps_fix=3" in snap["subsystems"]["gps"]["detail"]
+
+    def test_gps_fallback_without_get_gps_warns(self):
+        # A facade exposing neither stats gps_fix nor get_gps degrades to
+        # the "no gps data" warning — never a false OK, never a crash.
+        class LegacyMav:
+            connected = True
+
+            def get_flight_data(self):
+                return {"heading": 90.0}
+
+        snap = health_snapshot(
+            stats={"camera_ok": True, "fps": 5.0},
+            mavlink_ref=LegacyMav(),
+        )
+        assert snap["subsystems"]["gps"]["status"] == "warn"
+        assert "no gps data" in snap["subsystems"]["gps"]["detail"]
+
 
 # ---------------------------------------------------------------------------
 # compute_disk_free + /api/health additive disk_free_pct field (issue #154)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -163,6 +163,32 @@ class TestHealthSnapshot:
         assert snap["subsystems"]["gps"]["status"] == "ok"
         assert "gps_fix=3" in snap["subsystems"]["gps"]["detail"]
 
+    def test_gps_default_zero_consults_live_cache(self):
+        # StreamState defaults stats["gps_fix"] to 0 before the pipeline
+        # publishes — a 0 must consult get_gps() too, else the boot window
+        # reports "no fix" while MAVLink already holds a 3D fix.
+        class Mav:
+            connected = True
+
+            def get_gps(self):
+                return {"fix": 3, "lat": 1, "lon": 2, "last_update": 12.5}
+
+        snap = health_snapshot(
+            stats={"camera_ok": True, "fps": 5.0, "gps_fix": 0},
+            mavlink_ref=Mav(),
+        )
+        assert snap["subsystems"]["gps"]["status"] == "ok"
+        assert "gps_fix=3" in snap["subsystems"]["gps"]["detail"]
+
+    def test_gps_stats_zero_without_mavlink_still_no_fix(self):
+        # No MAVLink registered: a stats 0 keeps its "no fix" warn — the
+        # live-cache consult must not change the no-reference path.
+        snap = health_snapshot(
+            stats={"camera_ok": True, "fps": 5.0, "gps_fix": 0},
+        )
+        assert snap["subsystems"]["gps"]["status"] == "warn"
+        assert "no fix" in snap["subsystems"]["gps"]["detail"]
+
     def test_gps_fallback_without_get_gps_warns(self):
         # A facade exposing neither stats gps_fix nor get_gps degrades to
         # the "no gps data" warning — never a false OK, never a crash.


### PR DESCRIPTION
GPS health probe fallback asked `get_flight_data()` for a `gps_fix` key it has never returned — always degraded to "no gps data" when the stats cache was empty (boot window). Now reads `get_gps()["fix"]`. Two new tests cover the fallback hit and the no-accessor degradation. Wrong-direction-safe before and after. Found in the PR #300 adversarial review (R3-a).

Closes #302