### PR TITLE
fix: re-land PR #274's still-valid items — CI coverage gap, per-poller backoff, utcnow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,9 +73,12 @@ jobs:
 
       - name: Test (with coverage)
         run: |
+          # Full suite minus slow-marked tests. The old
+          # --ignore=test_integration_wiring + -k "not integration" pair
+          # silently excluded 49 wiring/nav/template tests from every PR;
+          # the whole set runs in ~3 s (PR #274 item 3, re-landed).
           python -m pytest tests/ -q --tb=short \
-            --ignore=tests/test_integration_wiring.py \
-            -k "not integration and not slow" \
+            -k "not slow" \
             --cov=hydra_detect --cov-report=term --cov-report=xml
 
       - name: Upload coverage XML

--- a/docs/adversarial/304.md
+++ b/docs/adversarial/304.md
@@ -1,0 +1,73 @@
+# Adversarial review — PR #304 (PR #274 salvage: CI gap, per-poller backoff, utcnow)
+
+Scope of safety-path changes: `mavlink_io.py` line 712 only — the alert-DTG
+timestamp swaps deprecated `datetime.utcnow()` for
+`datetime.now(datetime.timezone.utc)`. The CI and poller-manager changes are
+not on ADVERSARIAL_PATHS; they are reviewed in Rounds 2–3 anyway since this
+report exists.
+
+## Round 1 — pattern-match the change
+
+**R1-a — Output equivalence of the DTG string.** `utcnow()` returns a naive
+datetime carrying UTC wall-clock values; `now(timezone.utc)` returns an
+aware datetime with the same wall-clock values. `strftime("%Y%m%d %H%MZ")`
+formats only year/month/day/hour/minute — no `%z`/`%Z` directive — so the
+rendered string is byte-identical. The tzinfo attribute never escapes the
+expression (the datetime is consumed by strftime on the same line). ACCEPT
+(verified: no other consumer of the intermediate value exists).
+
+**R1-b — Exception surface.** `datetime.now(tz)` raises in exactly the same
+(non-)cases as `utcnow()`; no new failure mode inside the alert path, which
+sits on the MAVLink send side, not the RX dispatch loop. ACCEPT.
+
+**R1-c — Behavior under deprecation removal.** This is the forward-safety
+motive: `utcnow()` is scheduled for removal in a future CPython; on that
+upgrade the alert path would raise `AttributeError` mid-send. The swap
+removes a known future breakage from a safety-adjacent path. ACCEPT.
+
+## Round 2 — counter-critique, downgrade or confirm
+
+**R2-a — Is the CI change safe to land without a fleet touch?** The removed
+exclusions only ADD tests to CI (49 wiring/nav/template tests, verified
+green on main in ~3 s before the change). Worst case: a future PR that
+breaks dashboard wiring now fails CI — which is the point. No runtime
+artifact changes. CONFIRM.
+
+**R2-b — Per-poller backoff changes aggregate request rate.** Under the old
+shared counter, one failing endpoint throttled ALL pollers (accidental
+load-shedding). Post-fix, healthy pollers keep full cadence while the
+failing one backs off — aggregate request rate against a degraded box
+RISES vs the buggy behavior. Interrogated: the design intent (per-endpoint
+backoff) is what the code claimed to do; the accidental global throttle
+also reset itself on any healthy success, so it never provided coherent
+load-shedding — just erratic polling. The new node test pins the intended
+isolation. CONFIRM CORRECT.
+
+**R2-c — onConnection flap semantics unchanged.** The connection callback
+still reports per-event (true on any success, false on any failure), so a
+single failing poller still flaps the chip under mixed states. Pre-existing
+behavior, deliberately not expanded into this PR. ACCEPT (out of scope).
+
+## Round 3 — orthogonal sweep ("what else did #274 claim that this PR does not fix?")
+
+**R3-a — requirements.lock remains stale on main.** Regenerating it on a
+Windows/x86 dev box would produce a wrong-platform resolution (the header
+declares Jetson ARM64 provenance). Deferred to an on-box session — tracked
+in the #274-closure follow-up issue, not silently dropped. FOLLOW-UP.
+
+**R3-b — config.ini untracking + deploy.sh migration remains open.** The
+#274 version could delete a fielded unit's live config on `git pull`
+without the paired deploy.sh guard. Mid-class (CLS 03-26 running) is the
+wrong week for a deployment-semantics change; explicitly deferred with the
+risk documented in the follow-up issue. FOLLOW-UP (deliberate).
+
+**R3-c — Other `utcnow()` call sites.** Swept the tree: no other
+`datetime.utcnow()` remains in `hydra_detect/` after this change. ACCEPT.
+
+## Triage
+
+- Blockers: none.
+- Gates: none.
+- Follow-up: R3-a (lock regen on-box), R3-b (config.ini untrack +
+  migration) — both carried in the #274 closure issue.
+- Accepted: R1-a–R1-c, R2-a–R2-c, R3-c.

--- a/hydra_detect/mavlink_io.py
+++ b/hydra_detect/mavlink_io.py
@@ -709,7 +709,7 @@ class MAVLinkIO:
             self._global_alert_times.append(now)
 
         # Build alert message with DTG and coordinates
-        dtg = datetime.datetime.utcnow().strftime("%Y%m%d %H%MZ")
+        dtg = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d %H%MZ")
         coord = self.get_position_string()
 
         if coord is not None:

