### PR TITLE
docs: add IP-PROVENANCE.md asserting ownership and dependency licenses

### DIFF
--- a/IP-PROVENANCE.md
+++ b/IP-PROVENANCE.md
@@ -1,0 +1,49 @@
+# IP Provenance
+
+This document records the ownership and development provenance of Hydra.
+
+## Ownership
+
+Hydra is a personal project of Kyle Adomavicius ([rmeadomavic](https://github.com/rmeadomavic), kyle.adomavicius@gmail.com). Copyright 2026 Kyle Adomavicius. Released under the Apache License 2.0 (see [LICENSE](LICENSE)).
+
+## Development context
+
+- Developed outside employment scope, on personal time.
+- Developed on personally owned hardware: NVIDIA Jetson Orin Nano, Pixhawk 6C, Alfa wireless adapter, NESDR software-defined radio, RFD 900x telemetry radio.
+- The public commit history of this repository is the contemporaneous record of the work.
+
+## Dependencies
+
+Hydra is built on open-source libraries and public protocol specifications (MAVLink, MSP DisplayPort, Cursor-on-Target). License identifiers below are as published by each project on PyPI as of 2026-07-19.
+
+Runtime, per [requirements.txt](requirements.txt):
+
+| Package | License |
+|---|---|
+| opencv-python-headless | Apache-2.0 |
+| numpy | BSD-3-Clause AND 0BSD AND MIT AND Zlib AND CC0-1.0 |
+| ultralytics | AGPL-3.0 |
+| supervision | MIT |
+| pymavlink | LGPL-3.0 |
+| pyserial | BSD-3-Clause |
+| mgrs | MIT |
+| fastapi | MIT |
+| uvicorn | BSD-3-Clause |
+| jinja2 | BSD-3-Clause |
+| requests | Apache-2.0 |
+| ntplib | MIT |
+| pytak | Apache-2.0 |
+
+Optional, per [requirements-extra.txt](requirements-extra.txt):
+
+| Package | License |
+|---|---|
+| boxmot | AGPL-3.0 |
+
+Development-only tooling, per [requirements-dev.txt](requirements-dev.txt): pytest, pytest-cov, hypothesis, flake8, httpx, PyYAML. Used for test and lint; not part of the deployed software.
+
+Container builds use the public `dustynv/l4t-pytorch:r36.4.0` base image, which bundles NVIDIA JetPack / L4T components under their own licenses. Optional external services (Kismet, MediaMTX, GStreamer) are separately installed and separately licensed.
+
+## Model weights
+
+Model weights are not distributed in this repository. [`models/manifest.json`](models/manifest.json) records filenames, class lists, and SHA-256 checksums only.


### PR DESCRIPTION
## Summary

Adds a top-level `IP-PROVENANCE.md` recording ownership and development provenance: personal project of Kyle Adomavicius under Apache-2.0 (matching LICENSE), developed outside employment scope on personal time and personally owned hardware, with the public commit history as the contemporaneous record. Lists runtime / optional / dev dependencies from the actual requirements files with license identifiers as published on PyPI (2026-07-19), notes the container base image and external services, and states that model weights are not distributed (checksum manifest only).

## Test plan

- [x] Docs-only change; no code touched. CI fast suite runs regardless.
- [x] Manual verification: license identifiers cross-checked against live PyPI metadata for all 14 runtime/optional packages; ownership line matches LICENSE appendix; dependency list matches requirements.txt / requirements-extra.txt / requirements-dev.txt verbatim.

## Adversarial review

- [x] No safety-critical paths touched; `adversarial-required` CI job decides.

## Risk

Docs-only. Every claim is sourced from files in this repo (LICENSE, requirements manifests, models/manifest.json) or live PyPI metadata; revert-safe.