### PR TITLE
fix(web): Pixhawk wizard I/O off the event loop + single-flight lock (#288)

### DIFF
--- a/docs/adversarial/306.md
+++ b/docs/adversarial/306.md
@@ -1,0 +1,106 @@
+# Adversarial review — PR #306 (wizard event-loop fix + single-flight, #288)
+
+Scope: `web/server.py` — the four Pixhawk wizard handlers restructured so
+their blocking pymavlink spans run via `run_in_threadpool`, plus a
+module-level single-flight lock (423 when busy). Reviewed against main
+@ 58e9f0a with the fix applied.
+
+## Round 1 — pattern-match the changes
+
+**R1-a — Monkeypatch/late-binding integrity.** The extracted `_work`
+closures reference `_pixhawk_open_connection`, `_pixhawk_wizard.*`, and
+`_pixhawk_collect_live_params*` as module globals resolved at call time —
+NOT captured at definition. Verified empirically: all 10 pre-existing
+wizard-server tests, which monkeypatch those exact names, pass unchanged.
+ACCEPT.
+
+**R1-b — Lock held across an await.** `_pixhawk_wizard_lock` is a
+`threading.Lock` acquired with `blocking=False` (never parks the loop) and
+released in a `finally` on the same coroutine after the threadpool call
+returns. An exception inside `_work` propagates through
+`run_in_threadpool` and still hits the `finally` — the lock cannot stick.
+Pinned by `test_wizard_lock_releases_after_completion`. ACCEPT.
+
+**R1-c — Status-code and response-shape parity.** Outcome tags map to the
+identical codes the inline flow produced: connect failure → 408 with
+`{"error": "connect failed: ..."}`, apply hash mismatch → 409 carrying
+`fresh_diff`/`fresh_diff_hash`, success → the same payload keys. Audit
+lines fire with the same action/target/outcome strings, now from the async
+side. The only NEW code is 423 for busy — previously unrepresentable
+(calls serialized by parking the loop). ACCEPT.
+
+**R1-d — 423 choice for busy.** 409 was unavailable (apply already uses it
+for hash mismatch, and the frontend distinguishes on code); 423 Locked is
+unambiguous and the setup wizard surfaces `error` text regardless of code.
+ACCEPT.
+
+**R1-e — Exception surface inside `_work`.** Unexpected exceptions (e.g.
+pymavlink internals past the connect) previously propagated to a 500; they
+still do, now via `run_in_threadpool`'s re-raise, with `link.close()`
+guaranteed by the inner `finally`. No swallowed-error path was added.
+ACCEPT.
+
+## Round 2 — counter-critique, downgrade or confirm
+
+**R2-a — Does the single-flight lock create a new DoS?** An attacker
+holding the wizard busy (one in-flight call, 10 s max) makes other wizard
+calls 423 — but the wizard is an instructor-workflow surface, not a
+flight-critical poller, and pre-fix the same attacker froze THE ENTIRE
+DASHBOARD instead. The lock converts a room-wide outage into a
+wizard-only busy signal with a bounded (10 s) hold. Strict improvement.
+CONFIRM.
+
+**R2-b — Serial-port contention was the latent bug the lock also fixes.**
+Pre-fix, "concurrency" on the wizard meant loop-serialized calls — the
+threadpool change alone would have INTRODUCED true concurrency, letting two
+callers open the same `/dev/ttyUSB0` simultaneously mid-param-write. The
+lock is therefore load-bearing for correctness, not just DoS hygiene: the
+threadpool change must not land without it (and does not — same commit).
+CONFIRM CORRECT.
+
+**R2-c — Threadpool capacity.** anyio's default threadpool (40 threads)
+minus at most ONE wizard thread (single-flight) leaves the pool for other
+threadpooled work. Pre-lock, a request loop could have parked up to 40
+workers for 10 s each. ACCEPT.
+
+**R2-d — Is the apply path's backup file-write safe off-loop?** The
+backup `write_text` moved into the threadpool with the rest of the span —
+disk I/O off the loop is the correct direction; path construction
+(`_pixhawk_backup_path`) is pure. The write happens before any PARAM_SET,
+preserving the capture-before-mutate ordering the #264 review required.
+ACCEPT.
+
+## Round 3 — orthogonal sweep ("what else blocks this loop?")
+
+**R3-a — Remaining blocking work in async handlers.** Swept `server.py`
+for sync I/O in `async def` routes: the session-data ZIP export builds an
+archive inline, and `/api/config/import`'s restore path does config-file
+I/O — both are millisecond-scale local-disk operations, not 10 s network
+waits with caller-controlled endpoints. Materially different exposure
+class; not expanded here. FOLLOW-UP candidate only if profiling ever shows
+them hot.
+
+**R3-b — MJPEG generator unaffected.** `_generate_mjpeg` awaits between
+frames and never calls wizard code; the fix removes its only observed
+starvation source. ACCEPT.
+
+**R3-c — Test honesty.** The responsiveness test was RED-GREEN VERIFIED
+against the pre-fix code (fails at ~9 s). A first draft using `TestClient`
+passed against the broken code — TestClient runs each request on its own
+event loop and cannot reproduce loop starvation — so the committed test
+drives httpx `ASGITransport` on one shared loop. The 423 test also fails
+pre-fix (no lock existed). ACCEPT (both proven, not assumed).
+
+**R3-d — Wizard vs live pipeline MAVLink contention.** The wizard opens
+its own connection to a caller-supplied `conn` while the pipeline may hold
+the same serial device — pre-existing behavior, unchanged by this PR
+(#158-era design; the wizard is meant for pre-mission bench setup).
+ACCEPT (out of scope).
+
+## Triage
+
+- Blockers: none.
+- Gates: none.
+- Follow-up: R3-a (ZIP export / config-import disk I/O — only if profiling
+  shows it).
+- Accepted: R1-a–R1-e, R2-a–R2-d, R3-b–R3-d.

--- a/hydra_detect/web/server.py
+++ b/hydra_detect/web/server.py
@@ -22,6 +22,7 @@ from urllib.parse import urlsplit
 import cv2
 import numpy as np
 from fastapi import FastAPI, Header, HTTPException, Request, Response
+from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from starlette.datastructures import MutableHeaders
 from fastapi.staticfiles import StaticFiles
@@ -1056,6 +1057,22 @@ async def api_health():
 _PIXHAWK_CONNECT_TIMEOUT_SEC = 10.0
 _PIXHAWK_PARAM_COLLECT_TIMEOUT_SEC = 10.0
 
+# Issue #288: the wizard's pymavlink I/O is blocking (wait_heartbeat /
+# recv_match loops up to 10 s). The four wizard handlers run that work in
+# the threadpool via run_in_threadpool so the event loop — which also
+# serves MJPEG and every poller for the whole class — never parks. The
+# single-flight lock keeps concurrent wizard calls from stacking threads
+# (and from fighting over the same serial device); a busy wizard answers
+# 423 immediately.
+_pixhawk_wizard_lock = threading.Lock()
+
+
+def _pixhawk_wizard_busy_response() -> JSONResponse:
+    return JSONResponse(
+        {"error": "another Pixhawk wizard operation is in progress — retry when it completes"},
+        status_code=423,
+    )
+
 
 def _pixhawk_open_connection(conn_str: str, baud: int = 115200):
     """Open a mavutil connection and wait for a heartbeat.
@@ -1228,32 +1245,46 @@ async def api_pixhawk_detect(
     auth_err = _check_auth(authorization, request)
     if auth_err:
         return auth_err
+
+    def _work():
+        # Blocking pymavlink span — runs in the threadpool (issue #288).
+        try:
+            link = _pixhawk_open_connection(conn, baud=baud)
+        except Exception as exc:
+            return ("connect_failed", str(exc))
+        try:
+            # Request AUTOPILOT_VERSION via MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES.
+            try:
+                from pymavlink.dialects.v20 import common as mavlink2
+                link.mav.command_long_send(
+                    link.target_system, link.target_component,
+                    mavlink2.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES,
+                    0, 1, 0, 0, 0, 0, 0, 0,
+                )
+            except Exception:
+                # Some autopilots emit AUTOPILOT_VERSION on connect — best-effort only.
+                pass
+            info = _pixhawk_wizard.detect_fc(link, timeout=_PIXHAWK_CONNECT_TIMEOUT_SEC)
+        finally:
+            try:
+                link.close()
+            except Exception:
+                pass
+        return ("ok", info)
+
+    if not _pixhawk_wizard_lock.acquire(blocking=False):
+        return _pixhawk_wizard_busy_response()
     try:
-        link = _pixhawk_open_connection(conn, baud=baud)
-    except Exception as exc:
+        tag, payload = await run_in_threadpool(_work)
+    finally:
+        _pixhawk_wizard_lock.release()
+    if tag == "connect_failed":
         _audit(request, "pixhawk_detect", target=conn, outcome="connect_failed")
         return JSONResponse(
-            {"error": f"connect failed: {exc}"},
+            {"error": f"connect failed: {payload}"},
             status_code=408,
         )
-    try:
-        # Request AUTOPILOT_VERSION via MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES.
-        try:
-            from pymavlink.dialects.v20 import common as mavlink2
-            link.mav.command_long_send(
-                link.target_system, link.target_component,
-                mavlink2.MAV_CMD_REQUEST_AUTOPILOT_CAPABILITIES,
-                0, 1, 0, 0, 0, 0, 0, 0,
-            )
-        except Exception:
-            # Some autopilots emit AUTOPILOT_VERSION on connect — best-effort only.
-            pass
-        info = _pixhawk_wizard.detect_fc(link, timeout=_PIXHAWK_CONNECT_TIMEOUT_SEC)
-    finally:
-        try:
-            link.close()
-        except Exception:
-            pass
+    info = payload
     _audit(request, "pixhawk_detect", target=info.get("firmware", "unknown"))
     return info
 
@@ -1280,21 +1311,34 @@ async def api_pixhawk_diff(
     except ValueError as exc:
         return JSONResponse({"error": str(exc)}, status_code=500)
 
+    def _work():
+        # Blocking pymavlink span — runs in the threadpool (issue #288).
+        try:
+            link = _pixhawk_open_connection(conn, baud=baud)
+        except Exception as exc:
+            return ("connect_failed", str(exc))
+        try:
+            live = _pixhawk_collect_live_params(link)
+        finally:
+            try:
+                link.close()
+            except Exception:
+                pass
+        return ("ok", live)
+
+    if not _pixhawk_wizard_lock.acquire(blocking=False):
+        return _pixhawk_wizard_busy_response()
     try:
-        link = _pixhawk_open_connection(conn, baud=baud)
-    except Exception as exc:
+        tag, payload = await run_in_threadpool(_work)
+    finally:
+        _pixhawk_wizard_lock.release()
+    if tag == "connect_failed":
         _audit(request, "pixhawk_diff", target=profile, outcome="connect_failed")
         return JSONResponse(
-            {"error": f"connect failed: {exc}"},
+            {"error": f"connect failed: {payload}"},
             status_code=408,
         )
-    try:
-        live = _pixhawk_collect_live_params(link)
-    finally:
-        try:
-            link.close()
-        except Exception:
-            pass
+    live = payload
 
     rows = _pixhawk_wizard.compute_diff(live, pack)
     _audit(request, "pixhawk_diff", target=f"{profile}:{len(rows)}rows")
@@ -1346,87 +1390,110 @@ async def api_pixhawk_apply(
             status_code=404,
         )
 
-    try:
-        link = _pixhawk_open_connection(conn_str, baud=baud)
-    except Exception as exc:
-        _audit(request, "pixhawk_apply", target=profile, outcome="connect_failed")
-        return JSONResponse(
-            {"error": f"connect failed: {exc}"},
-            status_code=408,
-        )
+    def _work():
+        # Blocking pymavlink span — runs in the threadpool (issue #288).
+        try:
+            link = _pixhawk_open_connection(conn_str, baud=baud)
+        except Exception as exc:
+            return ("connect_failed", str(exc))
 
-    try:
-        # 1. Recompute live → fresh diff → freshness check. Capture per-name
-        #    MAV_PARAM_TYPE in the same pass so apply_pack can send each
-        #    PARAM_SET with the FC-reported type instead of always REAL32.
-        live, live_types = _pixhawk_collect_live_params_with_types(link)
-        fresh_diff = _pixhawk_wizard.compute_diff(live, pack)
-        fresh_hash = _pixhawk_diff_hash(fresh_diff)
-        if not hmac.compare_digest(fresh_hash, confirmed_hash):
-            _audit(request, "pixhawk_apply", target=profile, outcome="hash_mismatch")
-            return JSONResponse(
-                {
-                    "error": "diff changed since confirmation — re-run /diff and re-confirm",
+        try:
+            # 1. Recompute live → fresh diff → freshness check. Capture per-name
+            #    MAV_PARAM_TYPE in the same pass so apply_pack can send each
+            #    PARAM_SET with the FC-reported type instead of always REAL32.
+            live, live_types = _pixhawk_collect_live_params_with_types(link)
+            fresh_diff = _pixhawk_wizard.compute_diff(live, pack)
+            fresh_hash = _pixhawk_diff_hash(fresh_diff)
+            if not hmac.compare_digest(fresh_hash, confirmed_hash):
+                return ("hash_mismatch", {
                     "fresh_diff": fresh_diff,
                     "fresh_diff_hash": fresh_hash,
-                },
-                status_code=409,
+                })
+
+            # 2. Capture pre-change backup of every name we're about to touch.
+            names_to_touch = [
+                row["name"] for row in fresh_diff
+                if row.get("action") in ("change", "add")
+            ]
+            backup = _pixhawk_wizard.capture_backup(link, names_to_touch)
+            backup_path = _pixhawk_backup_path(_pixhawk_callsign_from_runtime())
+            backup_payload = {
+                "profile": profile,
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime(
+                    "%Y-%m-%dT%H:%M:%S.%fZ"
+                ),
+                "conn": conn_str,
+                "backup": backup,
+            }
+            backup_path.write_text(
+                json.dumps(backup_payload, indent=2, sort_keys=True),
+                encoding="utf-8",
             )
 
-        # 2. Capture pre-change backup of every name we're about to touch.
-        names_to_touch = [
-            row["name"] for row in fresh_diff
-            if row.get("action") in ("change", "add")
-        ]
-        backup = _pixhawk_wizard.capture_backup(link, names_to_touch)
-        backup_path = _pixhawk_backup_path(_pixhawk_callsign_from_runtime())
-        backup_payload = {
-            "profile": profile,
-            "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime(
+            # 3. Apply.
+            results = _pixhawk_wizard.apply_pack(
+                link, fresh_diff, live_param_types=live_types,
+            )
+
+            # 4. Authoritative post-apply re-read. PARAM_VALUE arriving during the
+            #    apply loop can be a third-party PARAM_SET broadcast (Mission
+            #    Planner on telemetry radio); the value we observed as the ack is
+            #    not necessarily the value we wrote. Re-read every touched param
+            #    after the apply loop completes and overwrite ``post_value`` with
+            #    the FC's actual current value, so the operator surface reflects
+            #    real state instead of an interloper's value. (R3-1)
+            re_read_at = datetime.datetime.now(datetime.timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%S.%fZ"
-            ),
-            "conn": conn_str,
-            "backup": backup,
-        }
-        backup_path.write_text(
-            json.dumps(backup_payload, indent=2, sort_keys=True),
-            encoding="utf-8",
-        )
+            )
+            if names_to_touch:
+                authoritative = _pixhawk_wizard.reread_params(link, names_to_touch)
+                for row in results:
+                    rname = row.get("name")
+                    if rname in authoritative:
+                        row["post_value"] = authoritative[rname]
+        finally:
+            try:
+                link.close()
+            except Exception:
+                pass
+        return ("ok", {
+            "backup_path": backup_path,
+            "results": results,
+            "re_read_at": re_read_at,
+        })
 
-        # 3. Apply.
-        results = _pixhawk_wizard.apply_pack(
-            link, fresh_diff, live_param_types=live_types,
-        )
-
-        # 4. Authoritative post-apply re-read. PARAM_VALUE arriving during the
-        #    apply loop can be a third-party PARAM_SET broadcast (Mission
-        #    Planner on telemetry radio); the value we observed as the ack is
-        #    not necessarily the value we wrote. Re-read every touched param
-        #    after the apply loop completes and overwrite ``post_value`` with
-        #    the FC's actual current value, so the operator surface reflects
-        #    real state instead of an interloper's value. (R3-1)
-        re_read_at = datetime.datetime.now(datetime.timezone.utc).strftime(
-            "%Y-%m-%dT%H:%M:%S.%fZ"
-        )
-        if names_to_touch:
-            authoritative = _pixhawk_wizard.reread_params(link, names_to_touch)
-            for row in results:
-                rname = row.get("name")
-                if rname in authoritative:
-                    row["post_value"] = authoritative[rname]
+    if not _pixhawk_wizard_lock.acquire(blocking=False):
+        return _pixhawk_wizard_busy_response()
+    try:
+        tag, payload = await run_in_threadpool(_work)
     finally:
-        try:
-            link.close()
-        except Exception:
-            pass
+        _pixhawk_wizard_lock.release()
 
+    if tag == "connect_failed":
+        _audit(request, "pixhawk_apply", target=profile, outcome="connect_failed")
+        return JSONResponse(
+            {"error": f"connect failed: {payload}"},
+            status_code=408,
+        )
+    if tag == "hash_mismatch":
+        _audit(request, "pixhawk_apply", target=profile, outcome="hash_mismatch")
+        return JSONResponse(
+            {
+                "error": "diff changed since confirmation — re-run /diff and re-confirm",
+                "fresh_diff": payload["fresh_diff"],
+                "fresh_diff_hash": payload["fresh_diff_hash"],
+            },
+            status_code=409,
+        )
+
+    results = payload["results"]
     _audit(request, "pixhawk_apply", target=f"{profile}:{len(results)}rows")
     return {
-        "backup_path": str(backup_path),
+        "backup_path": str(payload["backup_path"]),
         "results": results,
         "applied": sum(1 for r in results if r.get("applied")),
         "failed": sum(1 for r in results if not r.get("applied")),
-        "re_read_at": re_read_at,
+        "re_read_at": payload["re_read_at"],
     }
 
 
@@ -1489,21 +1556,34 @@ async def api_pixhawk_restore(
             status_code=400,
         )
 
+    def _work():
+        # Blocking pymavlink span — runs in the threadpool (issue #288).
+        try:
+            link = _pixhawk_open_connection(conn_str, baud=baud)
+        except Exception as exc:
+            return ("connect_failed", str(exc))
+        try:
+            results = _pixhawk_wizard.restore_backup(link, backup)
+        finally:
+            try:
+                link.close()
+            except Exception:
+                pass
+        return ("ok", results)
+
+    if not _pixhawk_wizard_lock.acquire(blocking=False):
+        return _pixhawk_wizard_busy_response()
     try:
-        link = _pixhawk_open_connection(conn_str, baud=baud)
-    except Exception as exc:
+        tag, payload = await run_in_threadpool(_work)
+    finally:
+        _pixhawk_wizard_lock.release()
+    if tag == "connect_failed":
         _audit(request, "pixhawk_restore", target=str(resolved), outcome="connect_failed")
         return JSONResponse(
-            {"error": f"connect failed: {exc}"},
+            {"error": f"connect failed: {payload}"},
             status_code=408,
         )
-    try:
-        results = _pixhawk_wizard.restore_backup(link, backup)
-    finally:
-        try:
-            link.close()
-        except Exception:
-            pass
+    results = payload
 
     _audit(request, "pixhawk_restore", target=f"{resolved.name}:{len(results)}rows")
     return {

--- a/tests/test_pixhawk_wizard_server.py
+++ b/tests/test_pixhawk_wizard_server.py
@@ -389,3 +389,118 @@ def test_apply_re_read_timeout_marks_post_value_null(tmp_path, monkeypatch, clie
     assert body["results"][0]["post_value"] is None
     assert body["results"][0]["applied"] is True
     assert "re_read_at" in body
+
+
+# ---------------------------------------------------------------------------
+# Issue #288 — wizard I/O must not block the event loop; single-flight lock
+# ---------------------------------------------------------------------------
+
+def test_stats_stays_responsive_while_wizard_connects(monkeypatch):
+    """The regression #288 describes: with the old async-def handlers, a
+    slow wizard connect parked the event loop and every other endpoint
+    stalled behind it. Both requests here share ONE event loop (TestClient
+    gives every request its own loop, which cannot reproduce the bug), so
+    pre-fix the wall-clock includes the full simulated connect park and the
+    elapsed assertion fails; post-fix the connect runs in the threadpool
+    and /api/stats answers while the wizard call is still in flight."""
+    import asyncio
+    import threading
+    import time
+
+    import httpx
+
+    release = threading.Event()
+
+    def _slow_open(conn_str, baud=115200):
+        # Simulated wait_heartbeat park on a dead conn string. Bounded so a
+        # pre-fix run fails the elapsed assertion instead of hanging.
+        release.wait(timeout=8.0)
+        raise RuntimeError("no heartbeat")
+
+    monkeypatch.setattr(srv_mod, "_pixhawk_open_connection", _slow_open)
+
+    async def _scenario():
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://test"
+        ) as ac:
+            t0 = time.monotonic()
+            wizard_task = asyncio.create_task(
+                ac.get(
+                    "/api/platform/setup/pixhawk/detect",
+                    params={"conn": "udp:127.0.0.1:1"},
+                )
+            )
+            # Let the wizard handler start. Pre-fix this sleep cannot return
+            # until the blocking connect finishes, because the loop is parked.
+            await asyncio.sleep(0.05)
+            stats = await ac.get("/api/stats")
+            elapsed = time.monotonic() - t0
+            release.set()
+            wizard = await wizard_task
+            return stats, wizard, elapsed
+
+    stats, wizard, elapsed = asyncio.run(_scenario())
+    assert stats.status_code == 200
+    assert wizard.status_code == 408  # connect failed → mapped error
+    assert elapsed < 2.0, (
+        f"/api/stats not served until {elapsed:.1f}s after the wizard call "
+        "started — the event loop is still being blocked"
+    )
+
+
+def test_concurrent_wizard_calls_get_423(monkeypatch, client):
+    """Single-flight: a second wizard call while one is in progress answers
+    423 immediately instead of stacking another 10s threadpool block."""
+    import threading
+
+    release = threading.Event()
+    entered = threading.Event()
+
+    def _slow_open(conn_str, baud=115200):
+        entered.set()
+        release.wait(timeout=10.0)
+        raise RuntimeError("no heartbeat")
+
+    monkeypatch.setattr(srv_mod, "_pixhawk_open_connection", _slow_open)
+
+    first = {}
+
+    def _call_first():
+        first["resp"] = client.get(
+            "/api/platform/setup/pixhawk/detect",
+            params={"conn": "udp:127.0.0.1:1"},
+        )
+
+    t = threading.Thread(target=_call_first)
+    t.start()
+    try:
+        assert entered.wait(timeout=5.0)
+        second = client.get(
+            "/api/platform/setup/pixhawk/detect",
+            params={"conn": "udp:127.0.0.1:2"},
+        )
+        assert second.status_code == 423
+        assert "in progress" in second.json()["error"]
+    finally:
+        release.set()
+        t.join(timeout=10.0)
+    assert first["resp"].status_code == 408
+
+
+def test_wizard_lock_releases_after_completion(monkeypatch, client):
+    """The lock must not stick: after a wizard call finishes (even by
+    failing), the next call proceeds instead of 423ing forever."""
+    def _fail_open(conn_str, baud=115200):
+        raise RuntimeError("no heartbeat")
+
+    monkeypatch.setattr(srv_mod, "_pixhawk_open_connection", _fail_open)
+
+    r1 = client.get(
+        "/api/platform/setup/pixhawk/detect", params={"conn": "udp:127.0.0.1:1"},
+    )
+    r2 = client.get(
+        "/api/platform/setup/pixhawk/detect", params={"conn": "udp:127.0.0.1:1"},
+    )
+    assert r1.status_code == 408
+    assert r2.status_code == 408  # not 423 — lock released


### PR DESCRIPTION
## Summary
- Each wizard handler's blocking pymavlink span (open → collect/apply/restore → close) moves into a sync closure run via `run_in_threadpool`; auth, body validation, audit, and response mapping stay on the loop.
- Module-level single-flight lock: a second wizard call while one is in progress answers **423 immediately** — no thread stacking, no two callers fighting over one serial device.
- Outcome tags (`connect_failed` / `hash_mismatch` / `ok`) preserve the exact status codes, audit lines, and response shapes of the old inline flow. All 10 existing wizard-server tests pass unchanged.

## Test honesty note
The loop-responsiveness test drives httpx `ASGITransport` on a **single shared event loop** — `TestClient` gives every request its own loop and physically cannot reproduce this bug (verified: a TestClient-based version passed against the broken code). Red-green proven: fails at ~9 s pre-fix, passes post-fix.

## Testing
- 3 new tests: shared-loop responsiveness (<2 s while wizard parked), concurrent-call 423, lock-release-after-completion.
- 258 tests across web/config/body-cap/wizard suites pass.

Closes #288