--- a/hydra_detect/web/static/js/polling/poller-manager.js
+++ b/hydra_detect/web/static/js/polling/poller-manager.js
@@ -5,18 +5,21 @@ window.HydraModules = window.HydraModules || {};
 window.HydraModules.createPollerManager = function createPollerManager({ store, fetchImpl, onStats, onConnection }) {
     const fetcher = fetchImpl || fetch;
     const pollers = {};
-    let pollFailCount = 0;
     const MAX_BACKOFF = 10000;
 
     function startPoller(name, url, intervalMs, update) {
         if (pollers[name]) clearTimeout(pollers[name].timer);
-        const entry = { baseInterval: intervalMs, timer: null };
+        // failCount is PER POLLER (PR #274 item 4, re-landed): a shared
+        // counter let one failing endpoint back-off every healthy poller,
+        // and any healthy poller's success reset the failing poller's
+        // backoff — defeating it under mixed success/failure.
+        const entry = { baseInterval: intervalMs, timer: null, failCount: 0 };
         pollers[name] = entry;
 
         const schedule = () => {
-            const delay = pollFailCount === 0
+            const delay = entry.failCount === 0
                 ? intervalMs
-                : Math.min(intervalMs * Math.pow(2, pollFailCount), MAX_BACKOFF);
+                : Math.min(intervalMs * Math.pow(2, entry.failCount), MAX_BACKOFF);
             entry.timer = setTimeout(poll, delay);
         };
 
@@ -26,14 +29,14 @@ window.HydraModules.createPollerManager = function createPollerManager({ store, 
                 if (resp.ok) {
                     const data = await resp.json();
                     update(data);
-                    pollFailCount = 0;
+                    entry.failCount = 0;
                     if (onConnection) onConnection(true);
                 } else {
-                    pollFailCount++;
+                    entry.failCount++;
                     if (onConnection) onConnection(false);
                 }
             } catch (e) {
-                pollFailCount++;
+                entry.failCount++;
                 if (onConnection) onConnection(false);
             }
             if (pollers[name]) schedule();

--- a/hydra_detect/web/static/js/tests/app-modules.test.mjs
+++ b/hydra_detect/web/static/js/tests/app-modules.test.mjs
@@ -55,6 +55,45 @@ test('poller starts/stops detail pollers per active view', async () => {
   manager.stopPoller('stats');
 });
 
+test('backoff state is per poller — one failing endpoint does not slow the rest', async (t) => {
+  setupGlobals();
+  loadScript('hydra_detect/web/static/js/state/store.js');
+  loadScript('hydra_detect/web/static/js/polling/poller-manager.js');
+
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  const calls = { good: 0, bad: 0 };
+  const fetchImpl = async (url) => {
+    if (url === '/good') { calls.good += 1; return { ok: true, json: async () => ({}) }; }
+    calls.bad += 1;
+    return { ok: false };
+  };
+  const store = window.HydraModules.createStore();
+  const manager = window.HydraModules.createPollerManager({ store, fetchImpl });
+
+  manager.startPoller('good', '/good', 1000, () => {});
+  manager.startPoller('bad', '/bad', 1000, () => {});
+  // Flush the immediate first polls.
+  await new Promise(r => { r(); });
+  await new Promise(r => { r(); });
+
+  // Advance 4 base intervals. The healthy poller must fire ~once per
+  // interval; the failing one backs off exponentially (2s, 4s, ...).
+  for (let i = 0; i < 4; i++) {
+    t.mock.timers.tick(1000);
+    // Let the async poll bodies settle between ticks.
+    await new Promise(r => { r(); });
+    await new Promise(r => { r(); });
+  }
+
+  assert.ok(calls.good >= 4, `healthy poller throttled: ${calls.good} calls in 4 intervals`);
+  assert.ok(calls.bad <= 3, `failing poller not backing off: ${calls.bad} calls in 4 intervals`);
+
+  manager.stopPoller('good');
+  manager.stopPoller('bad');
+  t.mock.timers.reset();
+});
+
 test('modal controller handles escape close and tab focus trap', () => {
   setupGlobals();
   loadScript('hydra_detect/web/static/js/ui/modal.js');


### PR DESCRIPTION
Salvage of PR #274, which sat unrebasable (11 files, 6 weeks of drift) — each item re-verified against current main before re-landing:

| #274 item | Status on main | Action |
|---|---|---|
| 3. CI excludes 49 wiring tests | Still excluded (`--ignore` + `-k "not integration"`) | **Re-landed** — verified all 49 pass on main in ~3 s before removing the exclusion |
| 4. Shared poller backoff | Still shared `pollFailCount` | **Re-landed** per-poller `entry.failCount` + node test with mocked timers proving isolation |
| 5. `datetime.utcnow()` deprecation | Still present (mavlink_io.py:712) | **Re-landed** — `now(timezone.utc)`, identical output |
| 1. requirements.lock regen | Lock still stale (worse post-dependabot wave) | **Not here** — must be resolved on Jetson ARM64, not a dev box; tracked in follow-up issue |
| 2. config.ini untrack + deploy migration | Still tracked | **Not here** — carries a live-config-deletion risk on `git pull` for fielded units; deployment-timing call, not a mid-class merge |

107 mavlink tests + 16 node tests pass. mavlink_io.py touch is the one-line deprecation swap; adversarial report to follow once the PR number exists.