### PR TITLE
fix: harden today's merges per 3-agent adversarial re-review

### DIFF
--- a/docs/adversarial/307.md
+++ b/docs/adversarial/307.md
@@ -1,0 +1,91 @@
+# Adversarial review — PR #307 (post-merge hardening from 3-agent re-review)
+
+Scope of safety-path changes: `mavlink_io.py` — GPS_RAW_INT branch extracted
+to `_handle_gps_raw_int()` with a new `raw_last_update` monotonic stamp.
+`observability/health.py` freshness gate and the JS/test changes are not on
+ADVERSARIAL_PATHS; rounds 2–3 cover them anyway. Reviewed against main
+@ bdb7aff with the fix applied.
+
+## Round 1 — pattern-match the mavlink_io change
+
+**R1-a — Behavior parity of the extraction.** The handler body is the
+verbatim inline branch (fix/cog/vel writes under `_gps_lock`) plus one new
+line: the stamp. Message dispatch order and lock scope are unchanged; the
+method is called from the same `elif` arm. Pinned by the rewritten tests,
+which now drive the real handler (the prior tests hand-seeded the cache and
+could not detect a broken branch — the re-review's T2). ACCEPT.
+
+**R1-b — Why a NEW key instead of stamping `last_update`.** `last_update`
+is written only by GLOBAL_POSITION_INT, and its 0.0 sentinel means "skip
+the freshness check — operator/sim GPS" to `autonomous.py:284-291` and
+`approach.py`. Having GPS_RAW_INT write it would let a fix-only stream
+(no position) flip those gates from skip-mode into age-checking, changing
+strike-gate behavior. `raw_last_update` is additive; zero existing readers.
+Verified by grep: only `health.py` consumes it. ACCEPT (verified).
+
+**R1-c — Dict-shape growth.** `raw_last_update: 0.0` joins the `_gps`
+defaults; all `_gps` readers access by key (`get_gps()` returns a copy;
+consumers use `.get`). `get_flight_data()` deliberately does NOT expose the
+stamp — no API surface change. ACCEPT.
+
+**R1-d — Monotonic clock semantics.** Same clock family as every other
+freshness stamp in the file (`last_update`, `battery_last_update`,
+`_rc_channels_last_update`); the suspend-clock caveat documented in the
+PR #286 review applies identically and is accepted for the same
+consistency reason. ACCEPT.
+
+## Round 2 — counter-critique, downgrade or confirm
+
+**R2-a — Does the 10 s freshness window reintroduce the #302 boot bug?**
+The boot scenario the #302 fix targeted is "stats defaulted, GPS_RAW_INT
+flowing" — exactly when the stamp is fresh, so the cache is still
+consulted. The window only rejects the cache when GPS_RAW_INT has actually
+stopped — which is when trusting it was the re-review's finding. An
+unstamped cache (fix never received) holds fix=0 anyway, so nothing of
+value is discarded. Pinned by four tests: fresh-consult ×2, stale-reject,
+unstamped-reject. CONFIRM CORRECT.
+
+**R2-b — Can the health probe now report WORSE than reality?** If
+GPS_RAW_INT stalls >10 s while the fix genuinely persists, the probe falls
+back to the stats value (which the pipeline publishes from the same cache
+— it would say fix=3) or, absent stats, warns. Warn-when-uncertain is the
+correct failure direction for a readiness surface. ACCEPT.
+
+**R2-c — JS epoch pattern consistency.** systems.js now uses the same
+generation-token discipline as tak-map.js rather than a third ad-hoc
+mechanism; the boolean-flag alternative was rejected in-review because a
+fast leave→enter resurrects the old in-flight poll under the new "on"
+state. One pattern, three files, one mental model. ACCEPT.
+
+**R2-d — Recovery-card reset loses craft A's cache on switch.** By design:
+A's fix remains in A's localStorage key and reloads when A's callsign
+returns. Only the in-memory pointer resets. No data loss. ACCEPT.
+
+## Round 3 — orthogonal sweep
+
+**R3-a — Other consumers of the extracted handler's fields.** `cog` and
+`ground_speed` feed only `/api/stats` → the ops-view compass advisory
+(display-only, established in the PR #300 review); `fix` feeds stats, the
+preflight callback, and now the freshness-gated health probe. No autonomy
+gate reads any of them through a changed path. ACCEPT.
+
+**R3-b — Do the other two JS poll loops in the codebase have the F2/F3
+class of bug?** rtl-spectrum-overlay uses a poll-fail counter with view
+lifecycle managed by ops.js enter/leave (its interval is cleared
+synchronously — no await-straddle); tak.js pollers were given health
+wiring in #299 and stop synchronously. The await-straddling loops were
+exactly the two fixed here. ACCEPT (swept).
+
+**R3-c — Test-suite honesty of the NEW tests.** The two new mjs tests and
+the stale/unstamped probe tests were red-green verified against the
+pre-fix implementations during development (old poller: bad=5 by tick 8,
+restart forks a chain; pre-gate probe: stale cache reports ok). The
+raw-ASGI 413 test bypasses client/transport normalization, which is the
+only way to deliver a lying Content-Length to the app. ACCEPT.
+
+## Triage
+
+- Blockers: none.
+- Gates: none.
+- Follow-up: none new.
+- Accepted: R1-a–R1-d, R2-a–R2-d, R3-a–R3-c.

--- a/hydra_detect/mavlink_io.py
+++ b/hydra_detect/mavlink_io.py
@@ -83,6 +83,11 @@ class MAVLinkIO:
             "lat": None, "lon": None, "alt": None, "fix": 0, "hdg": None,
             "cog": None, "ground_speed": None,
             "last_update": 0.0,
+            # Freshness of the GPS_RAW_INT-sourced fields (fix/cog/
+            # ground_speed). 0.0 = never received. Separate from last_update:
+            # that key's 0.0 means "skip freshness check" to the autonomy
+            # gates, a semantic this stamp must not inherit.
+            "raw_last_update": 0.0,
         }
         self._gps_lock = threading.Lock()
         self._stop_evt = threading.Event()
@@ -277,15 +282,7 @@ class MAVLinkIO:
                         self._gps["hdg"] = msg.hdg  # centidegrees
                         self._gps["last_update"] = time.monotonic()
                 elif msg_type == "GPS_RAW_INT":
-                    with self._gps_lock:
-                        self._gps["fix"] = msg.fix_type
-                        # cog: course over ground, centidegrees (65535 = unknown).
-                        # vel: ground speed, cm/s (65535 = unknown). Used by the
-                        # compass-health check (issue #298).
-                        cog = getattr(msg, "cog", 65535)
-                        self._gps["cog"] = None if cog == 65535 else (cog / 100.0) % 360.0
-                        vel = getattr(msg, "vel", 65535)
-                        self._gps["ground_speed"] = None if vel == 65535 else vel / 100.0
+                    self._handle_gps_raw_int(msg)
                 elif msg_type == "SYS_STATUS":
                     self._handle_sys_status(msg)
                 elif msg_type == "VFR_HUD":
@@ -362,6 +359,23 @@ class MAVLinkIO:
     def get_battery_monitor(self):
         """Return the attached BatteryMonitor, or ``None``."""
         return self._battery_monitor
+
+    def _handle_gps_raw_int(self, msg) -> None:
+        """Cache fix type, course-over-ground, and ground speed from GPS_RAW_INT.
+
+        cog: centidegrees, 65535 = unknown. vel: cm/s, 65535 = unknown. Used
+        by the compass-health check (issue #298). ``raw_last_update`` stamps
+        the freshness of these fields specifically — deliberately a separate
+        key from ``last_update`` (GLOBAL_POSITION_INT), whose 0.0 sentinel
+        carries skip-the-check semantics in the autonomy gates.
+        """
+        with self._gps_lock:
+            self._gps["fix"] = msg.fix_type
+            cog = getattr(msg, "cog", 65535)
+            self._gps["cog"] = None if cog == 65535 else (cog / 100.0) % 360.0
+            vel = getattr(msg, "vel", 65535)
+            self._gps["ground_speed"] = None if vel == 65535 else vel / 100.0
+            self._gps["raw_last_update"] = time.monotonic()
 
     def _handle_vfr_hud(self, msg) -> None:
         """Cache airspeed, groundspeed, altitude, heading, climb from VFR_HUD."""

--- a/hydra_detect/observability/health.py
+++ b/hydra_detect/observability/health.py
@@ -104,14 +104,18 @@ def _probe_gps(mavlink_ref: Any, stats: Dict[str, Any]) -> Dict[str, str]:
         # returned, so this probe always degraded to "no gps data" whenever
         # the stats cache was empty. StreamState also DEFAULTS gps_fix to 0
         # before the pipeline publishes, so a 0 must consult the live
-        # MAVLink cache too — get_gps() feeds the published stats and is
-        # never staler than them; prefer its value when it has one.
+        # MAVLink cache too. The cache value is trusted only while FRESH
+        # (GPS_RAW_INT seen within the last 10 s): a cache that latched
+        # fix=3 and then stopped hearing GPS must not override an explicit
+        # no-fix with a stale OK (2026-07-18 Codex re-review).
         getter = getattr(mavlink_ref, "get_gps", None)
         if callable(getter):
             data = getter()
             if isinstance(data, dict):
+                raw_ts = data.get("raw_last_update") or 0.0
+                fresh = raw_ts > 0.0 and (time.monotonic() - raw_ts) <= 10.0
                 live = data.get("fix")
-                if live is not None:
+                if fresh and live is not None:
                     fix = live
     if fix is None:
         return _warn("no gps data")

--- a/hydra_detect/web/static/js/ops.js
+++ b/hydra_detect/web/static/js/ops.js
@@ -955,11 +955,24 @@ const HydraOps = (() => {
     var _lastKnown = null;         // {lat, lon, heading, alt, ts}
     var LASTKNOWN_STALE_MS = 6000; // no fresh fix for this long → recovery mode
     var _lastFixAt = 0;
+    var _lastKnownCs = null;       // callsign the in-memory cache belongs to
 
     function _loadLastKnown(callsign) {
+        var cs = callsign || 'default';
+        // Callsign changed mid-session (config edit + pipeline restart with
+        // the page still open): the in-memory cache belongs to the OLD
+        // craft — presenting its coordinates as the new craft's last-known
+        // position would send a recovery party to the wrong spot. Reset and
+        // re-load from the new craft's storage key (2026-07-18 Codex
+        // re-review).
+        if (_lastKnownCs !== null && _lastKnownCs !== cs) {
+            _lastKnown = null;
+            _lastFixAt = 0;
+        }
+        _lastKnownCs = cs;
         if (_lastKnown) return;
         try {
-            var raw = localStorage.getItem('hydra-lastknown-' + (callsign || 'default'));
+            var raw = localStorage.getItem('hydra-lastknown-' + cs);
             if (raw) _lastKnown = JSON.parse(raw);
         } catch (e) { /* ignore */ }
     }

--- a/hydra_detect/web/static/js/polling/poller-manager.js
+++ b/hydra_detect/web/static/js/polling/poller-manager.js
@@ -39,7 +39,11 @@ window.HydraModules.createPollerManager = function createPollerManager({ store, 
                 entry.failCount++;
                 if (onConnection) onConnection(false);
             }
-            if (pollers[name]) schedule();
+            // Identity check, not just presence: if this name was re-started
+            // while our fetch was in flight, pollers[name] is a NEW entry and
+            // rescheduling from this stale closure would run two chains
+            // forever (2026-07-18 Codex re-review).
+            if (pollers[name] === entry) schedule();
         };
 
         poll();

--- a/hydra_detect/web/static/js/systems.js
+++ b/hydra_detect/web/static/js/systems.js
@@ -65,13 +65,24 @@ const HydraSystems = (() => {
     }
 
     // ── Polling ──
+    // Epoch token, same pattern as tak-map.js. Clearing timers alone is not
+    // enough: a poll awaiting fetch has pollTimer/pfTimer already null, so a
+    // stop() during the flight cleared nothing and the loop resurrected
+    // itself when the fetch resolved; a bare boolean still allowed a double
+    // chain on a fast leave→enter (the old in-flight poll resumes under the
+    // new "on" state). Every start/stop bumps the epoch; a poll carries the
+    // epoch it was scheduled under and dies when superseded
+    // (2026-07-18 Codex re-review).
+    let pollEpoch = 0;
+
     function startPolling() {
-        if (pollTimer !== null) return;
-        pollOnce();
-        startPreflightPolling();
+        pollEpoch += 1;
+        pollOnce(pollEpoch);
+        startPreflightPolling(pollEpoch);
     }
 
     function stopPolling() {
+        pollEpoch += 1;
         if (pollTimer !== null) {
             clearTimeout(pollTimer);
             pollTimer = null;
@@ -90,8 +101,9 @@ const HydraSystems = (() => {
     let pfTimer = null;
     let pfChecks = null;   // name(lowercased) → {status, message}
 
-    async function pollPreflightOnce() {
+    async function pollPreflightOnce(gen) {
         pfTimer = null;
+        if (gen !== pollEpoch) return;
         if (document.visibilityState !== 'hidden') {
             try {
                 const resp = await fetch('/api/preflight', { credentials: 'same-origin' });
@@ -108,12 +120,13 @@ const HydraSystems = (() => {
                 pfChecks = null;
             }
         }
-        pfTimer = setTimeout(pollPreflightOnce, PREFLIGHT_POLL_MS);
+        if (gen !== pollEpoch) return;  // onLeave landed while the fetch was in flight
+        pfTimer = setTimeout(() => pollPreflightOnce(gen), PREFLIGHT_POLL_MS);
     }
 
-    function startPreflightPolling() {
+    function startPreflightPolling(gen) {
         if (pfTimer !== null) return;
-        pollPreflightOnce();
+        pollPreflightOnce(gen);
     }
 
     function stopPreflightPolling() {
@@ -190,19 +203,20 @@ const HydraSystems = (() => {
         }
     }
 
-    function schedule(nextMs) {
+    function schedule(nextMs, gen) {
         if (pollTimer !== null) clearTimeout(pollTimer);
-        pollTimer = setTimeout(pollOnce, nextMs);
+        pollTimer = setTimeout(() => pollOnce(gen), nextMs);
     }
 
-    async function pollOnce() {
+    async function pollOnce(gen) {
         pollTimer = null;
+        if (gen !== pollEpoch) return;
         if (inFlight) {
-            schedule(POLL_INTERVAL_MS);
+            schedule(POLL_INTERVAL_MS, gen);
             return;
         }
         if (document.visibilityState === 'hidden') {
-            schedule(POLL_INTERVAL_MS);
+            schedule(POLL_INTERVAL_MS, gen);
             return;
         }
         inFlight = true;
@@ -210,6 +224,7 @@ const HydraSystems = (() => {
             const resp = await fetch('/api/stats', { credentials: 'same-origin' });
             if (!resp.ok) throw new Error('HTTP ' + resp.status);
             const data = await resp.json();
+            if (gen !== pollEpoch) return;  // superseded mid-flight — no DOM writes
             tickCount += 1;
             applyStats(data || {});
             backoffMs = POLL_INTERVAL_MS;
@@ -219,7 +234,8 @@ const HydraSystems = (() => {
         } finally {
             inFlight = false;
         }
-        schedule(backoffMs);
+        if (gen !== pollEpoch) return;  // onLeave landed while the fetch was in flight
+        schedule(backoffMs, gen);
     }
 
     // ── Application of stats to DOM ──

--- a/hydra_detect/web/static/js/tak-map.js
+++ b/hydra_detect/web/static/js/tak-map.js
@@ -136,6 +136,9 @@ window.HydraTakMap = (() => {
                 const r = await fetch('/api/stats', { credentials: 'same-origin' });
                 if (!r.ok) return false;
                 const s = await r.json();
+                // A stop() may have landed while the fetch was in flight —
+                // don't write markers/titles into a hidden view's map.
+                if (stopped) return false;
                 const lat = (typeof s.lat === 'number') ? s.lat : null;
                 const lon = (typeof s.lon === 'number') ? s.lon : null;
                 const callsign = s.callsign || 'HYDRA-1';
@@ -176,6 +179,7 @@ window.HydraTakMap = (() => {
                 const r = await fetch('/api/tak/peers', { credentials: 'same-origin' });
                 if (!r.ok) return false;
                 const data = await r.json();
+                if (stopped) return false;  // stop() landed mid-flight
                 const peers = Array.isArray(data.peers) ? data.peers : [];
                 const seen = new Set();
                 peers.forEach(p => {
@@ -214,6 +218,7 @@ window.HydraTakMap = (() => {
                 const r = await fetch('/api/active_tracks', { credentials: 'same-origin' });
                 if (!r.ok) return false;
                 const tracks = await r.json();
+                if (stopped) return false;  // stop() landed mid-flight
                 const list = Array.isArray(tracks) ? tracks : [];
                 const seen = new Set();
                 list.forEach(t => {

--- a/hydra_detect/web/static/js/tests/app-modules.test.mjs
+++ b/hydra_detect/web/static/js/tests/app-modules.test.mjs
@@ -56,6 +56,10 @@ test('poller starts/stops detail pollers per active view', async () => {
 });
 
 test('backoff state is per poller — one failing endpoint does not slow the rest', async (t) => {
+  if (!t.mock || !t.mock.timers || typeof t.mock.timers.enable !== 'function') {
+    t.skip('node:test mock.timers unavailable on this Node — need >= 20.4');
+    return;
+  }
   setupGlobals();
   loadScript('hydra_detect/web/static/js/state/store.js');
   loadScript('hydra_detect/web/static/js/polling/poller-manager.js');
@@ -77,20 +81,70 @@ test('backoff state is per poller — one failing endpoint does not slow the res
   await new Promise(r => { r(); });
   await new Promise(r => { r(); });
 
-  // Advance 4 base intervals. The healthy poller must fire ~once per
-  // interval; the failing one backs off exponentially (2s, 4s, ...).
-  for (let i = 0; i < 4; i++) {
+  // Advance 8 base intervals. The healthy poller must fire ~once per
+  // interval; the failing one backs off exponentially (2s, 4s, 8s...).
+  // The window length is load-bearing for test honesty: with the old
+  // SHARED fail counter the healthy poller's resets collapse the failing
+  // poller's backoff and it reaches 5 calls by tick 8 (empirically traced
+  // 2026-07-18) — over only 4 ticks both implementations stay <= 3 and the
+  // test proves nothing.
+  for (let i = 0; i < 8; i++) {
     t.mock.timers.tick(1000);
     // Let the async poll bodies settle between ticks.
     await new Promise(r => { r(); });
     await new Promise(r => { r(); });
   }
 
-  assert.ok(calls.good >= 4, `healthy poller throttled: ${calls.good} calls in 4 intervals`);
-  assert.ok(calls.bad <= 3, `failing poller not backing off: ${calls.bad} calls in 4 intervals`);
+  assert.ok(calls.good >= 8, `healthy poller throttled: ${calls.good} calls in 8 intervals`);
+  assert.ok(calls.bad <= 3, `failing poller not backing off: ${calls.bad} calls in 8 intervals`);
 
   manager.stopPoller('good');
   manager.stopPoller('bad');
+  t.mock.timers.reset();
+});
+
+test('restarting a named poller mid-flight does not fork a second chain', async (t) => {
+  if (!t.mock || !t.mock.timers || typeof t.mock.timers.enable !== 'function') {
+    t.skip('node:test mock.timers unavailable on this Node — need >= 20.4');
+    return;
+  }
+  setupGlobals();
+  loadScript('hydra_detect/web/static/js/state/store.js');
+  loadScript('hydra_detect/web/static/js/polling/poller-manager.js');
+
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+
+  let calls = 0;
+  let releaseFirst;
+  const firstGate = new Promise(r => { releaseFirst = r; });
+  const fetchImpl = async () => {
+    calls += 1;
+    if (calls === 1) await firstGate;  // hold the first request in flight
+    return { ok: true, json: async () => ({}) };
+  };
+  const store = window.HydraModules.createStore();
+  const manager = window.HydraModules.createPollerManager({ store, fetchImpl });
+
+  manager.startPoller('stats', '/api/stats', 1000, () => {});
+  await new Promise(r => { r(); });
+  // Restart the same name while request #1 is still awaiting.
+  manager.startPoller('stats', '/api/stats', 1000, () => {});
+  await new Promise(r => { r(); });
+  releaseFirst();
+  await new Promise(r => { r(); });
+  await new Promise(r => { r(); });
+
+  const before = calls;
+  // Two chains would fire ~2 calls per tick; a single chain fires 1.
+  for (let i = 0; i < 4; i++) {
+    t.mock.timers.tick(1000);
+    await new Promise(r => { r(); });
+    await new Promise(r => { r(); });
+  }
+  const perTick = (calls - before) / 4;
+  assert.ok(perTick <= 1, `stale chain survived restart: ${perTick} calls/tick (want <= 1)`);
+
+  manager.stopPoller('stats');
   t.mock.timers.reset();
 });
 

--- a/tests/test_body_cap.py
+++ b/tests/test_body_cap.py
@@ -44,20 +44,49 @@ class TestDeclaredLengthCap:
         assert r.status_code == 413
         assert r.json() == {"error": "Request body too large"}
 
-    def test_lying_content_length_still_rejected(self, client):
-        # Declared length under the cap; actual body over it. The streamed
-        # cap must catch what the header check waves through.
-        r = client.post(
-            "/api/client_error",
-            content=_oversized_payload(),
-            headers={
-                "Content-Type": "application/json",
-                "Content-Length": "10",
-            },
-        )
-        # Either the transport rejects the mismatch or the app returns 413 —
-        # both acceptable; what is NOT acceptable is a 2xx.
-        assert r.status_code >= 400
+    def test_lying_content_length_still_rejected(self):
+        # Declared length under the cap; actual streamed body over it. The
+        # streamed cap must catch what the header check waves through, and
+        # must answer EXACTLY 413. Raw ASGI invocation — an HTTP client or
+        # its transport would normalize/refuse the mismatched header, and an
+        # earlier version of this test accepted any >= 400, which a 400/429
+        # from unrelated causes could satisfy (2026-07-18 Codex re-review).
+        import asyncio
+
+        async def _run():
+            sent = []
+            body = _oversized_payload()
+            chunks = [body[i:i + 8192] for i in range(0, len(body), 8192)]
+            idx = {"i": 0}
+
+            async def receive():
+                if idx["i"] < len(chunks):
+                    c = chunks[idx["i"]]
+                    idx["i"] += 1
+                    return {"type": "http.request", "body": c,
+                            "more_body": idx["i"] < len(chunks)}
+                return {"type": "http.request", "body": b"", "more_body": False}
+
+            async def send(message):
+                sent.append(message)
+
+            scope = {
+                "type": "http", "asgi": {"version": "3.0"},
+                "http_version": "1.1", "method": "POST", "scheme": "http",
+                "path": "/api/client_error", "raw_path": b"/api/client_error",
+                "query_string": b"", "root_path": "",
+                "headers": [
+                    (b"host", b"testserver"),
+                    (b"content-type", b"application/json"),
+                    (b"content-length", b"10"),  # the lie
+                ],
+                "client": ("127.0.0.1", 50000), "server": ("testserver", 80),
+            }
+            await web_server.app(scope, receive, send)
+            start = next(m for m in sent if m["type"] == "http.response.start")
+            return start["status"]
+
+        assert asyncio.run(_run()) == 413
 
 
 class TestStreamedCap:

--- a/tests/test_mavlink_flight_data.py
+++ b/tests/test_mavlink_flight_data.py
@@ -41,31 +41,44 @@ class TestFlightDataAccessor:
 
     def test_gps_raw_int_populates_cog_and_ground_speed(self):
         """Issue #298: course over ground + ground speed from GPS_RAW_INT
-        feed the compass-health check. 65535 sentinels map to None."""
+        feed the compass-health check. Drives the REAL handler — an earlier
+        version of this test hand-seeded the cache with a copy of the
+        production formulas and would have stayed green with the handler
+        deleted (2026-07-18 Codex re-review)."""
         mav = _make_mavlink_io()
         msg = MagicMock()
         msg.get_type.return_value = "GPS_RAW_INT"
         msg.fix_type = 3
         msg.cog = 22750   # centidegrees → 227.5°
         msg.vel = 240     # cm/s → 2.4 m/s
-        # Exercise the real listener branch via the cached-dict path.
-        with mav._gps_lock:
-            mav._gps["fix"] = msg.fix_type
-            cog = getattr(msg, "cog", 65535)
-            mav._gps["cog"] = None if cog == 65535 else (cog / 100.0) % 360.0
-            vel = getattr(msg, "vel", 65535)
-            mav._gps["ground_speed"] = None if vel == 65535 else vel / 100.0
+        mav._handle_gps_raw_int(msg)
         fd = mav.get_flight_data()
         assert fd["cog"] == 227.5
         assert fd["ground_speed"] == 2.4
+        with mav._gps_lock:
+            assert mav._gps["fix"] == 3
+            assert mav._gps["raw_last_update"] > 0.0
 
     def test_gps_raw_int_unknown_sentinels_map_to_none(self):
         mav = _make_mavlink_io()
-        with mav._gps_lock:
-            cog = 65535
-            mav._gps["cog"] = None if cog == 65535 else (cog / 100.0) % 360.0
-            vel = 65535
-            mav._gps["ground_speed"] = None if vel == 65535 else vel / 100.0
+        msg = MagicMock()
+        msg.get_type.return_value = "GPS_RAW_INT"
+        msg.fix_type = 0
+        msg.cog = 65535
+        msg.vel = 65535
+        mav._handle_gps_raw_int(msg)
+        fd = mav.get_flight_data()
+        assert fd["cog"] is None
+        assert fd["ground_speed"] is None
+
+    def test_gps_raw_int_missing_fields_default_to_none(self):
+        """Dialect variants without cog/vel degrade to None, not
+        AttributeError inside the RX dispatch loop."""
+        mav = _make_mavlink_io()
+        msg = MagicMock(spec=["get_type", "fix_type"])
+        msg.get_type.return_value = "GPS_RAW_INT"
+        msg.fix_type = 2
+        mav._handle_gps_raw_int(msg)
         fd = mav.get_flight_data()
         assert fd["cog"] is None
         assert fd["ground_speed"] is None

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -150,11 +150,14 @@ class TestHealthSnapshot:
         # Issue #302: stats has no gps_fix → probe must read the fix type
         # from get_gps()["fix"] (the old code asked get_flight_data() for a
         # "gps_fix" key it never returned, so this path always warned).
+        import time as _time
+
         class Mav:
             connected = True
 
             def get_gps(self):
-                return {"fix": 3, "lat": 1, "lon": 2, "last_update": 12.5}
+                return {"fix": 3, "lat": 1, "lon": 2,
+                        "raw_last_update": _time.monotonic()}
 
         snap = health_snapshot(
             stats={"camera_ok": True, "fps": 5.0},
@@ -167,11 +170,14 @@ class TestHealthSnapshot:
         # StreamState defaults stats["gps_fix"] to 0 before the pipeline
         # publishes — a 0 must consult get_gps() too, else the boot window
         # reports "no fix" while MAVLink already holds a 3D fix.
+        import time as _time
+
         class Mav:
             connected = True
 
             def get_gps(self):
-                return {"fix": 3, "lat": 1, "lon": 2, "last_update": 12.5}
+                return {"fix": 3, "lat": 1, "lon": 2,
+                        "raw_last_update": _time.monotonic()}
 
         snap = health_snapshot(
             stats={"camera_ok": True, "fps": 5.0, "gps_fix": 0},
@@ -179,6 +185,42 @@ class TestHealthSnapshot:
         )
         assert snap["subsystems"]["gps"]["status"] == "ok"
         assert "gps_fix=3" in snap["subsystems"]["gps"]["detail"]
+
+    def test_gps_stale_cache_does_not_override_no_fix(self):
+        # 2026-07-18 Codex re-review: a cache that latched fix=3 and then
+        # stopped hearing GPS_RAW_INT must NOT override an explicit 0 with
+        # a stale OK. Freshness window is 10 s on raw_last_update.
+        import time as _time
+
+        class Mav:
+            connected = True
+
+            def get_gps(self):
+                return {"fix": 3, "lat": 1, "lon": 2,
+                        "raw_last_update": _time.monotonic() - 60.0}
+
+        snap = health_snapshot(
+            stats={"camera_ok": True, "fps": 5.0, "gps_fix": 0},
+            mavlink_ref=Mav(),
+        )
+        assert snap["subsystems"]["gps"]["status"] == "warn"
+        assert "no fix" in snap["subsystems"]["gps"]["detail"]
+
+    def test_gps_unstamped_cache_does_not_override(self):
+        # A cache with no raw_last_update (never heard GPS_RAW_INT, or an
+        # older MAVLinkIO shape) is not trusted over the stats value.
+        class Mav:
+            connected = True
+
+            def get_gps(self):
+                return {"fix": 3, "lat": 1, "lon": 2}
+
+        snap = health_snapshot(
+            stats={"camera_ok": True, "fps": 5.0, "gps_fix": 0},
+            mavlink_ref=Mav(),
+        )
+        assert snap["subsystems"]["gps"]["status"] == "warn"
+        assert "no fix" in snap["subsystems"]["gps"]["detail"]
 
     def test_gps_stats_zero_without_mavlink_still_no_fix(self):
         # No MAVLink registered: a stats 0 keeps its "no fix" warn — the

--- a/tests/test_pixhawk_wizard_server.py
+++ b/tests/test_pixhawk_wizard_server.py
@@ -443,7 +443,7 @@ def test_stats_stays_responsive_while_wizard_connects(monkeypatch):
     stats, wizard, elapsed = asyncio.run(_scenario())
     assert stats.status_code == 200
     assert wizard.status_code == 408  # connect failed → mapped error
-    assert elapsed < 2.0, (
+    assert elapsed < 4.0, (
         f"/api/stats not served until {elapsed:.1f}s after the wizard call "
         "started — the event loop is still being blocked"
     )

--- a/tests/test_systems_view.py
+++ b/tests/test_systems_view.py
@@ -97,20 +97,31 @@ class TestSystemsJs:
         assert "window.HydraSystems = HydraSystems" in body
 
     def test_systems_js_polls_only_known_endpoints(self, client):
+        import re
+
         body = client.get("/static/js/systems.js").text
         # systems.js polls /api/stats (live environment metrics) and, since
         # issue #295, /api/preflight (authoritative camera/mavlink/config/
-        # disk verdicts for the checklist). Both are pre-existing endpoints —
-        # no new backend was invented. Any OTHER /api/... call would mean an
-        # unflagged endpoint; fail so it gets reviewed.
+        # disk verdicts for the checklist). Any OTHER /api/... reference
+        # means an unflagged endpoint; fail so it gets reviewed.
+        #
+        # Scan EVERY /api/... string literal in any quote style with
+        # exact-segment prefix matching — the old scan matched only lines
+        # containing the exact text fetch('/api/ and used substring
+        # matching, so a double-quoted, template-string, or wrapper-based
+        # call (and /api/stats-anything) slipped through (2026-07-18 Codex
+        # re-review).
         allowed = ("/api/stats", "/api/preflight")
-        api_calls = [line.strip() for line in body.splitlines() if "fetch('/api/" in line]
-        assert api_calls, "systems.js should at least poll /api/stats"
-        assert any("/api/stats" in c for c in api_calls), "systems.js must still poll /api/stats"
-        for call in api_calls:
-            assert any(a in call for a in allowed), (
-                f"systems.js fetches an unexpected endpoint: {call!r} — "
-                "if a new backend endpoint is needed, flag it for review"
+        literals = re.findall(r"""["'`](/api/[^"'`\s]*)["'`]""", body)
+        assert literals, "systems.js should reference at least /api/stats"
+        paths = [u.split("?")[0] for u in literals]
+        assert "/api/stats" in paths, "systems.js must still poll /api/stats"
+        for path in paths:
+            assert any(
+                path == ep or path.startswith(ep + "/") for ep in allowed
+            ), (
+                f"systems.js references unallowed endpoint {path!r} — "
+                "add it to the allowlist deliberately or remove the call"
             )
 
 


### PR DESCRIPTION
Independent post-merge re-review of today's 6 squashes (1697cd8..HEAD) by three parallel Codex (gpt-5.6-sol) reviewers — backend, frontend, tests/CI — with every finding re-verified against source before fixing. 7 survived:

| # | Finding | Fix |
|---|---|---|
| B1 | Stale MAVLink cache (fix=3 latched, GPS stream stopped) overrides an explicit stats no-fix with a false OK in `_probe_gps` | `_handle_gps_raw_int()` extracted + `raw_last_update` stamp (separate from `last_update`, whose 0.0 means skip-check to autonomy gates); probe trusts cache only when stamped ≤ 10 s |
| F1 | tak-map refreshers write into a hidden view's map when stop() lands mid-fetch | post-fetch `stopped` bail in all 3 refreshers |
| F2 | Restarting a named poller mid-flight forks a second permanent chain | completion reschedule checks `pollers[name] === entry` |
| F3 | Leaving Systems mid-fetch resurrects both poll loops forever | epoch tokens (tak-map pattern) on both loops; boolean was insufficient (fast leave→enter double chain) |
| F4 | Recovery card shows craft A's coords as craft B's after mid-session callsign change | in-memory cache tracks its callsign, resets + reloads on change |
| T1 | mjs backoff test passed against the old shared-counter bug (empirically confirmed) | 8-tick window (old code: bad=5, new: bad=3) + restart-fork regression test + mock.timers capability skip |
| T2/T3/T4/T5 | cog tests hand-seeded the cache; lying-content-length accepted any ≥400; allowlist scan missed non-`fetch('` literals; 2 s wall-clock margin | drive the real handler; raw-ASGI exact-413; any-quote-style exact-segment scan; 4 s ceiling |

All test fixes red-green verified (each fails against the pre-fix implementation). 249 Python tests + 17 node tests pass.